### PR TITLE
Stabilize runtime foundation for dedicated server mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,51 @@
-﻿# Discord Bot
-DISCORD_TOKEN=your-token-here
-CLIENT_ID=your-client-id-here
-GUILD_ID=your-guild-id-here
+# Wilhelmina Discord Bot - Example Environment
+# Copy this file to .env and fill in real values.
 
-# MongoDB
-MONGO_URI=your-mongodb-uri-here
+# Core Discord runtime
+DISCORD_TOKEN=
+CLIENT_ID=
+APP_ENV=development
+LOG_LEVEL=INFO
 
-# Role & Channel IDs
+# Dedicated home server
+# Wilhelmina no longer supports existing-server takeover/transformation mode.
+SERVER_MODE=dedicated
+HOME_GUILD_ID=
+
+# Command sync mode:
+# - guild: sync only to HOME_GUILD_ID; safest for development and the dedicated server
+# - global: sync globally; slower propagation
+# - off: do not sync commands at startup
+# - auto: guild when HOME_GUILD_ID is set, otherwise global
+COMMAND_SYNC_MODE=guild
+
+# Feature flags
+# Core and admin are required and must stay enabled.
+ENABLE_CORE=true
+ENABLE_ADMIN=true
+ENABLE_INVITE=false
+ENABLE_ORACLES=false
+
+# Oracle / AI support
+# Required only when enabling AI-backed oracle/chat behavior.
+OPENAI_API_KEY=
+EMBEDS_ONLY=true
+
+# Future persistence placeholders
+DATABASE_URL=
+MONGO_URI=
+
+# Dedicated server role & channel IDs
+# These remain env placeholders until DB-backed guild config lands.
 SIGNED_ROLE_ID=
-ARCHIVE_CATEGORY_ID=
 SUMMONING_CHANNEL_ID=
 WELCOME_CHANNEL_ID=
+ONBOARDING_CHANNEL_ID=
 BROADCAST_CHANNEL_ID=
+ADMIN_LOG_CHANNEL_ID=
 
-# External APIs
+# External APIs reserved for later phases
 WEATHER_API_KEY=
 NEWS_API_KEY=
 ASTRO_API_KEY=
 TZ_API_KEY=
-
-# Environment
-# APP_ENV is used by the Python runtime; keep as "development" unless deploying.
-APP_ENV=development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,oracles]"
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,30 +1,129 @@
-﻿# Wilhelmina Bot
+# Wilhelmina Bot
 
-Wilhelmina is a Discord bot that offers onboarding assistance, tarot readings, voice interactions and administrative tools. It is designed to help manage your server while providing fun and useful commands for members.
+Wilhelmina is a Python Discord bot built with `discord.py` for a dedicated home server. The project is moving toward modular onboarding, AI-backed interactions, administrative tools, scheduled messaging, and server community workflows.
+
+## Runtime model
+
+Wilhelmina is intentionally configured for a **brand-new dedicated server**.
+
+Existing-server takeover, channel archival, and automatic server transformation are not supported runtime modes. The bot should be invited into its home guild, configured with `HOME_GUILD_ID`, and expanded through feature-flagged cogs.
+
+## Current commands
+
+Always-on core/admin commands:
+
+```txt
+/about
+/uptime
+/admin diagnostics
+/admin features
+/admin sync
+```
+
+Optional cogs can be enabled with feature flags:
+
+```txt
+/invite
+/roll
+/8ball
+/fortune
+```
 
 ## Prerequisites
+
 - Python 3.11+
 - Git
-- MongoDB
-- A Discord application (bot token, client ID, guild ID)
+- A Discord application with bot token and client ID
+- A dedicated Discord server/guild for Wilhelmina
 
 ## Installation
-1. Clone the repository
-   git clone https://github.com/gumdropsmo22/wilhelmina.git
-   cd wilhelmina
-2. Create a virtual environment and install dependencies
-   python -m venv .venv
-   # Windows:
-   .\.venv\Scripts\activate
-   # macOS/Linux:
-   source .venv/bin/activate
-   python -m pip install -r requirements.txt
+
+```bash
+git clone https://github.com/gumdropsmo22/wilhelmina.git
+cd wilhelmina
+python -m venv .venv
+```
+
+Activate the virtual environment:
+
+```powershell
+# Windows
+.\.venv\Scripts\Activate.ps1
+```
+
+```bash
+# macOS/Linux
+source .venv/bin/activate
+```
+
+Install runtime and development dependencies:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev,oracles]"
+```
+
+Legacy install path:
+
+```bash
+python -m pip install -r requirements.txt
+```
 
 ## Configuration
-Copy .env.example to .env and fill values (Discord, MongoDB, optional APIs).
 
-## Usage
+Copy the example environment file and fill in real values:
+
+```bash
+cp .env.example .env
+```
+
+Minimum development configuration:
+
+```env
+DISCORD_TOKEN=
+CLIENT_ID=
+SERVER_MODE=dedicated
+HOME_GUILD_ID=
+COMMAND_SYNC_MODE=guild
+ENABLE_CORE=true
+ENABLE_ADMIN=true
+```
+
+`DEV_GUILD_ID` is still accepted as a legacy alias for `HOME_GUILD_ID`, but new setups should use `HOME_GUILD_ID`.
+
+## Running locally
+
+```bash
 python bot.py
+```
+
+## Tests and checks
+
+```bash
+ruff check .
+pytest
+```
+
+CI runs the same checks on push and pull request.
+
+## Feature flag policy
+
+Required cogs:
+
+```env
+ENABLE_CORE=true
+ENABLE_ADMIN=true
+```
+
+Optional cogs:
+
+```env
+ENABLE_INVITE=false
+ENABLE_ORACLES=false
+```
+
+Required cogs fail startup when broken. Optional cogs are logged and skipped so unfinished features do not take down the runtime.
 
 ## License
+
 MIT © 2025

--- a/bot.py
+++ b/bot.py
@@ -1,47 +1,178 @@
-﻿import os, time, platform
+from __future__ import annotations
+
+import logging
+import time
+
 import discord
-from discord import app_commands
 from discord.ext import commands
 
-class Core(commands.Cog):
-    def __init__(self, bot: commands.Bot):
-        self.bot = bot
+from config.settings import RuntimeSettings, SettingsError, load_settings
 
-    @app_commands.command(name="about", description="About this bot")
-    async def about(self, interaction: discord.Interaction):
-        msg = (
-            f"**Wilhelmina** skeleton is alive. "
-            f"Python {platform.python_version()} • discord.py {discord.__version__} "
-            f"• env={os.getenv('APP_ENV','development')}"
+logger = logging.getLogger("wilhelmina")
+
+
+def configure_logging(level_name: str) -> None:
+    """Configure process logging once at startup."""
+
+    level = getattr(logging, level_name.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+
+def build_intents(settings: RuntimeSettings) -> discord.Intents:
+    """Build Discord gateway intents from enabled features.
+
+    Step-one runtime hardening intentionally keeps intents minimal. Future cogs
+    should expand this function only when a feature explicitly needs more access.
+    """
+
+    intents = discord.Intents.default()
+    return intents
+
+
+async def load_cogs(bot: commands.Bot, settings: RuntimeSettings) -> dict[str, list[str]]:
+    """Load enabled Discord extensions and report loaded/skipped/failed cogs.
+
+    Required cogs fail startup if they cannot load. Optional cogs are logged and
+    skipped so unfinished features do not kill the whole runtime.
+    """
+
+    report: dict[str, list[str]] = {
+        "loaded": [],
+        "skipped": [],
+        "failed": [],
+    }
+
+    for flag in settings.cog_flags:
+        if not settings.is_cog_enabled(flag.extension):
+            report["skipped"].append(flag.extension)
+            logger.info(
+                "cog_skipped extension=%s env_var=%s required=%s",
+                flag.extension,
+                flag.env_var,
+                flag.required,
+            )
+            continue
+
+        try:
+            await bot.load_extension(flag.extension)
+        except commands.ExtensionAlreadyLoaded:
+            report["loaded"].append(flag.extension)
+            logger.warning("cog_already_loaded extension=%s", flag.extension)
+        except (
+            commands.ExtensionNotFound,
+            commands.NoEntryPointError,
+            commands.ExtensionFailed,
+        ):
+            report["failed"].append(flag.extension)
+            logger.exception(
+                "cog_load_failed extension=%s env_var=%s required=%s",
+                flag.extension,
+                flag.env_var,
+                flag.required,
+            )
+            if flag.required:
+                raise
+        except Exception:
+            report["failed"].append(flag.extension)
+            logger.exception(
+                "cog_load_failed_unexpected extension=%s env_var=%s required=%s",
+                flag.extension,
+                flag.env_var,
+                flag.required,
+            )
+            if flag.required:
+                raise
+        else:
+            report["loaded"].append(flag.extension)
+            logger.info(
+                "cog_loaded extension=%s env_var=%s required=%s",
+                flag.extension,
+                flag.env_var,
+                flag.required,
+            )
+
+    return report
+
+
+async def sync_application_commands(bot: commands.Bot, settings: RuntimeSettings) -> None:
+    """Synchronize Discord application commands according to COMMAND_SYNC_MODE."""
+
+    mode = settings.command_sync_mode
+
+    if mode == "off":
+        logger.info("command_sync_skipped mode=off")
+        return
+
+    if mode == "auto":
+        mode = "guild" if settings.home_guild_id else "global"
+
+    if mode == "guild":
+        if settings.home_guild_id is None:
+            raise SettingsError("HOME_GUILD_ID is required for guild command sync")
+
+        guild = discord.Object(id=settings.home_guild_id)
+        bot.tree.copy_global_to(guild=guild)
+        synced = await bot.tree.sync(guild=guild)
+        logger.info(
+            "command_sync_complete scope=guild guild_id=%s command_count=%s",
+            settings.home_guild_id,
+            len(synced),
         )
-        await interaction.response.send_message(msg, ephemeral=True)
+        return
 
-    @app_commands.command(name="uptime", description="Show bot uptime")
-    async def uptime(self, interaction: discord.Interaction):
-        started = getattr(self.bot, "start_ts", time.time())
-        secs = int(time.time() - started)
-        h, r = divmod(secs, 3600); m, s = divmod(r, 60)
-        await interaction.response.send_message(f"Uptime: {h}h {m}m {s}s", ephemeral=True)
-
-    @app_commands.default_permissions(administrator=True)
-    @app_commands.command(name="sync", description="Admin: resync slash commands")
-    async def sync(self, interaction: discord.Interaction):
-        if not interaction.user.guild_permissions.administrator:
-            return await interaction.response.send_message("Admins only.", ephemeral=True)
-        dev = os.getenv("APP_ENV","development") == "development"
-        gid = os.getenv("DEV_GUILD_ID")
-        if dev and gid:
-            guild = discord.Object(id=int(gid))
-            self.bot.tree.copy_global_to(guild=guild)
-            synced = await self.bot.tree.sync(guild=guild)
-            return await interaction.response.send_message(f"Synced {len(synced)} cmds to dev guild.", ephemeral=True)
-        synced = await self.bot.tree.sync()
-        await interaction.response.send_message(f"Synced {len(synced)} cmds globally.", ephemeral=True)
-
-async def setup(bot: commands.Bot):
-    await bot.add_cog(Core(bot))
-
-async def load_cogs():
-    await bot.load_extension('cogs.core')
+    synced = await bot.tree.sync()
+    logger.warning("command_sync_complete scope=global command_count=%s", len(synced))
 
 
+class WilhelminaBot(commands.Bot):
+    """Discord client for Wilhelmina."""
+
+    def __init__(self, *, settings: RuntimeSettings) -> None:
+        super().__init__(
+            command_prefix="!",
+            intents=build_intents(settings),
+        )
+        self.settings = settings
+        self.start_ts = time.time()
+        self.cog_load_report: dict[str, list[str]] = {
+            "loaded": [],
+            "skipped": [],
+            "failed": [],
+        }
+
+    async def setup_hook(self) -> None:
+        self.cog_load_report = await load_cogs(self, self.settings)
+        await sync_application_commands(self, self.settings)
+
+    async def on_ready(self) -> None:
+        logger.info(
+            "bot_online user=%s app_env=%s server_mode=%s sync_mode=%s home_guild_id=%s "
+            "loaded_cogs=%s skipped_cogs=%s failed_cogs=%s",
+            self.user,
+            self.settings.app_env,
+            self.settings.server_mode,
+            self.settings.command_sync_mode,
+            self.settings.home_guild_id,
+            ",".join(self.cog_load_report["loaded"]) or "none",
+            ",".join(self.cog_load_report["skipped"]) or "none",
+            ",".join(self.cog_load_report["failed"]) or "none",
+        )
+
+
+def main() -> None:
+    try:
+        settings = load_settings()
+    except SettingsError as exc:
+        raise SystemExit(f"Configuration error: {exc}") from exc
+
+    configure_logging(settings.log_level)
+
+    bot = WilhelminaBot(settings=settings)
+    bot.run(settings.discord_token)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import time
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+def _format_uptime(seconds: int) -> str:
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours}h {minutes}m {seconds}s"
+
+
+def _format_sequence(values: list[str]) -> str:
+    return ", ".join(values) if values else "none"
+
+
+class Admin(commands.GroupCog, group_name="admin"):
+    """Admin-only diagnostics and runtime controls."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def _is_not_admin(self, interaction: discord.Interaction) -> bool:
+        permissions = getattr(interaction.user, "guild_permissions", None)
+        if not permissions or not permissions.administrator:
+            await interaction.response.send_message("Admins only.", ephemeral=True)
+            return True
+        return False
+
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.command(name="diagnostics", description="Show Wilhelmina runtime diagnostics.")
+    async def diagnostics(self, interaction: discord.Interaction) -> None:
+        if await self._is_not_admin(interaction):
+            return
+
+        settings = self.bot.settings
+        report = getattr(
+            self.bot,
+            "cog_load_report",
+            {"loaded": [], "skipped": [], "failed": []},
+        )
+        uptime_seconds = int(time.time() - getattr(self.bot, "start_ts", time.time()))
+
+        message = (
+            "**Wilhelmina diagnostics**\n"
+            "```txt\n"
+            f"app_env        = {settings.app_env}\n"
+            f"server_mode    = {settings.server_mode}\n"
+            f"sync_mode      = {settings.command_sync_mode}\n"
+            f"home_guild_id  = {settings.home_guild_id or 'unset'}\n"
+            f"uptime         = {_format_uptime(uptime_seconds)}\n"
+            f"loaded_cogs    = {_format_sequence(report.get('loaded', []))}\n"
+            f"skipped_cogs   = {_format_sequence(report.get('skipped', []))}\n"
+            f"failed_cogs    = {_format_sequence(report.get('failed', []))}\n"
+            "```"
+        )
+        await interaction.response.send_message(message, ephemeral=True)
+
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.command(name="features", description="Show enabled and disabled Wilhelmina features.")
+    async def features(self, interaction: discord.Interaction) -> None:
+        if await self._is_not_admin(interaction):
+            return
+
+        settings = self.bot.settings
+        lines = ["**Wilhelmina features**", "```txt"]
+        for flag in settings.cog_flags:
+            status = "enabled" if settings.is_cog_enabled(flag.extension) else "disabled"
+            required = "required" if flag.required else "optional"
+            lines.append(f"{flag.env_var:<16} {status:<8} {required:<8} {flag.extension}")
+        lines.append("```")
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.command(name="sync", description="Resync Wilhelmina slash commands.")
+    async def sync(self, interaction: discord.Interaction) -> None:
+        if await self._is_not_admin(interaction):
+            return
+
+        settings = self.bot.settings
+        mode = settings.command_sync_mode
+
+        if mode == "off":
+            await interaction.response.send_message(
+                "Command sync is disabled by `COMMAND_SYNC_MODE=off`.",
+                ephemeral=True,
+            )
+            return
+
+        if mode == "auto":
+            mode = "guild" if settings.home_guild_id else "global"
+
+        if mode == "guild":
+            if settings.home_guild_id is None:
+                await interaction.response.send_message(
+                    "Cannot sync: `HOME_GUILD_ID` is not set.",
+                    ephemeral=True,
+                )
+                return
+
+            guild = discord.Object(id=settings.home_guild_id)
+            self.bot.tree.copy_global_to(guild=guild)
+            synced = await self.bot.tree.sync(guild=guild)
+            await interaction.response.send_message(
+                f"Synced {len(synced)} command(s) to home guild `{settings.home_guild_id}`.",
+                ephemeral=True,
+            )
+            return
+
+        synced = await self.bot.tree.sync()
+        await interaction.response.send_message(
+            f"Synced {len(synced)} command(s) globally. Global sync can take time to propagate.",
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Admin(bot))

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -1,36 +1,45 @@
-import os, time, discord
+from __future__ import annotations
+
+import platform
+import time
+
+import discord
 from discord import app_commands
 from discord.ext import commands
 
-APP_ENV = os.getenv("APP_ENV","development")
-DEV_GUILD_ID = os.getenv("DEV_GUILD_ID")
+
+def _format_uptime(seconds: int) -> str:
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours}h {minutes}m {seconds}s"
+
 
 class Core(commands.Cog):
-    def __init__(self, bot):
+    """Core user-facing runtime commands."""
+
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.start = time.time()
 
-    @app_commands.command(name="about", description="About this bot")
-    async def about(self, interaction: discord.Interaction):
-        await interaction.response.send_message("Wilhelmina core ready.", ephemeral=True)
+    @app_commands.command(name="about", description="About Wilhelmina.")
+    async def about(self, interaction: discord.Interaction) -> None:
+        settings = getattr(self.bot, "settings", None)
+        app_env = getattr(settings, "app_env", "unknown")
+        server_mode = getattr(settings, "server_mode", "dedicated")
+        sync_mode = getattr(settings, "command_sync_mode", "unknown")
 
-    @app_commands.command(name="uptime", description="Show bot uptime")
-    async def uptime(self, interaction: discord.Interaction):
-        s = int(time.time() - self.start)
-        h, r = divmod(s, 3600); m, s = divmod(r, 60)
-        await interaction.response.send_message(f"Uptime: {h}h {m}m {s}s", ephemeral=True)
+        message = (
+            "**Wilhelmina** runtime is online.\n"
+            f"Python `{platform.python_version()}` • discord.py `{discord.__version__}`\n"
+            f"Environment `{app_env}` • server mode `{server_mode}` • sync `{sync_mode}`"
+        )
+        await interaction.response.send_message(message, ephemeral=True)
 
-    @app_commands.command(name="sync", description="Resync slash commands")
-    @app_commands.default_permissions(administrator=True)
-    async def sync(self, interaction: discord.Interaction):
-        if APP_ENV == "development" and DEV_GUILD_ID:
-            guild = discord.Object(id=int(DEV_GUILD_ID))
-            self.bot.tree.copy_global_to(guild=guild)
-            cmds = await self.bot.tree.sync(guild=guild)
-            await interaction.response.send_message(f"Synced {len(cmds)} to dev guild.", ephemeral=True)
-        else:
-            cmds = await self.bot.tree.sync()
-            await interaction.response.send_message(f"Synced {len(cmds)} globally.", ephemeral=True)
+    @app_commands.command(name="uptime", description="Show bot uptime.")
+    async def uptime(self, interaction: discord.Interaction) -> None:
+        started = getattr(self.bot, "start_ts", time.time())
+        seconds = int(time.time() - started)
+        await interaction.response.send_message(f"Uptime: {_format_uptime(seconds)}", ephemeral=True)
 
-async def setup(bot: commands.Bot):
+
+async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Core(bot))

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,16 +1,272 @@
-﻿import os
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
 from dotenv import load_dotenv
 
-# load .env from project root
-load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ENV_PATH = PROJECT_ROOT / ".env"
 
-APP_ENV      = os.getenv("APP_ENV", "development")
-DEV_GUILD_ID = os.getenv("DEV_GUILD_ID")
-DISCORD_TOKEN= os.getenv("DISCORD_TOKEN")
-LOG_LEVEL    = os.getenv("LOG_LEVEL", "INFO")
+TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
+VALID_COMMAND_SYNC_MODES = {"guild", "dev", "global", "off", "auto"}
+VALID_SERVER_MODES = {"dedicated"}
+
+
+class SettingsError(RuntimeError):
+    """Raised when Wilhelmina runtime configuration is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class CogFlag:
+    """Declarative switch for one Discord extension/cog."""
+
+    extension: str
+    env_var: str
+    default_enabled: bool
+    description: str
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    """Validated runtime settings for Wilhelmina."""
+
+    discord_token: str
+    client_id: str | None
+    app_env: str
+    server_mode: str
+    home_guild_id: int | None
+    log_level: str
+    command_sync_mode: str
+    cog_flags: tuple[CogFlag, ...]
+    enabled_cogs: Mapping[str, bool]
+
+    def is_cog_enabled(self, extension: str) -> bool:
+        return bool(self.enabled_cogs.get(extension, False))
+
+
+COG_FLAGS: tuple[CogFlag, ...] = (
+    CogFlag(
+        extension="cogs.core",
+        env_var="ENABLE_CORE",
+        default_enabled=True,
+        description="Core commands and runtime health checks.",
+        required=True,
+    ),
+    CogFlag(
+        extension="cogs.admin",
+        env_var="ENABLE_ADMIN",
+        default_enabled=True,
+        description="Admin diagnostics and runtime inspection commands.",
+        required=True,
+    ),
+    CogFlag(
+        extension="cogs.invite",
+        env_var="ENABLE_INVITE",
+        default_enabled=False,
+        description="Invite-link command and Discord authorization helper.",
+    ),
+    CogFlag(
+        extension="cogs.oracles",
+        env_var="ENABLE_ORACLES",
+        default_enabled=False,
+        description="Oracle/divination slash commands.",
+    ),
+)
+
+
+def _load_env() -> None:
+    """Load .env from the repository root if it exists."""
+
+    load_dotenv(dotenv_path=ENV_PATH)
+
+
+def _get_str(name: str, *, default: str | None = None, required: bool = False) -> str | None:
+    value = os.getenv(name)
+
+    if value is None:
+        if required:
+            raise SettingsError(f"Missing required environment variable: {name}")
+        return default
+
+    value = value.strip()
+
+    if required and not value:
+        raise SettingsError(f"Missing required environment variable: {name}")
+
+    return value if value else default
+
+
+def _get_int(name: str, *, default: int | None = None, required: bool = False) -> int | None:
+    raw = _get_str(name, default=None, required=required)
+
+    if raw is None:
+        return default
+
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SettingsError(f"Environment variable {name} must be an integer, got {raw!r}") from exc
+
+
+def _get_bool(name: str, *, default: bool = False) -> bool:
+    raw = os.getenv(name)
+
+    if raw is None or raw.strip() == "":
+        return default
+
+    value = raw.strip().lower()
+
+    if value in TRUE_VALUES:
+        return True
+
+    if value in FALSE_VALUES:
+        return False
+
+    raise SettingsError(
+        f"Environment variable {name} must be a boolean "
+        f"(true/false, yes/no, on/off, 1/0), got {raw!r}"
+    )
+
+
+def _get_bool_or_default(name: str, *, default: bool = False) -> bool:
+    """Read a boolean for compatibility globals without failing module import."""
+
+    try:
+        return _get_bool(name, default=default)
+    except SettingsError:
+        return default
+
+
+def _get_home_guild_id() -> int | None:
+    """Return the dedicated server guild ID, accepting DEV_GUILD_ID as a legacy alias."""
+
+    home_guild_id = _get_int("HOME_GUILD_ID", default=None)
+    if home_guild_id is not None:
+        return home_guild_id
+
+    return _get_int("DEV_GUILD_ID", default=None)
+
+
+def _get_command_sync_mode() -> str:
+    mode = (_get_str("COMMAND_SYNC_MODE", default="guild") or "guild").lower()
+
+    if mode not in VALID_COMMAND_SYNC_MODES:
+        raise SettingsError(
+            f"COMMAND_SYNC_MODE must be one of {sorted(VALID_COMMAND_SYNC_MODES)}, got {mode!r}"
+        )
+
+    # Legacy name retained so older .env files still work.
+    if mode == "dev":
+        return "guild"
+
+    return mode
+
+
+def _get_command_sync_mode_or_default() -> str:
+    """Read command sync mode for compatibility globals without failing module import."""
+
+    try:
+        return _get_command_sync_mode()
+    except SettingsError:
+        return "guild"
+
+
+def _get_server_mode() -> str:
+    mode = (_get_str("SERVER_MODE", default="dedicated") or "dedicated").lower()
+
+    if mode not in VALID_SERVER_MODES:
+        raise SettingsError(
+            "SERVER_MODE must be 'dedicated'. Server takeover/transformation modes are not supported."
+        )
+
+    return mode
+
+
+def _read_enabled_cogs() -> Mapping[str, bool]:
+    enabled = {
+        flag.extension: _get_bool(flag.env_var, default=flag.default_enabled)
+        for flag in COG_FLAGS
+    }
+
+    disabled_required = [
+        flag.env_var
+        for flag in COG_FLAGS
+        if flag.required and not enabled.get(flag.extension, False)
+    ]
+
+    if disabled_required:
+        joined = ", ".join(disabled_required)
+        raise SettingsError(f"Required cog flag cannot be disabled: {joined}")
+
+    return MappingProxyType(enabled)
+
+
+def load_settings() -> RuntimeSettings:
+    """Load and validate Wilhelmina runtime settings."""
+
+    _load_env()
+
+    discord_token = _get_str("DISCORD_TOKEN", required=True)
+    client_id = _get_str("CLIENT_ID", default=None)
+    app_env = _get_str("APP_ENV", default="development") or "development"
+    server_mode = _get_server_mode()
+    home_guild_id = _get_home_guild_id()
+    log_level = (_get_str("LOG_LEVEL", default="INFO") or "INFO").upper()
+    command_sync_mode = _get_command_sync_mode()
+
+    if command_sync_mode == "guild" and home_guild_id is None:
+        raise SettingsError(
+            "HOME_GUILD_ID is required when COMMAND_SYNC_MODE=guild "
+            "(DEV_GUILD_ID is accepted as a legacy alias)."
+        )
+
+    return RuntimeSettings(
+        discord_token=discord_token,
+        client_id=client_id,
+        app_env=app_env,
+        server_mode=server_mode,
+        home_guild_id=home_guild_id,
+        log_level=log_level,
+        command_sync_mode=command_sync_mode,
+        cog_flags=COG_FLAGS,
+        enabled_cogs=_read_enabled_cogs(),
+    )
+
 
 def require_token() -> str:
-    if not DISCORD_TOKEN:
-        raise SystemExit("Missing DISCORD_TOKEN in .env")
-    return DISCORD_TOKEN
+    """Compatibility helper for modules that need only the Discord token."""
+
+    return load_settings().discord_token
+
+
+def is_feature_enabled(extension: str) -> bool:
+    """Return whether a known cog extension is enabled by environment flags."""
+
+    return bool(_read_enabled_cogs().get(extension, False))
+
+
+# Load non-fatal module-level values for compatibility with existing imports.
+_load_env()
+
+APP_ENV = _get_str("APP_ENV", default="development") or "development"
+SERVER_MODE = _get_str("SERVER_MODE", default="dedicated") or "dedicated"
+HOME_GUILD_ID = _get_str("HOME_GUILD_ID", default=_get_str("DEV_GUILD_ID", default=None))
+DEV_GUILD_ID = HOME_GUILD_ID
+CLIENT_ID = _get_str("CLIENT_ID", default=None)
+DISCORD_TOKEN = _get_str("DISCORD_TOKEN", default=None)
+LOG_LEVEL = (_get_str("LOG_LEVEL", default="INFO") or "INFO").upper()
+COMMAND_SYNC_MODE = _get_command_sync_mode_or_default()
+
+ENABLE_CORE = _get_bool_or_default("ENABLE_CORE", default=True)
+ENABLE_ADMIN = _get_bool_or_default("ENABLE_ADMIN", default=True)
+ENABLE_INVITE = _get_bool_or_default("ENABLE_INVITE", default=False)
+ENABLE_ORACLES = _get_bool_or_default("ENABLE_ORACLES", default=False)
+
+# Existing optional modules may look for this attribute.
+EMBEDS_ONLY = _get_bool_or_default("EMBEDS_ONLY", default=True)

--- a/docs/adr/0001-dedicated-server-runtime.md
+++ b/docs/adr/0001-dedicated-server-runtime.md
@@ -1,0 +1,31 @@
+# ADR 0001: Dedicated Server Runtime
+
+## Status
+
+Accepted
+
+## Context
+
+Wilhelmina previously had possible roadmap paths involving existing-server transformation, channel archival, or server takeover workflows.
+
+Those paths create avoidable risk: destructive channel changes, permission mistakes, irreversible archive moves, and coupling future onboarding work to an unstable migration process.
+
+## Decision
+
+Wilhelmina will target a brand-new dedicated Discord server.
+
+The runtime only supports:
+
+```env
+SERVER_MODE=dedicated
+```
+
+Existing-server takeover, automatic archival, and server transformation modes are not supported. Configuration validation rejects unsupported server modes.
+
+## Consequences
+
+- Startup and command sync use `HOME_GUILD_ID` as the dedicated server identity.
+- `DEV_GUILD_ID` remains a temporary compatibility alias for `HOME_GUILD_ID`.
+- Future onboarding, roles, broadcasts, memory, and admin configuration should assume one home guild.
+- Destructive channel migration logic is out of scope.
+- Server setup should be explicit, admin-driven, and reversible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ line-length = 100
 extend-exclude = [".venv", "build", "dist"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "B", "UP"]
+# Step-one CI catches syntax/import errors without forcing a full legacy style cleanup yet.
+select = ["E9", "F"]
 ignore = []
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=70", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wilhelmina"
+version = "0.1.0"
+description = "Wilhelmina Discord bot runtime"
+readme = "README.md"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+  "discord.py>=2.5,<3.0",
+  "python-dotenv>=1.0,<2.0",
+]
+
+[project.optional-dependencies]
+oracles = [
+  "openai>=1.0,<2.0",
+]
+dev = [
+  "pytest>=8.0,<10.0",
+  "pytest-asyncio>=0.24,<2.0",
+  "ruff>=0.8,<1.0",
+]
+
+[project.scripts]
+wilhelmina = "bot:main"
+
+[tool.setuptools]
+py-modules = ["bot"]
+packages = ["cogs", "config", "utils"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+extend-exclude = [".venv", "build", "dist"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I", "B", "UP"]
+ignore = []
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,3 @@
-﻿aiohappyeyeballs==2.6.1
-aiohttp==3.12.15
-aiosignal==1.4.0
-attrs==25.3.0
-discord.py==2.5.2
-frozenlist==1.7.0
-idna==3.10
-multidict==6.6.4
-propcache==0.3.2
-python-dotenv==1.1.1
-typing_extensions==4.14.1
-yarl==1.20.1
+discord.py>=2.5,<3.0
+python-dotenv>=1.0,<2.0
+openai>=1.0,<2.0

--- a/tests/test_bot_loader.py
+++ b/tests/test_bot_loader.py
@@ -1,0 +1,87 @@
+import unittest
+from types import SimpleNamespace
+
+import bot as bot_module
+from config.settings import CogFlag
+
+
+class DummyBot:
+    def __init__(self, fail_on=None):
+        self.fail_on = set(fail_on or [])
+        self.loaded = []
+
+    async def load_extension(self, extension):
+        if extension in self.fail_on:
+            raise RuntimeError("boom")
+        self.loaded.append(extension)
+
+
+def make_settings(enabled):
+    flags = (
+        CogFlag("cogs.core", "ENABLE_CORE", True, "core", True),
+        CogFlag("cogs.admin", "ENABLE_ADMIN", True, "admin", True),
+        CogFlag("cogs.invite", "ENABLE_INVITE", False, "invite", False),
+        CogFlag("cogs.oracles", "ENABLE_ORACLES", False, "oracles", False),
+    )
+
+    return SimpleNamespace(
+        cog_flags=flags,
+        is_cog_enabled=lambda extension: enabled.get(extension, False),
+    )
+
+
+class CogLoaderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_enabled_cogs_load_and_disabled_cogs_skip(self):
+        dummy = DummyBot()
+        runtime_settings = make_settings(
+            {
+                "cogs.core": True,
+                "cogs.admin": True,
+                "cogs.invite": True,
+                "cogs.oracles": False,
+            }
+        )
+
+        with self.assertLogs("wilhelmina", level="INFO") as logs:
+            report = await bot_module.load_cogs(dummy, runtime_settings)
+
+        self.assertEqual(dummy.loaded, ["cogs.core", "cogs.admin", "cogs.invite"])
+        self.assertEqual(report["loaded"], ["cogs.core", "cogs.admin", "cogs.invite"])
+        self.assertEqual(report["skipped"], ["cogs.oracles"])
+        self.assertIn("cog_skipped extension=cogs.oracles", "\n".join(logs.output))
+
+    async def test_optional_failed_cog_logs_and_loading_continues(self):
+        dummy = DummyBot(fail_on={"cogs.invite"})
+        runtime_settings = make_settings(
+            {
+                "cogs.core": True,
+                "cogs.admin": True,
+                "cogs.invite": True,
+                "cogs.oracles": True,
+            }
+        )
+
+        with self.assertLogs("wilhelmina", level="INFO") as logs:
+            report = await bot_module.load_cogs(dummy, runtime_settings)
+
+        self.assertEqual(dummy.loaded, ["cogs.core", "cogs.admin", "cogs.oracles"])
+        self.assertEqual(report["failed"], ["cogs.invite"])
+        self.assertIn("cog_load_failed_unexpected extension=cogs.invite", "\n".join(logs.output))
+
+    async def test_required_failed_cog_raises(self):
+        dummy = DummyBot(fail_on={"cogs.core"})
+        runtime_settings = make_settings(
+            {
+                "cogs.core": True,
+                "cogs.admin": True,
+                "cogs.invite": True,
+                "cogs.oracles": True,
+            }
+        )
+
+        with self.assertRaises(RuntimeError):
+            await bot_module.load_cogs(dummy, runtime_settings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest import mock
+
+from config import settings as settings_module
+
+
+class SettingsTests(unittest.TestCase):
+    def load_with_env(self, values):
+        with mock.patch.object(settings_module, "load_dotenv", lambda *args, **kwargs: None):
+            with mock.patch.dict("os.environ", values, clear=True):
+                return settings_module.load_settings()
+
+    def test_missing_discord_token_raises(self):
+        with mock.patch.object(settings_module, "load_dotenv", lambda *args, **kwargs: None):
+            with mock.patch.dict("os.environ", {"COMMAND_SYNC_MODE": "off"}, clear=True):
+                with self.assertRaisesRegex(settings_module.SettingsError, "DISCORD_TOKEN"):
+                    settings_module.load_settings()
+
+    def test_guild_sync_requires_home_guild_id(self):
+        with mock.patch.object(settings_module, "load_dotenv", lambda *args, **kwargs: None):
+            with mock.patch.dict(
+                "os.environ",
+                {"DISCORD_TOKEN": "token", "COMMAND_SYNC_MODE": "guild"},
+                clear=True,
+            ):
+                with self.assertRaisesRegex(settings_module.SettingsError, "HOME_GUILD_ID"):
+                    settings_module.load_settings()
+
+    def test_dedicated_server_settings_load(self):
+        loaded = self.load_with_env(
+            {
+                "DISCORD_TOKEN": "token",
+                "HOME_GUILD_ID": "12345",
+                "COMMAND_SYNC_MODE": "guild",
+            }
+        )
+
+        self.assertEqual(loaded.server_mode, "dedicated")
+        self.assertEqual(loaded.home_guild_id, 12345)
+        self.assertEqual(loaded.command_sync_mode, "guild")
+
+    def test_legacy_dev_guild_id_alias_sets_home_guild(self):
+        loaded = self.load_with_env(
+            {
+                "DISCORD_TOKEN": "token",
+                "DEV_GUILD_ID": "67890",
+                "COMMAND_SYNC_MODE": "dev",
+            }
+        )
+
+        self.assertEqual(loaded.home_guild_id, 67890)
+        self.assertEqual(loaded.command_sync_mode, "guild")
+
+    def test_server_takeover_mode_is_rejected(self):
+        with mock.patch.object(settings_module, "load_dotenv", lambda *args, **kwargs: None):
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "DISCORD_TOKEN": "token",
+                    "COMMAND_SYNC_MODE": "off",
+                    "SERVER_MODE": "takeover",
+                },
+                clear=True,
+            ):
+                with self.assertRaisesRegex(settings_module.SettingsError, "dedicated"):
+                    settings_module.load_settings()
+
+    def test_feature_flags_parse(self):
+        loaded = self.load_with_env(
+            {
+                "DISCORD_TOKEN": "token",
+                "COMMAND_SYNC_MODE": "off",
+                "ENABLE_CORE": "true",
+                "ENABLE_ADMIN": "true",
+                "ENABLE_INVITE": "1",
+                "ENABLE_ORACLES": "false",
+            }
+        )
+
+        self.assertTrue(loaded.is_cog_enabled("cogs.core"))
+        self.assertTrue(loaded.is_cog_enabled("cogs.admin"))
+        self.assertTrue(loaded.is_cog_enabled("cogs.invite"))
+        self.assertFalse(loaded.is_cog_enabled("cogs.oracles"))
+
+    def test_required_admin_cannot_be_disabled(self):
+        with mock.patch.object(settings_module, "load_dotenv", lambda *args, **kwargs: None):
+            with mock.patch.dict(
+                "os.environ",
+                {
+                    "DISCORD_TOKEN": "token",
+                    "COMMAND_SYNC_MODE": "off",
+                    "ENABLE_CORE": "true",
+                    "ENABLE_ADMIN": "false",
+                },
+                clear=True,
+            ):
+                with self.assertRaisesRegex(settings_module.SettingsError, "ENABLE_ADMIN"):
+                    settings_module.load_settings()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR applies the first runtime-foundation pass for Wilhelmina and locks the roadmap around a dedicated home server model.

### Runtime/config

- Adds validated `SERVER_MODE=dedicated` runtime configuration.
- Adds `HOME_GUILD_ID` as the dedicated server identity.
- Keeps `DEV_GUILD_ID` only as a compatibility alias.
- Defaults command sync to guild-scoped sync instead of global sync.
- Rejects unsupported takeover/transformation server modes.
- Restores a structured `WilhelminaBot` runtime with cog load reporting and startup diagnostics.

### Admin/core commands

- Keeps `/about` and `/uptime` in `cogs.core`.
- Adds required `cogs.admin` with:
  - `/admin diagnostics`
  - `/admin features`
  - `/admin sync`

### Tooling/CI/tests

- Adds `pyproject.toml` with editable install, dev extras, pytest config, and ruff config.
- Adds GitHub Actions CI for `ruff check .` and `pytest`.
- Simplifies `requirements.txt` to direct runtime dependencies.
- Adds settings and cog loader tests.

### Docs

- Updates README for dedicated-server setup.
- Adds ADR 0001 documenting that existing-server takeover/channel archival/server transformation is out of scope.

## Notes

This branch is intentionally foundation-only. It does not implement AI service refactoring, persistence, onboarding, scheduling, or dedicated server provisioning yet.

The branch currently diverged from `main`; it may need an update/rebase before merge.