### PR TITLE
Add Phase 3 operational readiness inspection

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -7,7 +7,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from services import audit_log, guild_config
+from services import audit_log, config_validation, guild_config
 from services.database import initialize_database, managed_connection
 
 ROLE_FIELD_CHOICES = [
@@ -70,6 +70,32 @@ def _format_config(config: guild_config.GuildConfig | None) -> str:
     return "\n".join(lines)
 
 
+def _format_readiness_block(
+    title: str,
+    result: config_validation.ConfigValidationResult,
+    *,
+    checklist: bool = False,
+) -> str:
+    lines = [f"**{title}**", "```txt"]
+    if checklist:
+        lines.extend(config_validation.format_checklist_lines(result))
+    else:
+        lines.append(f"overall_ok = {str(result.ok).lower()}")
+        lines.append(f"errors     = {len(result.errors)}")
+        lines.append(f"warnings   = {len(result.warnings)}")
+        lines.append("")
+        lines.extend(config_validation.format_check_lines(result))
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _format_audit_event(event: audit_log.AuditEvent) -> str:
+    return (
+        f"#{event.id} {event.created_at} "
+        f"actor={event.actor_user_id} action={event.action} target={event.target}"
+    )
+
+
 @app_commands.guild_only()
 @app_commands.default_permissions(administrator=True)
 class Admin(commands.GroupCog, group_name="admin"):
@@ -78,6 +104,14 @@ class Admin(commands.GroupCog, group_name="admin"):
     config = app_commands.Group(
         name="config",
         description="Manage Wilhelmina's stored guild configuration.",
+    )
+    setup = app_commands.Group(
+        name="setup",
+        description="Inspect Wilhelmina's operational readiness.",
+    )
+    logs = app_commands.Group(
+        name="logs",
+        description="Inspect Wilhelmina's administrative audit log.",
     )
 
     def __init__(self, bot: commands.Bot):
@@ -100,7 +134,7 @@ class Admin(commands.GroupCog, group_name="admin"):
 
         if home_guild_id is None:
             await interaction.response.send_message(
-                "Cannot resolve a guild. Set `HOME_GUILD_ID` before using admin config commands.",
+                "Cannot resolve a guild. Set `HOME_GUILD_ID` before using admin commands.",
                 ephemeral=True,
             )
             return None
@@ -120,6 +154,15 @@ class Admin(commands.GroupCog, group_name="admin"):
             return None
 
         return int(home_guild_id)
+
+    async def _guard_admin_home_guild(
+        self,
+        interaction: discord.Interaction,
+    ) -> int | None:
+        if await self._reject_non_admin(interaction):
+            return None
+
+        return await self._resolve_guild_id(interaction)
 
     async def _send_config_error(
         self,
@@ -149,9 +192,31 @@ class Admin(commands.GroupCog, group_name="admin"):
             after=guild_config.config_to_audit_dict(after),
         )
 
+    def _load_config(self, guild_id: int) -> guild_config.GuildConfig | None:
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            return guild_config.get_guild_config(connection, guild_id)
+
+    def _build_readiness_result(
+        self,
+        interaction: discord.Interaction,
+        guild_id: int,
+    ) -> config_validation.ConfigValidationResult:
+        config = self._load_config(guild_id)
+        bot_user = getattr(self.bot, "user", None)
+        bot_user_id = getattr(bot_user, "id", None)
+        return config_validation.validate_config(
+            config=config,
+            guild=interaction.guild,
+            configured_home_guild_id=guild_id,
+            bot_user_id=bot_user_id,
+        )
+
     @app_commands.command(name="diagnostics", description="Show Wilhelmina runtime diagnostics.")
     async def diagnostics(self, interaction: discord.Interaction) -> None:
-        if await self._reject_non_admin(interaction):
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
             return
 
         settings = self.bot.settings
@@ -168,7 +233,7 @@ class Admin(commands.GroupCog, group_name="admin"):
             f"app_env        = {settings.app_env}\n"
             f"server_mode    = {settings.server_mode}\n"
             f"sync_mode      = {settings.command_sync_mode}\n"
-            f"home_guild_id  = {settings.home_guild_id or 'unset'}\n"
+            f"home_guild_id  = {guild_id}\n"
             f"database_path  = {settings.database_path}\n"
             f"uptime         = {_format_uptime(uptime_seconds)}\n"
             f"loaded_cogs    = {_format_sequence(report.get('loaded', []))}\n"
@@ -183,11 +248,12 @@ class Admin(commands.GroupCog, group_name="admin"):
         description="Show enabled and disabled Wilhelmina features.",
     )
     async def features(self, interaction: discord.Interaction) -> None:
-        if await self._reject_non_admin(interaction):
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
             return
 
         settings = self.bot.settings
-        lines = ["**Wilhelmina features**", "```txt"]
+        lines = ["**Wilhelmina features**", "```txt", f"home_guild_id = {guild_id}", ""]
         for flag in settings.cog_flags:
             status = "enabled" if settings.is_cog_enabled(flag.extension) else "disabled"
             required = "required" if flag.required else "optional"
@@ -197,7 +263,8 @@ class Admin(commands.GroupCog, group_name="admin"):
 
     @app_commands.command(name="sync", description="Resync Wilhelmina slash commands.")
     async def sync(self, interaction: discord.Interaction) -> None:
-        if await self._reject_non_admin(interaction):
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
             return
 
         settings = self.bot.settings
@@ -211,45 +278,109 @@ class Admin(commands.GroupCog, group_name="admin"):
             return
 
         if mode == "auto":
-            mode = "guild" if settings.home_guild_id else "global"
+            mode = "guild"
 
-        if mode == "guild":
-            if settings.home_guild_id is None:
-                await interaction.response.send_message(
-                    "Cannot sync: `HOME_GUILD_ID` is not set.",
-                    ephemeral=True,
-                )
-                return
-
-            guild = discord.Object(id=settings.home_guild_id)
-            self.bot.tree.copy_global_to(guild=guild)
-            synced = await self.bot.tree.sync(guild=guild)
+        if mode == "global":
             await interaction.response.send_message(
-                f"Synced {len(synced)} command(s) to home guild `{settings.home_guild_id}`.",
+                "Global sync is disabled from Discord commands in dedicated-server mode.",
                 ephemeral=True,
             )
             return
 
-        synced = await self.bot.tree.sync()
+        guild = discord.Object(id=guild_id)
+        self.bot.tree.copy_global_to(guild=guild)
+        synced = await self.bot.tree.sync(guild=guild)
         await interaction.response.send_message(
-            f"Synced {len(synced)} command(s) globally. Global sync can take time to propagate.",
+            f"Synced {len(synced)} command(s) to home guild `{guild_id}`.",
             ephemeral=True,
         )
 
-    @config.command(name="view", description="View Wilhelmina's stored guild configuration.")
-    async def config_view(self, interaction: discord.Interaction) -> None:
-        if await self._reject_non_admin(interaction):
+    @setup.command(name="status", description="Show operational readiness status.")
+    async def setup_status(self, interaction: discord.Interaction) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
             return
 
-        guild_id = await self._resolve_guild_id(interaction)
+        result = self._build_readiness_result(interaction, guild_id)
+        await interaction.response.send_message(
+            _format_readiness_block("Wilhelmina setup status", result),
+            ephemeral=True,
+        )
+
+    @setup.command(name="checklist", description="Show operational setup checklist.")
+    async def setup_checklist(self, interaction: discord.Interaction) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        result = self._build_readiness_result(interaction, guild_id)
+        await interaction.response.send_message(
+            _format_readiness_block(
+                "Wilhelmina setup checklist",
+                result,
+                checklist=True,
+            ),
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="permissions", description="Show bot permission readiness.")
+    async def permissions(self, interaction: discord.Interaction) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        result = self._build_readiness_result(interaction, guild_id)
+        permission_checks = [
+            check
+            for check in result.checks
+            if ".view_channel" in check.field
+            or ".send_messages" in check.field
+            or ".embed_links" in check.field
+            or ".manage_roles" in check.field
+        ]
+        permission_result = config_validation.ConfigValidationResult(
+            tuple(permission_checks)
+        )
+        await interaction.response.send_message(
+            _format_readiness_block("Wilhelmina permission report", permission_result),
+            ephemeral=True,
+        )
+
+    @logs.command(name="recent", description="Show recent admin audit events.")
+    @app_commands.describe(limit="Number of audit events to show. Range: 1-25.")
+    async def logs_recent(
+        self,
+        interaction: discord.Interaction,
+        limit: app_commands.Range[int, 1, 25] = 10,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
         if guild_id is None:
             return
 
         database_path = self._database_path()
         initialize_database(database_path)
         with managed_connection(database_path) as connection:
-            config = guild_config.get_guild_config(connection, guild_id)
+            events = audit_log.list_audit_events(connection, guild_id, limit=limit)
 
+        if not events:
+            await interaction.response.send_message(
+                "No audit events have been recorded yet.",
+                ephemeral=True,
+            )
+            return
+
+        lines = ["**Recent Wilhelmina audit events**", "```txt"]
+        lines.extend(_format_audit_event(event) for event in events)
+        lines.append("```")
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+    @config.command(name="view", description="View Wilhelmina's stored guild configuration.")
+    async def config_view(self, interaction: discord.Interaction) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        config = self._load_config(guild_id)
         await interaction.response.send_message(
             f"**Wilhelmina guild config**\n{_format_config(config)}",
             ephemeral=True,
@@ -267,10 +398,7 @@ class Admin(commands.GroupCog, group_name="admin"):
         field: str,
         role: discord.Role,
     ) -> None:
-        if await self._reject_non_admin(interaction):
-            return
-
-        guild_id = await self._resolve_guild_id(interaction)
+        guild_id = await self._guard_admin_home_guild(interaction)
         if guild_id is None:
             return
 
@@ -309,10 +437,7 @@ class Admin(commands.GroupCog, group_name="admin"):
         field: str,
         channel: discord.TextChannel,
     ) -> None:
-        if await self._reject_non_admin(interaction):
-            return
-
-        guild_id = await self._resolve_guild_id(interaction)
+        guild_id = await self._guard_admin_home_guild(interaction)
         if guild_id is None:
             return
 
@@ -346,10 +471,7 @@ class Admin(commands.GroupCog, group_name="admin"):
         interaction: discord.Interaction,
         timezone: str,
     ) -> None:
-        if await self._reject_non_admin(interaction):
-            return
-
-        guild_id = await self._resolve_guild_id(interaction)
+        guild_id = await self._guard_admin_home_guild(interaction)
         if guild_id is None:
             return
 
@@ -378,44 +500,15 @@ class Admin(commands.GroupCog, group_name="admin"):
 
     @config.command(name="validate", description="Validate stored guild roles and channels.")
     async def config_validate(self, interaction: discord.Interaction) -> None:
-        if await self._reject_non_admin(interaction):
-            return
-
-        guild_id = await self._resolve_guild_id(interaction)
+        guild_id = await self._guard_admin_home_guild(interaction)
         if guild_id is None:
             return
 
-        database_path = self._database_path()
-        initialize_database(database_path)
-        with managed_connection(database_path) as connection:
-            config = guild_config.get_guild_config(connection, guild_id)
-
-        if config is None:
-            await interaction.response.send_message(
-                "No guild configuration has been stored yet.",
-                ephemeral=True,
-            )
-            return
-
-        guild = interaction.guild
-        issues = guild_config.validate_guild_config(
-            config,
-            role_exists=(lambda role_id: guild.get_role(role_id) is not None) if guild else None,
-            channel_exists=(lambda channel_id: guild.get_channel(channel_id) is not None)
-            if guild
-            else None,
+        result = self._build_readiness_result(interaction, guild_id)
+        await interaction.response.send_message(
+            _format_readiness_block("Wilhelmina guild config validation", result),
+            ephemeral=True,
         )
-
-        lines = ["**Wilhelmina guild config validation**", "```txt"]
-        for issue in issues:
-            marker = "OK" if issue.ok else "!!"
-            lines.append(
-                f"{marker} {issue.field:<24} "
-                f"{_format_config_value(issue.value):<24} {issue.message}"
-            )
-        lines.append("```")
-
-        await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
     @config.command(name="clear", description="Clear stored guild config or one selected field.")
     @app_commands.describe(
@@ -427,10 +520,7 @@ class Admin(commands.GroupCog, group_name="admin"):
         interaction: discord.Interaction,
         field: str | None = None,
     ) -> None:
-        if await self._reject_non_admin(interaction):
-            return
-
-        guild_id = await self._resolve_guild_id(interaction)
+        guild_id = await self._guard_admin_home_guild(interaction)
         if guild_id is None:
             return
 

--- a/docs/adr/0004-operational-readiness.md
+++ b/docs/adr/0004-operational-readiness.md
@@ -1,0 +1,89 @@
+# ADR 0004: Operational readiness inspection
+
+Date: 2026-05-21
+
+## Status
+
+Accepted
+
+## Context
+
+Wilhelmina now has durable SQLite storage for guild configuration and audit events. Before onboarding or automation can be built safely, administrators need a deterministic way to inspect whether the dedicated home guild is configured correctly.
+
+Phase 3 needs to answer practical questions:
+
+```txt
+Is HOME_GUILD_ID configured?
+Does the command run in the home guild?
+Does the guild_config row exist?
+Do configured roles exist?
+Do configured channels exist?
+Can the bot view and send in those channels?
+Can recent audit events be listed?
+```
+
+## Decision
+
+Add a report-only readiness layer:
+
+```txt
+services/config_validation.py
+/admin setup status
+/admin setup checklist
+/admin permissions
+/admin logs recent
+```
+
+The validation service returns structured checks and issues. The admin commands format those results for ephemeral administrator responses.
+
+## Boundaries
+
+Phase 3 is inspection only.
+
+It does not add:
+
+```txt
+role creation
+channel creation
+role assignment
+automatic permission edits
+onboarding state
+scheduled jobs
+memory
+server takeover
+server transformation
+```
+
+All Discord objects are inspected through the live guild object available to the command. No command added in this phase changes Discord server structure.
+
+## Consequences
+
+Positive:
+
+- Administrators can see exactly what is missing before onboarding exists.
+- The bot reports permission problems without attempting to fix them.
+- Readiness logic is testable without live Discord API calls.
+- Audit log visibility becomes available through `/admin logs recent`.
+
+Tradeoffs:
+
+- The bot still depends on humans to create roles/channels and set permissions.
+- Permission inspection is best-effort when Discord objects or bot member data are unavailable.
+- Setup automation remains intentionally out of scope until later phases.
+
+## Test expectations
+
+Phase 3 tests cover:
+
+```txt
+home guild validation
+complete config validation
+missing role reporting
+missing channel reporting
+missing channel permission reporting
+warning-level optional permissions
+missing config row reporting
+bad timezone reporting
+admin readiness helper formatting
+audit event formatting
+```

--- a/services/config_validation.py
+++ b/services/config_validation.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from services import guild_config
+
+Severity = Literal["error", "warning", "info"]
+
+ROLE_LABELS: dict[str, str] = {
+    "admin_role_id": "Admin role",
+    "member_role_id": "Member role",
+    "pending_role_id": "Pending role",
+}
+
+CHANNEL_LABELS: dict[str, str] = {
+    "welcome_channel_id": "Welcome channel",
+    "onboarding_channel_id": "Onboarding channel",
+    "broadcast_channel_id": "Broadcast channel",
+    "admin_log_channel_id": "Admin log channel",
+}
+
+CHANNEL_PERMISSION_NAMES: tuple[str, ...] = (
+    "view_channel",
+    "send_messages",
+    "embed_links",
+)
+
+OPTIONAL_PERMISSION_NAMES: tuple[str, ...] = ("manage_roles",)
+
+
+@dataclass(frozen=True)
+class ConfigCheck:
+    """One readiness check result."""
+
+    name: str
+    field: str
+    value: int | str | None
+    ok: bool
+    severity: Severity
+    message: str
+
+
+@dataclass(frozen=True)
+class ConfigIssue:
+    """One failed readiness issue."""
+
+    field: str
+    value: int | str | None
+    message: str
+    severity: Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class ConfigValidationResult:
+    """Structured readiness result for Wilhelmina's configured home guild."""
+
+    checks: tuple[ConfigCheck, ...]
+
+    @property
+    def issues(self) -> tuple[ConfigIssue, ...]:
+        return tuple(
+            ConfigIssue(
+                field=check.field,
+                value=check.value,
+                message=check.message,
+                severity=check.severity,
+            )
+            for check in self.checks
+            if not check.ok and check.severity in {"error", "warning"}
+        )
+
+    @property
+    def ok(self) -> bool:
+        return not any(issue.severity == "error" for issue in self.issues)
+
+    @property
+    def errors(self) -> tuple[ConfigIssue, ...]:
+        return tuple(issue for issue in self.issues if issue.severity == "error")
+
+    @property
+    def warnings(self) -> tuple[ConfigIssue, ...]:
+        return tuple(issue for issue in self.issues if issue.severity == "warning")
+
+
+def _check(
+    *,
+    name: str,
+    field: str,
+    value: int | str | None,
+    ok: bool,
+    message: str,
+    severity: Severity = "error",
+) -> ConfigCheck:
+    return ConfigCheck(
+        name=name,
+        field=field,
+        value=value,
+        ok=ok,
+        severity="info" if ok else severity,
+        message=message,
+    )
+
+
+def _get_role(guild: Any, role_id: int | None) -> Any | None:
+    if guild is None or role_id is None:
+        return None
+
+    get_role = getattr(guild, "get_role", None)
+    if callable(get_role):
+        return get_role(role_id)
+
+    roles = getattr(guild, "roles", ())
+    return next((role for role in roles if getattr(role, "id", None) == role_id), None)
+
+
+def _get_channel(guild: Any, channel_id: int | None) -> Any | None:
+    if guild is None or channel_id is None:
+        return None
+
+    get_channel = getattr(guild, "get_channel", None)
+    if callable(get_channel):
+        return get_channel(channel_id)
+
+    channels = getattr(guild, "channels", ())
+    return next(
+        (channel for channel in channels if getattr(channel, "id", None) == channel_id),
+        None,
+    )
+
+
+def _get_bot_member(guild: Any, bot_user_id: int | None = None) -> Any | None:
+    if guild is None:
+        return None
+
+    guild_me = getattr(guild, "me", None)
+    if guild_me is not None:
+        return guild_me
+
+    if bot_user_id is None:
+        return None
+
+    get_member = getattr(guild, "get_member", None)
+    if callable(get_member):
+        return get_member(bot_user_id)
+
+    return None
+
+
+def _check_permission(channel: Any, member: Any, permission_name: str) -> bool | None:
+    if channel is None or member is None:
+        return None
+
+    permissions_for = getattr(channel, "permissions_for", None)
+    if not callable(permissions_for):
+        return None
+
+    permissions = permissions_for(member)
+    value = getattr(permissions, permission_name, None)
+    if value is None:
+        return None
+
+    return bool(value)
+
+
+def validate_home_guild(
+    *,
+    configured_home_guild_id: int | None,
+    interaction_guild_id: int | None,
+) -> ConfigValidationResult:
+    """Validate that an admin interaction belongs to the configured home guild."""
+
+    checks: list[ConfigCheck] = []
+
+    checks.append(
+        _check(
+            name="Home guild configured",
+            field="HOME_GUILD_ID",
+            value=configured_home_guild_id,
+            ok=configured_home_guild_id is not None,
+            message="HOME_GUILD_ID is configured"
+            if configured_home_guild_id is not None
+            else "HOME_GUILD_ID is not configured",
+        )
+    )
+
+    checks.append(
+        _check(
+            name="Interaction guild available",
+            field="interaction.guild_id",
+            value=interaction_guild_id,
+            ok=interaction_guild_id is not None,
+            message="command is running inside a guild"
+            if interaction_guild_id is not None
+            else "command is not running inside a guild",
+        )
+    )
+
+    if configured_home_guild_id is not None and interaction_guild_id is not None:
+        checks.append(
+            _check(
+                name="Interaction guild matches home guild",
+                field="interaction.guild_id",
+                value=interaction_guild_id,
+                ok=int(configured_home_guild_id) == int(interaction_guild_id),
+                message="command is running in the configured home guild"
+                if int(configured_home_guild_id) == int(interaction_guild_id)
+                else "command is not running in the configured home guild",
+            )
+        )
+
+    return ConfigValidationResult(tuple(checks))
+
+
+def validate_config(
+    *,
+    config: guild_config.GuildConfig | None,
+    guild: Any,
+    configured_home_guild_id: int | None,
+    bot_user_id: int | None = None,
+) -> ConfigValidationResult:
+    """Validate stored guild configuration against the live guild objects."""
+
+    checks: list[ConfigCheck] = []
+
+    actual_guild_id = getattr(guild, "id", None)
+    checks.extend(
+        validate_home_guild(
+            configured_home_guild_id=configured_home_guild_id,
+            interaction_guild_id=actual_guild_id,
+        ).checks
+    )
+
+    if config is None:
+        checks.append(
+            _check(
+                name="Guild config row",
+                field="guild_config",
+                value=None,
+                ok=False,
+                message="no guild_config row has been stored yet",
+            )
+        )
+        return ConfigValidationResult(tuple(checks))
+
+    checks.append(
+        _check(
+            name="Stored guild ID",
+            field="guild_id",
+            value=config.guild_id,
+            ok=configured_home_guild_id is not None
+            and int(config.guild_id) == int(configured_home_guild_id),
+            message="stored guild_id matches HOME_GUILD_ID"
+            if configured_home_guild_id is not None
+            and int(config.guild_id) == int(configured_home_guild_id)
+            else "stored guild_id does not match HOME_GUILD_ID",
+        )
+    )
+
+    for field, label in ROLE_LABELS.items():
+        role_id = getattr(config, field)
+        role = _get_role(guild, role_id)
+        if role_id is None:
+            checks.append(
+                _check(
+                    name=label,
+                    field=field,
+                    value=role_id,
+                    ok=False,
+                    message="role is not configured",
+                )
+            )
+        else:
+            checks.append(
+                _check(
+                    name=label,
+                    field=field,
+                    value=role_id,
+                    ok=role is not None,
+                    message="role exists" if role is not None else "role was not found",
+                )
+            )
+
+    bot_member = _get_bot_member(guild, bot_user_id)
+
+    for field, label in CHANNEL_LABELS.items():
+        channel_id = getattr(config, field)
+        channel = _get_channel(guild, channel_id)
+        if channel_id is None:
+            checks.append(
+                _check(
+                    name=label,
+                    field=field,
+                    value=channel_id,
+                    ok=False,
+                    message="channel is not configured",
+                )
+            )
+            continue
+
+        checks.append(
+            _check(
+                name=label,
+                field=field,
+                value=channel_id,
+                ok=channel is not None,
+                message="channel exists" if channel is not None else "channel was not found",
+            )
+        )
+
+        if channel is None:
+            continue
+
+        for permission_name in CHANNEL_PERMISSION_NAMES:
+            permission_value = _check_permission(channel, bot_member, permission_name)
+            checks.append(
+                _check(
+                    name=f"{label} permission: {permission_name}",
+                    field=f"{field}.{permission_name}",
+                    value=channel_id,
+                    ok=permission_value is True,
+                    severity="warning" if permission_value is None else "error",
+                    message="permission is allowed"
+                    if permission_value is True
+                    else (
+                        "permission could not be inspected"
+                        if permission_value is None
+                        else "permission is missing"
+                    ),
+                )
+            )
+
+        for permission_name in OPTIONAL_PERMISSION_NAMES:
+            permission_value = _check_permission(channel, bot_member, permission_name)
+            checks.append(
+                _check(
+                    name=f"{label} optional permission: {permission_name}",
+                    field=f"{field}.{permission_name}",
+                    value=channel_id,
+                    ok=permission_value is True,
+                    severity="warning",
+                    message="permission is allowed"
+                    if permission_value is True
+                    else (
+                        "permission could not be inspected"
+                        if permission_value is None
+                        else "permission is missing"
+                    ),
+                )
+            )
+
+    try:
+        guild_config.validate_timezone(config.timezone)
+    except guild_config.InvalidGuildConfigValue as exc:
+        checks.append(
+            _check(
+                name="Timezone",
+                field="timezone",
+                value=config.timezone,
+                ok=False,
+                message=str(exc),
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                name="Timezone",
+                field="timezone",
+                value=config.timezone,
+                ok=True,
+                message="timezone is valid",
+            )
+        )
+
+    return ConfigValidationResult(tuple(checks))
+
+
+def format_check_lines(result: ConfigValidationResult) -> list[str]:
+    """Render readiness checks as aligned text lines."""
+
+    lines: list[str] = []
+    for check in result.checks:
+        marker = "OK" if check.ok else ("!!" if check.severity == "error" else "??")
+        value = "unset" if check.value is None else str(check.value)
+        lines.append(f"{marker} {check.name:<44} {value:<24} {check.message}")
+    return lines
+
+
+def format_checklist_lines(result: ConfigValidationResult) -> list[str]:
+    """Render readiness checks as a compact checklist."""
+
+    lines: list[str] = []
+    for check in result.checks:
+        marker = "[x]" if check.ok else ("[!]" if check.severity == "error" else "[?]")
+        lines.append(f"{marker} {check.name}: {check.message}")
+    return lines

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from cogs.admin import Admin
-from services import audit_log, guild_config
+from cogs.admin import Admin, _format_audit_event, _format_readiness_block
+from services import audit_log, config_validation, guild_config
 from services.database import initialize_database, managed_connection
 
 
@@ -19,8 +19,20 @@ class DummyResponse:
 
 
 class DummyPermissions:
-    def __init__(self, administrator):
+    def __init__(
+        self,
+        administrator=True,
+        *,
+        view_channel=True,
+        send_messages=True,
+        embed_links=True,
+        manage_roles=False,
+    ):
         self.administrator = administrator
+        self.view_channel = view_channel
+        self.send_messages = send_messages
+        self.embed_links = embed_links
+        self.manage_roles = manage_roles
 
 
 class DummyUser:
@@ -29,10 +41,49 @@ class DummyUser:
         self.guild_permissions = DummyPermissions(administrator)
 
 
+class DummyRole:
+    def __init__(self, role_id: int, name: str):
+        self.id = role_id
+        self.name = name
+
+
+class DummyMember:
+    id = 4242
+
+
+class DummyChannel:
+    def __init__(self, channel_id: int, name: str, permissions=None):
+        self.id = channel_id
+        self.name = name
+        self._permissions = permissions or DummyPermissions()
+
+    def permissions_for(self, member):
+        return self._permissions
+
+
+class DummyGuild:
+    def __init__(self, *, guild_id=123, roles=(), channels=(), me=None):
+        self.id = guild_id
+        self._roles = {role.id: role for role in roles}
+        self._channels = {channel.id: channel for channel in channels}
+        self.me = me or DummyMember()
+
+    def get_role(self, role_id: int):
+        return self._roles.get(role_id)
+
+    def get_channel(self, channel_id: int):
+        return self._channels.get(channel_id)
+
+    def get_member(self, member_id: int):
+        if member_id == self.me.id:
+            return self.me
+        return None
+
+
 class DummyInteraction:
-    def __init__(self, *, guild_id=123, administrator=True):
+    def __init__(self, *, guild_id=123, administrator=True, guild=None):
         self.guild_id = guild_id
-        self.guild = None
+        self.guild = guild
         self.user = DummyUser(administrator=administrator)
         self.response = DummyResponse()
 
@@ -42,9 +93,39 @@ def make_admin(*, home_guild_id=123, database_path=":memory:"):
         settings=SimpleNamespace(
             home_guild_id=home_guild_id,
             database_path=str(database_path),
-        )
+        ),
+        user=SimpleNamespace(id=4242),
     )
     return Admin(bot)
+
+
+def make_guild() -> DummyGuild:
+    return DummyGuild(
+        guild_id=123,
+        roles=[
+            DummyRole(10, "admin"),
+            DummyRole(11, "member"),
+            DummyRole(12, "pending"),
+        ],
+        channels=[
+            DummyChannel(20, "welcome"),
+            DummyChannel(21, "onboarding"),
+            DummyChannel(22, "broadcast"),
+            DummyChannel(23, "admin-log"),
+        ],
+    )
+
+
+def seed_complete_config(database_path):
+    initialize_database(database_path)
+    with managed_connection(database_path) as connection:
+        guild_config.set_role(connection, 123, "admin_role_id", 10)
+        guild_config.set_role(connection, 123, "member_role_id", 11)
+        guild_config.set_role(connection, 123, "pending_role_id", 12)
+        guild_config.set_channel(connection, 123, "welcome_channel_id", 20)
+        guild_config.set_channel(connection, 123, "onboarding_channel_id", 21)
+        guild_config.set_channel(connection, 123, "broadcast_channel_id", 22)
+        guild_config.set_channel(connection, 123, "admin_log_channel_id", 23)
 
 
 def test_admin_group_declares_admin_permissions_at_class_level():
@@ -113,6 +194,17 @@ async def test_reject_non_admin_allows_admin():
     assert interaction.response.messages == []
 
 
+@pytest.mark.asyncio
+async def test_guard_admin_home_guild_combines_admin_and_guild_checks():
+    admin = make_admin(home_guild_id=123)
+    interaction = DummyInteraction(guild_id=999, administrator=True)
+
+    resolved = await admin._guard_admin_home_guild(interaction)
+
+    assert resolved is None
+    assert "home guild" in interaction.response.messages[0][0]
+
+
 def test_admin_config_audit_writer_records_event(tmp_path):
     database_path = tmp_path / "wilhelmina.sqlite3"
     admin = make_admin(home_guild_id=123, database_path=database_path)
@@ -141,3 +233,55 @@ def test_admin_config_audit_writer_records_event(tmp_path):
     assert events[0].action == "guild_config.set_timezone"
     assert events[0].target == "timezone"
     assert audit_log.deserialize_payload(events[0].after_json)["guild_id"] == 123
+
+
+def test_build_readiness_result_uses_stored_config_and_guild_objects(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    seed_complete_config(database_path)
+    admin = make_admin(home_guild_id=123, database_path=database_path)
+    interaction = DummyInteraction(guild_id=123, guild=make_guild())
+
+    result = admin._build_readiness_result(interaction, 123)
+
+    assert result.ok is True
+    assert any(check.field == "admin_role_id" for check in result.checks)
+    assert any(check.field == "welcome_channel_id.send_messages" for check in result.checks)
+
+
+def test_readiness_block_formats_status_and_checklist():
+    result = config_validation.ConfigValidationResult(
+        (
+            config_validation.ConfigCheck(
+                name="Example",
+                field="example",
+                value=None,
+                ok=False,
+                severity="error",
+                message="missing",
+            ),
+        )
+    )
+
+    status = _format_readiness_block("Status", result)
+    checklist = _format_readiness_block("Checklist", result, checklist=True)
+
+    assert "overall_ok = false" in status
+    assert "[!] Example: missing" in checklist
+
+
+def test_format_audit_event_is_compact():
+    event = audit_log.AuditEvent(
+        id=1,
+        guild_id=123,
+        actor_user_id=9001,
+        action="guild_config.set_role",
+        target="admin_role_id",
+        before_json=None,
+        after_json=None,
+        created_at="2026-05-20T00:00:00+00:00",
+    )
+
+    assert _format_audit_event(event) == (
+        "#1 2026-05-20T00:00:00+00:00 "
+        "actor=9001 action=guild_config.set_role target=admin_role_id"
+    )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from services import config_validation, guild_config
+
+
+class DummyRole:
+    def __init__(self, role_id: int):
+        self.id = role_id
+
+
+class DummyPermissions:
+    def __init__(
+        self,
+        *,
+        view_channel=True,
+        send_messages=True,
+        embed_links=True,
+        manage_roles=False,
+    ):
+        self.view_channel = view_channel
+        self.send_messages = send_messages
+        self.embed_links = embed_links
+        self.manage_roles = manage_roles
+
+
+class DummyMember:
+    id = 42
+
+
+class DummyChannel:
+    def __init__(self, channel_id: int, permissions: DummyPermissions | None = None):
+        self.id = channel_id
+        self._permissions = permissions or DummyPermissions()
+
+    def permissions_for(self, member):
+        return self._permissions
+
+
+class DummyGuild:
+    def __init__(self, *, guild_id=123, roles=(), channels=(), me=None):
+        self.id = guild_id
+        self._roles = {role.id: role for role in roles}
+        self._channels = {channel.id: channel for channel in channels}
+        self.me = me or DummyMember()
+
+    def get_role(self, role_id: int):
+        return self._roles.get(role_id)
+
+    def get_channel(self, channel_id: int):
+        return self._channels.get(channel_id)
+
+    def get_member(self, member_id: int):
+        if member_id == self.me.id:
+            return self.me
+        return None
+
+
+def make_config() -> guild_config.GuildConfig:
+    return guild_config.GuildConfig(
+        guild_id=123,
+        admin_role_id=10,
+        member_role_id=11,
+        pending_role_id=12,
+        welcome_channel_id=20,
+        onboarding_channel_id=21,
+        broadcast_channel_id=22,
+        admin_log_channel_id=23,
+        timezone="UTC",
+        created_at="2026-05-20T00:00:00+00:00",
+        updated_at="2026-05-20T00:00:00+00:00",
+    )
+
+
+def make_guild() -> DummyGuild:
+    return DummyGuild(
+        guild_id=123,
+        roles=[DummyRole(10), DummyRole(11), DummyRole(12)],
+        channels=[
+            DummyChannel(20),
+            DummyChannel(21),
+            DummyChannel(22),
+            DummyChannel(23),
+        ],
+    )
+
+
+def test_validate_home_guild_accepts_matching_guild():
+    result = config_validation.validate_home_guild(
+        configured_home_guild_id=123,
+        interaction_guild_id=123,
+    )
+
+    assert result.ok is True
+    assert not result.errors
+
+
+def test_validate_config_accepts_complete_config():
+    result = config_validation.validate_config(
+        config=make_config(),
+        guild=make_guild(),
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is True
+    assert not result.errors
+    assert config_validation.format_checklist_lines(result)
+
+
+def test_validate_config_reports_missing_role():
+    guild = make_guild()
+    guild._roles.pop(11)
+
+    result = config_validation.validate_config(
+        config=make_config(),
+        guild=guild,
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is False
+    assert any(issue.field == "member_role_id" for issue in result.errors)
+
+
+def test_validate_config_reports_missing_channel():
+    guild = make_guild()
+    guild._channels.pop(22)
+
+    result = config_validation.validate_config(
+        config=make_config(),
+        guild=guild,
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is False
+    assert any(issue.field == "broadcast_channel_id" for issue in result.errors)
+
+
+def test_validate_config_reports_missing_send_permission():
+    guild = make_guild()
+    guild._channels[20] = DummyChannel(
+        20,
+        DummyPermissions(send_messages=False),
+    )
+
+    result = config_validation.validate_config(
+        config=make_config(),
+        guild=guild,
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is False
+    assert any(
+        issue.field == "welcome_channel_id.send_messages"
+        for issue in result.errors
+    )
+
+
+def test_validate_config_treats_manage_roles_as_warning():
+    guild = make_guild()
+
+    result = config_validation.validate_config(
+        config=make_config(),
+        guild=guild,
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is True
+    assert any(
+        issue.field == "welcome_channel_id.manage_roles"
+        for issue in result.warnings
+    )
+
+
+def test_validate_config_reports_missing_config_row():
+    result = config_validation.validate_config(
+        config=None,
+        guild=make_guild(),
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is False
+    assert any(issue.field == "guild_config" for issue in result.errors)
+
+
+def test_validate_config_reports_bad_timezone():
+    config = replace(make_config(), timezone="Not/AZone")
+
+    result = config_validation.validate_config(
+        config=config,
+        guild=make_guild(),
+        configured_home_guild_id=123,
+        bot_user_id=42,
+    )
+
+    assert result.ok is False
+    assert any(issue.field == "timezone" for issue in result.errors)


### PR DESCRIPTION
## Summary

Adds Phase 3 operational readiness inspection for Wilhelmina.

Implemented:

- `services/config_validation.py`
- `/admin setup status`
- `/admin setup checklist`
- `/admin permissions`
- `/admin logs recent`
- home-guild guard reuse across admin commands
- deterministic readiness tests using dummy Discord objects
- ADR 0004 documenting report-only operational readiness

## Boundaries

This PR is inspection/reporting only.

It does not add:

- role creation
- channel creation
- role assignment
- automatic permission edits
- onboarding state
- scheduling
- memory
- server takeover/transformation
- Oracle/persona architecture

## Validation

Expected CI gates:

- `ruff check .`
- `pytest`

## Notes

README update was intentionally left minimal/out of this PR after connector filtering blocked the full replacement payload. ADR 0004 carries the Phase 3 design boundary.