### PR TITLE
feat: add default ephemeral interaction replies

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,9 @@ from pathlib import Path
 import discord
 from discord.ext import commands
 
+from utils.interactions import register_default_ephemeral
+from utils.errors import register_error_handler
+
 # load .env (no extra deps)
 envp = Path(".env")
 if envp.exists():
@@ -18,9 +21,12 @@ DEV_GUILD_ID = os.getenv("DEV_GUILD_ID")
 
 intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
+register_default_ephemeral(True)
+register_error_handler(bot)
 
 async def load_cogs():
     await bot.load_extension("cogs.core")
+    await bot.load_extension("cogs.help")
 
 @bot.event
 async def on_ready():

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,0 +1,41 @@
+"""Utilities for error handling setup."""
+
+from __future__ import annotations
+
+import logging
+from discord.ext import commands
+
+__all__ = ["register_error_handler"]
+
+log = logging.getLogger(__name__)
+
+_registered: bool = False
+
+
+def register_error_handler(bot: commands.Bot) -> None:
+    """Register the centralized error handler cog.
+
+    This schedules loading of the :mod:`cogs.errors` extension before the bot
+    connects. The function is idempotent and safe to call multiple times.
+
+    Parameters
+    ----------
+    bot:
+        The bot instance to attach the error handler to.
+    """
+
+    global _registered
+    if _registered:
+        log.debug("Error handler already registered")
+        return
+    _registered = True
+
+    async def load_errors() -> None:
+        try:
+            await bot.load_extension("cogs.errors")
+            log.info("Errors cog loaded")
+        except Exception:
+            log.exception("Failed to load errors cog")
+
+    bot.add_setup_hook(load_errors)
+

--- a/utils/interactions.py
+++ b/utils/interactions.py
@@ -1,0 +1,94 @@
+"""Utility functions for Discord interaction handling.
+
+This module provides a helper to globally enforce default ephemeral
+responses for Discord interactions. When registered, interaction responses
+and follow-up webhook sends will automatically include ``ephemeral`` with a
+configurable default unless the caller explicitly specifies otherwise.
+
+Usage::
+    from utils.interactions import register_default_ephemeral
+    register_default_ephemeral(True)  # in bot.py after bot = commands.Bot(...)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+import discord
+
+try:
+    from discord.webhook.async_ import InteractionWebhook as _IWebhook
+except Exception:  # pragma: no cover - fallback for older discord versions
+    _IWebhook = None  # type: ignore[assignment]
+
+__all__ = ["register_default_ephemeral"]
+
+logger = logging.getLogger(__name__)
+
+# Module-level state to control default behaviour and ensure idempotency
+_default_ephemeral: bool = True
+_patched: bool = False
+_original_send_message: Callable[..., Awaitable[Any]] | None = None
+_original_webhook_send: Callable[..., Awaitable[Any]] | None = None
+
+
+def register_default_ephemeral(ephemeral_default: bool = True) -> None:
+    """Register global monkey patches enforcing default ephemeral replies.
+
+    Parameters
+    ----------
+    ephemeral_default:
+        If ``True`` (the default), all interaction responses and follow-up
+        messages will be ephemeral unless ``ephemeral`` is explicitly provided
+        by the caller. Setting this to ``False`` will default to non-ephemeral
+        responses while still respecting explicit ``ephemeral`` values.
+
+    Notes
+    -----
+    The function is idempotent: repeated calls will simply update the default
+    without applying the patches multiple times.
+    """
+
+    global _default_ephemeral, _patched, _original_send_message, _original_webhook_send
+
+    _default_ephemeral = ephemeral_default
+
+    if _patched:
+        logger.debug(
+            "Default ephemeral already registered; updated default to %s", ephemeral_default
+        )
+        return
+
+    # Store original methods for future reference/debugging
+    _original_send_message = discord.InteractionResponse.send_message
+
+    async def send_message_with_default(
+        self: discord.InteractionResponse, *args: Any, **kwargs: Any
+    ) -> Any:
+        if "ephemeral" not in kwargs:
+            kwargs["ephemeral"] = _default_ephemeral
+            logger.debug(
+                "Injected default ephemeral=%s into InteractionResponse.send_message", _default_ephemeral
+            )
+        return await _original_send_message(self, *args, **kwargs)  # type: ignore[misc]
+
+    discord.InteractionResponse.send_message = send_message_with_default  # type: ignore[assignment]
+
+    if _IWebhook is not None:
+        _original_webhook_send = _IWebhook.send
+
+        async def webhook_send_with_default(
+            self: _IWebhook, *args: Any, **kwargs: Any
+        ) -> Any:
+            if "ephemeral" not in kwargs:
+                kwargs["ephemeral"] = _default_ephemeral
+                logger.debug(
+                    "Injected default ephemeral=%s into InteractionWebhook.send", _default_ephemeral
+                )
+            return await _original_webhook_send(self, *args, **kwargs)  # type: ignore[misc]
+
+        _IWebhook.send = webhook_send_with_default  # type: ignore[assignment]
+
+    _patched = True
+    logger.info("Registered default ephemeral=%s for interaction responses", _default_ephemeral)


### PR DESCRIPTION
## Summary
- patch `InteractionWebhook.send` instead of generic `Webhook` to avoid non-interaction webhooks
- register default ephemeral and centralized error handler during bot startup before loading cogs
- load core and help cogs on startup

## Testing
- `python -m py_compile bot.py utils/errors.py utils/interactions.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad0cfdc8832ebf274670cbd23a34