### PR TITLE
Add Phase 4 onboarding state foundation

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -8,6 +8,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from services import audit_log, config_validation, guild_config
+from services import onboarding as onboarding_service
 from services.database import initialize_database, managed_connection
 
 ROLE_FIELD_CHOICES = [
@@ -23,6 +24,12 @@ CHANNEL_FIELD_CHOICES = [
 ]
 CLEAR_FIELD_CHOICES = ROLE_FIELD_CHOICES + CHANNEL_FIELD_CHOICES + [
     app_commands.Choice(name="timezone", value="timezone"),
+]
+ONBOARDING_STATE_CHOICES = [
+    app_commands.Choice(name="pending", value="pending"),
+    app_commands.Choice(name="approved", value="approved"),
+    app_commands.Choice(name="rejected", value="rejected"),
+    app_commands.Choice(name="completed", value="completed"),
 ]
 
 ROLE_FIELD_ORDER = ("admin_role_id", "member_role_id", "pending_role_id")
@@ -96,6 +103,46 @@ def _format_audit_event(event: audit_log.AuditEvent) -> str:
     )
 
 
+def _format_onboarding_record(record: onboarding_service.OnboardingRecord | None) -> str:
+    if record is None:
+        return "No onboarding record exists for that user."
+
+    lines = [
+        "```txt",
+        f"guild_id     = {record.guild_id}",
+        f"user_id      = {record.user_id}",
+        f"state        = {record.state}",
+        f"started_at   = {record.started_at}",
+        f"completed_at = {_format_config_value(record.completed_at)}",
+        f"approved_by  = {_format_config_value(record.approved_by)}",
+        f"rejected_by  = {_format_config_value(record.rejected_by)}",
+        f"notes        = {_format_config_value(record.notes)}",
+        f"created_at   = {record.created_at}",
+        f"updated_at   = {record.updated_at}",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def _format_onboarding_rows(records: list[onboarding_service.OnboardingRecord]) -> str:
+    if not records:
+        return "No onboarding records found."
+
+    lines = ["```txt"]
+    for record in records:
+        notes = f" notes={record.notes}" if record.notes else ""
+        lines.append(
+            f"user={record.user_id} state={record.state} "
+            f"updated={record.updated_at}{notes}"
+        )
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _format_user_label(user: discord.User | discord.Member) -> str:
+    return getattr(user, "mention", f"`{user.id}`")
+
+
 @app_commands.guild_only()
 @app_commands.default_permissions(administrator=True)
 class Admin(commands.GroupCog, group_name="admin"):
@@ -112,6 +159,10 @@ class Admin(commands.GroupCog, group_name="admin"):
     logs = app_commands.Group(
         name="logs",
         description="Inspect Wilhelmina's administrative audit log.",
+    )
+    onboarding = app_commands.Group(
+        name="onboarding",
+        description="Inspect and manually update onboarding state.",
     )
 
     def __init__(self, bot: commands.Bot):
@@ -170,6 +221,13 @@ class Admin(commands.GroupCog, group_name="admin"):
         error: Exception,
     ) -> None:
         await interaction.response.send_message(f"Config error: {error}", ephemeral=True)
+
+    async def _send_onboarding_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+    ) -> None:
+        await interaction.response.send_message(f"Onboarding error: {error}", ephemeral=True)
 
     def _record_config_audit(
         self,
@@ -373,6 +431,230 @@ class Admin(commands.GroupCog, group_name="admin"):
         lines.extend(_format_audit_event(event) for event in events)
         lines.append("```")
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+    @onboarding.command(name="view", description="View one user's onboarding state.")
+    @app_commands.describe(user="User to inspect.")
+    async def onboarding_view(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            record = onboarding_service.get_onboarding_record(connection, guild_id, user.id)
+
+        await interaction.response.send_message(
+            f"**Onboarding state for {_format_user_label(user)}**\n{_format_onboarding_record(record)}",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="list", description="List recent onboarding records.")
+    @app_commands.describe(
+        state="Optional state filter.",
+        limit="Number of rows to show. Range: 1-25.",
+    )
+    @app_commands.choices(state=ONBOARDING_STATE_CHOICES)
+    async def onboarding_list(
+        self,
+        interaction: discord.Interaction,
+        state: str | None = None,
+        limit: app_commands.Range[int, 1, 25] = 10,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                records = onboarding_service.list_onboarding_records(
+                    connection,
+                    guild_id,
+                    state=state,
+                    limit=limit,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        label = f" state={state}" if state else ""
+        await interaction.response.send_message(
+            f"**Recent onboarding records{label}**\n{_format_onboarding_rows(records)}",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="start", description="Start or reset onboarding for one user.")
+    @app_commands.describe(user="User to start onboarding for.", notes="Optional admin notes.")
+    async def onboarding_start(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        notes: str | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                _, after = onboarding_service.start_onboarding(
+                    connection,
+                    guild_id,
+                    user.id,
+                    actor_user_id=interaction.user.id,
+                    notes=notes,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        await interaction.response.send_message(
+            f"Started onboarding for {_format_user_label(user)} as `{after.state}`.",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="approve", description="Approve one user's onboarding state.")
+    @app_commands.describe(user="User to approve.", notes="Optional admin notes.")
+    async def onboarding_approve(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        notes: str | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                _, after = onboarding_service.approve_onboarding(
+                    connection,
+                    guild_id,
+                    user.id,
+                    actor_user_id=interaction.user.id,
+                    notes=notes,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        await interaction.response.send_message(
+            f"Approved onboarding for {_format_user_label(user)} as `{after.state}`.",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="reject", description="Reject one user's onboarding state.")
+    @app_commands.describe(user="User to reject.", notes="Optional admin notes.")
+    async def onboarding_reject(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        notes: str | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                _, after = onboarding_service.reject_onboarding(
+                    connection,
+                    guild_id,
+                    user.id,
+                    actor_user_id=interaction.user.id,
+                    notes=notes,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        await interaction.response.send_message(
+            f"Rejected onboarding for {_format_user_label(user)} as `{after.state}`.",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="complete", description="Complete one approved onboarding state.")
+    @app_commands.describe(user="User to complete.", notes="Optional admin notes.")
+    async def onboarding_complete(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        notes: str | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                _, after = onboarding_service.complete_onboarding(
+                    connection,
+                    guild_id,
+                    user.id,
+                    actor_user_id=interaction.user.id,
+                    notes=notes,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        await interaction.response.send_message(
+            f"Completed onboarding for {_format_user_label(user)} as `{after.state}`.",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="override", description="Force-set one user's onboarding state.")
+    @app_commands.describe(
+        user="User to update.",
+        state="State to force-set.",
+        notes="Optional admin notes.",
+    )
+    @app_commands.choices(state=ONBOARDING_STATE_CHOICES)
+    async def onboarding_override(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        state: str,
+        notes: str | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                _, after = onboarding_service.override_state(
+                    connection,
+                    guild_id,
+                    user.id,
+                    state=state,
+                    actor_user_id=interaction.user.id,
+                    notes=notes,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        await interaction.response.send_message(
+            f"Overrode onboarding for {_format_user_label(user)} as `{after.state}`.",
+            ephemeral=True,
+        )
 
     @config.command(name="view", description="View Wilhelmina's stored guild configuration.")
     async def config_view(self, interaction: discord.Interaction) -> None:

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -139,6 +139,30 @@ def _format_onboarding_rows(records: list[onboarding_service.OnboardingRecord]) 
     return "\n".join(lines)
 
 
+def _format_onboarding_summary(summary: onboarding_service.OnboardingSummary) -> str:
+    lines = [
+        "```txt",
+        f"guild_id  = {summary.guild_id}",
+        f"total     = {summary.total}",
+        f"pending   = {summary.pending}",
+        f"approved  = {summary.approved}",
+        f"rejected  = {summary.rejected}",
+        f"completed = {summary.completed}",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def _format_onboarding_history(events: list[audit_log.AuditEvent]) -> str:
+    if not events:
+        return "No onboarding history found for that user."
+
+    lines = ["```txt"]
+    lines.extend(_format_audit_event(event) for event in events)
+    lines.append("```")
+    return "\n".join(lines)
+
+
 def _format_user_label(user: discord.User | discord.Member) -> str:
     return getattr(user, "mention", f"`{user.id}`")
 
@@ -432,6 +456,22 @@ class Admin(commands.GroupCog, group_name="admin"):
         lines.append("```")
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
+    @onboarding.command(name="summary", description="Show onboarding state counts.")
+    async def onboarding_summary(self, interaction: discord.Interaction) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            summary = onboarding_service.summarize_onboarding(connection, guild_id)
+
+        await interaction.response.send_message(
+            f"**Onboarding summary**\n{_format_onboarding_summary(summary)}",
+            ephemeral=True,
+        )
+
     @onboarding.command(name="view", description="View one user's onboarding state.")
     @app_commands.describe(user="User to inspect.")
     async def onboarding_view(
@@ -450,6 +490,36 @@ class Admin(commands.GroupCog, group_name="admin"):
 
         await interaction.response.send_message(
             f"**Onboarding state for {_format_user_label(user)}**\n{_format_onboarding_record(record)}",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="history", description="Show one user's onboarding audit history.")
+    @app_commands.describe(
+        user="User to inspect.",
+        limit="Number of audit events to show. Range: 1-25.",
+    )
+    async def onboarding_history(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        limit: app_commands.Range[int, 1, 25] = 10,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            events = onboarding_service.list_onboarding_history(
+                connection,
+                guild_id,
+                user.id,
+                limit=limit,
+            )
+
+        await interaction.response.send_message(
+            f"**Onboarding history for {_format_user_label(user)}**\n{_format_onboarding_history(events)}",
             ephemeral=True,
         )
 
@@ -614,6 +684,42 @@ class Admin(commands.GroupCog, group_name="admin"):
 
         await interaction.response.send_message(
             f"Completed onboarding for {_format_user_label(user)} as `{after.state}`.",
+            ephemeral=True,
+        )
+
+    @onboarding.command(name="notes", description="Update or clear one user's onboarding notes.")
+    @app_commands.describe(
+        user="User to update.",
+        notes="New notes. Leave empty to clear existing notes.",
+    )
+    async def onboarding_notes(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+        notes: str | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                _, after = onboarding_service.update_notes(
+                    connection,
+                    guild_id,
+                    user.id,
+                    actor_user_id=interaction.user.id,
+                    notes=notes,
+                )
+        except onboarding_service.OnboardingError as exc:
+            await self._send_onboarding_error(interaction, exc)
+            return
+
+        detail = "cleared" if after.notes is None else "updated"
+        await interaction.response.send_message(
+            f"{detail.capitalize()} onboarding notes for {_format_user_label(user)}.",
             ephemeral=True,
         )
 

--- a/docs/adr/0005-onboarding-state.md
+++ b/docs/adr/0005-onboarding-state.md
@@ -10,7 +10,7 @@ Accepted
 
 Wilhelmina has dedicated-server runtime, persistent guild configuration, audit logging, and operational readiness inspection. The next safe step is to track onboarding state before any role automation, welcome flow, or rules acknowledgement workflow exists.
 
-Administrators need to inspect and manually correct onboarding state without the bot mutating Discord roles or channels.
+Administrators need to inspect, summarize, audit, and manually correct onboarding state without the bot changing Discord roles or channels.
 
 ## Decision
 
@@ -20,15 +20,33 @@ Add a SQLite-backed `onboarding_state` table and a service boundary:
 services/onboarding.py
 ```
 
+The service owns deterministic onboarding state transitions and read models:
+
+```txt
+start_onboarding
+approve_onboarding
+reject_onboarding
+complete_onboarding
+override_state
+update_notes
+get_onboarding_record
+list_onboarding_records
+summarize_onboarding
+list_onboarding_history
+```
+
 Add admin-only commands under:
 
 ```txt
+/admin onboarding summary
 /admin onboarding view
+/admin onboarding history
 /admin onboarding list
 /admin onboarding start
 /admin onboarding approve
 /admin onboarding reject
 /admin onboarding complete
+/admin onboarding notes
 /admin onboarding override
 ```
 
@@ -41,32 +59,22 @@ rejected
 completed
 ```
 
-All state changes are auditable through the existing `audit_log` table.
+All state changes and note updates are auditable through the existing `audit_log` table. Per-user onboarding history is read from audit events targeting that user's ID.
 
 ## Boundaries
 
-This phase records state only.
+This phase records and reports state only.
 
-It does not add:
-
-```txt
-role assignment
-role removal
-channel creation
-channel permission changes
-welcome messages
-rules acknowledgement UI
-scheduled jobs
-memory
-server takeover
-server transformation
-```
+It does not add role assignment, role removal, channel creation, permission edits, welcome messages, rules acknowledgement UI, scheduled jobs, memory, or server transformation workflows.
 
 ## Consequences
 
 Positive:
 
 - Onboarding state is durable and inspectable.
+- Admins can summarize onboarding load by state.
+- Admins can view a user's onboarding history.
+- Admins can update or clear notes without changing state.
 - Admins can manually override mistakes.
 - Future role automation has a deterministic state ledger to consume.
 - Audit rows show who changed onboarding state and when.
@@ -79,10 +87,8 @@ Tradeoffs:
 
 ## Migration notes
 
-Schema version advances to 2 and adds:
+Schema version advances to 2 and adds `onboarding_state`.
 
-```sql
-CREATE TABLE IF NOT EXISTS onboarding_state (...)
-```
+No additional schema change is required for summary, notes update, or history. Summary reads from `onboarding_state`; history reads from `audit_log` by target user ID.
 
 Existing SQLite databases are initialized idempotently. Deployment should still back up `DATABASE_PATH` before upgrading.

--- a/docs/adr/0005-onboarding-state.md
+++ b/docs/adr/0005-onboarding-state.md
@@ -1,0 +1,88 @@
+# ADR 0005: Onboarding state foundation
+
+Date: 2026-05-21
+
+## Status
+
+Accepted
+
+## Context
+
+Wilhelmina has dedicated-server runtime, persistent guild configuration, audit logging, and operational readiness inspection. The next safe step is to track onboarding state before any role automation, welcome flow, or rules acknowledgement workflow exists.
+
+Administrators need to inspect and manually correct onboarding state without the bot mutating Discord roles or channels.
+
+## Decision
+
+Add a SQLite-backed `onboarding_state` table and a service boundary:
+
+```txt
+services/onboarding.py
+```
+
+Add admin-only commands under:
+
+```txt
+/admin onboarding view
+/admin onboarding list
+/admin onboarding start
+/admin onboarding approve
+/admin onboarding reject
+/admin onboarding complete
+/admin onboarding override
+```
+
+State values are:
+
+```txt
+pending
+approved
+rejected
+completed
+```
+
+All state changes are auditable through the existing `audit_log` table.
+
+## Boundaries
+
+This phase records state only.
+
+It does not add:
+
+```txt
+role assignment
+role removal
+channel creation
+channel permission changes
+welcome messages
+rules acknowledgement UI
+scheduled jobs
+memory
+server takeover
+server transformation
+```
+
+## Consequences
+
+Positive:
+
+- Onboarding state is durable and inspectable.
+- Admins can manually override mistakes.
+- Future role automation has a deterministic state ledger to consume.
+- Audit rows show who changed onboarding state and when.
+
+Tradeoffs:
+
+- The bot does not yet move users between pending/member roles.
+- The bot does not yet greet users or collect rules acknowledgement.
+- Human admins remain responsible for acting on the state until later phases.
+
+## Migration notes
+
+Schema version advances to 2 and adds:
+
+```sql
+CREATE TABLE IF NOT EXISTS onboarding_state (...)
+```
+
+Existing SQLite databases are initialized idempotently. Deployment should still back up `DATABASE_PATH` before upgrading.

--- a/services/audit_log.py
+++ b/services/audit_log.py
@@ -118,3 +118,27 @@ def list_audit_events(
     ).fetchall()
 
     return [_row_to_event(row) for row in rows]
+
+
+def list_audit_events_for_target(
+    connection: sqlite3.Connection,
+    guild_id: int,
+    target: str | int,
+    *,
+    limit: int = 10,
+) -> list[AuditEvent]:
+    """Return recent audit events for one guild and target."""
+
+    bounded_limit = max(1, min(int(limit), 100))
+    rows = connection.execute(
+        """
+        SELECT *
+        FROM audit_log
+        WHERE guild_id = ? AND target = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+        """,
+        (int(guild_id), str(target), bounded_limit),
+    ).fetchall()
+
+    return [_row_to_event(row) for row in rows]

--- a/services/database.py
+++ b/services/database.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-CURRENT_SCHEMA_VERSION = 1
+CURRENT_SCHEMA_VERSION = 2
 DEFAULT_DATABASE_PATH = Path("data/wilhelmina.sqlite3")
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
@@ -46,6 +46,25 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE INDEX IF NOT EXISTS idx_audit_log_guild_created
     ON audit_log (guild_id, created_at DESC)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS onboarding_state (
+        guild_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL,
+        state TEXT NOT NULL,
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        approved_by INTEGER,
+        rejected_by INTEGER,
+        notes TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (guild_id, user_id)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_onboarding_state_guild_state
+    ON onboarding_state (guild_id, state, updated_at DESC)
     """,
 )
 

--- a/services/onboarding.py
+++ b/services/onboarding.py
@@ -46,6 +46,16 @@ class OnboardingRecord:
     updated_at: str
 
 
+@dataclass(frozen=True)
+class OnboardingSummary:
+    guild_id: int
+    total: int
+    pending: int
+    approved: int
+    rejected: int
+    completed: int
+
+
 def _validate_state(state: str) -> OnboardingStateValue:
     normalized = (state or "").strip().lower()
     if normalized not in VALID_STATES:
@@ -181,6 +191,57 @@ def list_onboarding_records(
         ).fetchall()
 
     return [_row_to_record(row) for row in rows if row is not None]
+
+
+def summarize_onboarding(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+) -> OnboardingSummary:
+    """Count onboarding records by state for one guild."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    counts = {state: 0 for state in VALID_STATES}
+    rows = connection.execute(
+        """
+        SELECT state, COUNT(*) AS count
+        FROM onboarding_state
+        WHERE guild_id = ?
+        GROUP BY state
+        """,
+        (normalized_guild_id,),
+    ).fetchall()
+
+    for row in rows:
+        state = _validate_state(str(row["state"]))
+        counts[state] = int(row["count"])
+
+    return OnboardingSummary(
+        guild_id=normalized_guild_id,
+        total=sum(counts.values()),
+        pending=counts[PENDING],
+        approved=counts[APPROVED],
+        rejected=counts[REJECTED],
+        completed=counts[COMPLETED],
+    )
+
+
+def list_onboarding_history(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    limit: int = 10,
+) -> list[audit_log.AuditEvent]:
+    """Return recent audit events for one user's onboarding record."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    normalized_user_id = validate_snowflake(user_id, "user_id")
+    return audit_log.list_audit_events_for_target(
+        connection,
+        normalized_guild_id,
+        normalized_user_id,
+        limit=limit,
+    )
 
 
 def _apply_state_fields(
@@ -328,6 +389,41 @@ def start_onboarding(
         guild_id=normalized_guild_id,
         actor_user_id=normalized_actor_id,
         action="onboarding.start",
+        target_user_id=normalized_user_id,
+        before=before,
+        after=after,
+    )
+    return before, after
+
+
+def update_notes(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    actor_user_id: int | str,
+    notes: str | None,
+) -> tuple[OnboardingRecord, OnboardingRecord]:
+    """Update admin notes for an existing onboarding record without changing state."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    normalized_user_id = validate_snowflake(user_id, "user_id")
+    normalized_actor_id = validate_snowflake(actor_user_id, "actor_user_id")
+    before = get_onboarding_record(connection, normalized_guild_id, normalized_user_id)
+    if before is None:
+        raise InvalidOnboardingTransition("onboarding has not been started for this user")
+
+    after = _update_existing_record(
+        connection,
+        guild_id=normalized_guild_id,
+        user_id=normalized_user_id,
+        fields={"notes": _validate_notes(notes), "updated_at": utc_now_iso()},
+    )
+    _record_audit(
+        connection,
+        guild_id=normalized_guild_id,
+        actor_user_id=normalized_actor_id,
+        action="onboarding.update_notes",
         target_user_id=normalized_user_id,
         before=before,
         after=after,

--- a/services/onboarding.py
+++ b/services/onboarding.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+from services import audit_log
+from services.database import utc_now_iso
+from services.guild_config import validate_snowflake
+
+OnboardingStateValue = Literal["pending", "approved", "rejected", "completed"]
+
+PENDING: OnboardingStateValue = "pending"
+APPROVED: OnboardingStateValue = "approved"
+REJECTED: OnboardingStateValue = "rejected"
+COMPLETED: OnboardingStateValue = "completed"
+
+VALID_STATES: frozenset[str] = frozenset({PENDING, APPROVED, REJECTED, COMPLETED})
+TERMINAL_STATES: frozenset[str] = frozenset({REJECTED, COMPLETED})
+MAX_NOTES_LENGTH = 1000
+
+
+class OnboardingError(ValueError):
+    """Base exception for invalid onboarding operations."""
+
+
+class InvalidOnboardingState(OnboardingError):
+    """Raised when an unknown onboarding state is requested."""
+
+
+class InvalidOnboardingTransition(OnboardingError):
+    """Raised when a state transition is not allowed."""
+
+
+@dataclass(frozen=True)
+class OnboardingRecord:
+    guild_id: int
+    user_id: int
+    state: OnboardingStateValue
+    started_at: str
+    completed_at: str | None
+    approved_by: int | None
+    rejected_by: int | None
+    notes: str | None
+    created_at: str
+    updated_at: str
+
+
+def _validate_state(state: str) -> OnboardingStateValue:
+    normalized = (state or "").strip().lower()
+    if normalized not in VALID_STATES:
+        allowed = ", ".join(sorted(VALID_STATES))
+        raise InvalidOnboardingState(f"Unknown onboarding state {state!r}. Allowed: {allowed}")
+    return normalized  # type: ignore[return-value]
+
+
+def _validate_notes(notes: str | None) -> str | None:
+    if notes is None:
+        return None
+
+    normalized = notes.strip()
+    if not normalized:
+        return None
+
+    if len(normalized) > MAX_NOTES_LENGTH:
+        raise OnboardingError(f"notes must be {MAX_NOTES_LENGTH} characters or fewer")
+
+    return normalized
+
+
+def _row_to_record(row: sqlite3.Row | None) -> OnboardingRecord | None:
+    if row is None:
+        return None
+
+    return OnboardingRecord(
+        guild_id=int(row["guild_id"]),
+        user_id=int(row["user_id"]),
+        state=_validate_state(str(row["state"])),
+        started_at=str(row["started_at"]),
+        completed_at=row["completed_at"],
+        approved_by=row["approved_by"],
+        rejected_by=row["rejected_by"],
+        notes=row["notes"],
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def record_to_dict(record: OnboardingRecord) -> dict[str, int | str | None]:
+    """Serialize an onboarding record for display or audit snapshots."""
+
+    return asdict(record)
+
+
+def record_to_audit_dict(record: OnboardingRecord | None) -> dict[str, int | str | None] | None:
+    """Serialize a nullable onboarding record for audit snapshots."""
+
+    if record is None:
+        return None
+    return record_to_dict(record)
+
+
+def _record_audit(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    actor_user_id: int | None,
+    action: str,
+    target_user_id: int,
+    before: OnboardingRecord | None,
+    after: OnboardingRecord | None,
+) -> None:
+    if actor_user_id is None:
+        return
+
+    audit_log.record_audit_event(
+        connection,
+        guild_id=guild_id,
+        actor_user_id=actor_user_id,
+        action=action,
+        target=str(target_user_id),
+        before=record_to_audit_dict(before),
+        after=record_to_audit_dict(after),
+    )
+
+
+def get_onboarding_record(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+) -> OnboardingRecord | None:
+    """Fetch one onboarding record by guild and user."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    normalized_user_id = validate_snowflake(user_id, "user_id")
+    row = connection.execute(
+        """
+        SELECT *
+        FROM onboarding_state
+        WHERE guild_id = ? AND user_id = ?
+        """,
+        (normalized_guild_id, normalized_user_id),
+    ).fetchone()
+    return _row_to_record(row)
+
+
+def list_onboarding_records(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    *,
+    state: str | None = None,
+    limit: int = 25,
+) -> list[OnboardingRecord]:
+    """List recent onboarding records for a guild, optionally filtered by state."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    bounded_limit = max(1, min(int(limit), 100))
+
+    if state is None:
+        rows = connection.execute(
+            """
+            SELECT *
+            FROM onboarding_state
+            WHERE guild_id = ?
+            ORDER BY updated_at DESC, user_id ASC
+            LIMIT ?
+            """,
+            (normalized_guild_id, bounded_limit),
+        ).fetchall()
+    else:
+        normalized_state = _validate_state(state)
+        rows = connection.execute(
+            """
+            SELECT *
+            FROM onboarding_state
+            WHERE guild_id = ? AND state = ?
+            ORDER BY updated_at DESC, user_id ASC
+            LIMIT ?
+            """,
+            (normalized_guild_id, normalized_state, bounded_limit),
+        ).fetchall()
+
+    return [_row_to_record(row) for row in rows if row is not None]
+
+
+def _apply_state_fields(
+    *,
+    state: OnboardingStateValue,
+    actor_user_id: int | None,
+    notes: str | None,
+    now: str,
+) -> dict[str, int | str | None]:
+    fields: dict[str, int | str | None] = {
+        "state": state,
+        "updated_at": now,
+        "notes": _validate_notes(notes),
+    }
+
+    if state == PENDING:
+        fields.update(
+            {
+                "completed_at": None,
+                "approved_by": None,
+                "rejected_by": None,
+            }
+        )
+    elif state == APPROVED:
+        fields.update(
+            {
+                "completed_at": None,
+                "approved_by": actor_user_id,
+                "rejected_by": None,
+            }
+        )
+    elif state == REJECTED:
+        fields.update(
+            {
+                "completed_at": None,
+                "approved_by": None,
+                "rejected_by": actor_user_id,
+            }
+        )
+    elif state == COMPLETED:
+        fields.update(
+            {
+                "completed_at": now,
+                "rejected_by": None,
+            }
+        )
+
+    return fields
+
+
+def _update_existing_record(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    fields: dict[str, int | str | None],
+) -> OnboardingRecord:
+    assignments = ", ".join([f"{field} = ?" for field in fields])
+    values = list(fields.values())
+    values.extend([guild_id, user_id])
+    connection.execute(
+        f"""
+        UPDATE onboarding_state
+        SET {assignments}
+        WHERE guild_id = ? AND user_id = ?
+        """,
+        values,
+    )
+
+    updated = get_onboarding_record(connection, guild_id, user_id)
+    if updated is None:
+        raise RuntimeError("Failed to update onboarding_state row")
+    return updated
+
+
+def start_onboarding(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    actor_user_id: int | str | None = None,
+    notes: str | None = None,
+) -> tuple[OnboardingRecord | None, OnboardingRecord]:
+    """Create or reset a user to pending onboarding."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    normalized_user_id = validate_snowflake(user_id, "user_id")
+    normalized_actor_id = (
+        validate_snowflake(actor_user_id, "actor_user_id")
+        if actor_user_id is not None
+        else None
+    )
+    normalized_notes = _validate_notes(notes)
+    before = get_onboarding_record(connection, normalized_guild_id, normalized_user_id)
+    now = utc_now_iso()
+
+    if before is None:
+        connection.execute(
+            """
+            INSERT INTO onboarding_state (
+                guild_id,
+                user_id,
+                state,
+                started_at,
+                completed_at,
+                approved_by,
+                rejected_by,
+                notes,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)
+            """,
+            (
+                normalized_guild_id,
+                normalized_user_id,
+                PENDING,
+                now,
+                normalized_notes,
+                now,
+                now,
+            ),
+        )
+    else:
+        fields = _apply_state_fields(
+            state=PENDING,
+            actor_user_id=normalized_actor_id,
+            notes=normalized_notes,
+            now=now,
+        )
+        fields["started_at"] = now
+        _update_existing_record(
+            connection,
+            guild_id=normalized_guild_id,
+            user_id=normalized_user_id,
+            fields=fields,
+        )
+
+    after = get_onboarding_record(connection, normalized_guild_id, normalized_user_id)
+    if after is None:
+        raise RuntimeError("Failed to create onboarding_state row")
+
+    _record_audit(
+        connection,
+        guild_id=normalized_guild_id,
+        actor_user_id=normalized_actor_id,
+        action="onboarding.start",
+        target_user_id=normalized_user_id,
+        before=before,
+        after=after,
+    )
+    return before, after
+
+
+def _transition(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    new_state: OnboardingStateValue,
+    actor_user_id: int | str | None,
+    notes: str | None,
+    action: str,
+) -> tuple[OnboardingRecord, OnboardingRecord]:
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    normalized_user_id = validate_snowflake(user_id, "user_id")
+    normalized_actor_id = (
+        validate_snowflake(actor_user_id, "actor_user_id")
+        if actor_user_id is not None
+        else None
+    )
+
+    before = get_onboarding_record(connection, normalized_guild_id, normalized_user_id)
+    if before is None:
+        raise InvalidOnboardingTransition("onboarding has not been started for this user")
+
+    if before.state in TERMINAL_STATES and before.state != new_state:
+        raise InvalidOnboardingTransition(
+            f"cannot transition from terminal state {before.state!r}; use override_state"
+        )
+
+    if new_state == COMPLETED and before.state != APPROVED:
+        raise InvalidOnboardingTransition("only approved onboarding can be completed")
+
+    now = utc_now_iso()
+    fields = _apply_state_fields(
+        state=new_state,
+        actor_user_id=normalized_actor_id,
+        notes=notes if notes is not None else before.notes,
+        now=now,
+    )
+    if new_state == COMPLETED and before.approved_by is not None:
+        fields["approved_by"] = before.approved_by
+
+    after = _update_existing_record(
+        connection,
+        guild_id=normalized_guild_id,
+        user_id=normalized_user_id,
+        fields=fields,
+    )
+    _record_audit(
+        connection,
+        guild_id=normalized_guild_id,
+        actor_user_id=normalized_actor_id,
+        action=action,
+        target_user_id=normalized_user_id,
+        before=before,
+        after=after,
+    )
+    return before, after
+
+
+def approve_onboarding(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    actor_user_id: int | str,
+    notes: str | None = None,
+) -> tuple[OnboardingRecord, OnboardingRecord]:
+    """Mark a pending onboarding record as approved."""
+
+    return _transition(
+        connection,
+        guild_id,
+        user_id,
+        new_state=APPROVED,
+        actor_user_id=actor_user_id,
+        notes=notes,
+        action="onboarding.approve",
+    )
+
+
+def reject_onboarding(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    actor_user_id: int | str,
+    notes: str | None = None,
+) -> tuple[OnboardingRecord, OnboardingRecord]:
+    """Mark an onboarding record as rejected."""
+
+    return _transition(
+        connection,
+        guild_id,
+        user_id,
+        new_state=REJECTED,
+        actor_user_id=actor_user_id,
+        notes=notes,
+        action="onboarding.reject",
+    )
+
+
+def complete_onboarding(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    actor_user_id: int | str,
+    notes: str | None = None,
+) -> tuple[OnboardingRecord, OnboardingRecord]:
+    """Mark an approved onboarding record as completed."""
+
+    return _transition(
+        connection,
+        guild_id,
+        user_id,
+        new_state=COMPLETED,
+        actor_user_id=actor_user_id,
+        notes=notes,
+        action="onboarding.complete",
+    )
+
+
+def override_state(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    user_id: int | str,
+    *,
+    state: str,
+    actor_user_id: int | str,
+    notes: str | None = None,
+) -> tuple[OnboardingRecord | None, OnboardingRecord]:
+    """Force-set a user's onboarding state for manual admin correction."""
+
+    normalized_guild_id = validate_snowflake(guild_id, "guild_id")
+    normalized_user_id = validate_snowflake(user_id, "user_id")
+    normalized_actor_id = validate_snowflake(actor_user_id, "actor_user_id")
+    normalized_state = _validate_state(state)
+    before = get_onboarding_record(connection, normalized_guild_id, normalized_user_id)
+    now = utc_now_iso()
+    fields = _apply_state_fields(
+        state=normalized_state,
+        actor_user_id=normalized_actor_id,
+        notes=notes,
+        now=now,
+    )
+
+    if before is None:
+        connection.execute(
+            """
+            INSERT INTO onboarding_state (
+                guild_id,
+                user_id,
+                state,
+                started_at,
+                completed_at,
+                approved_by,
+                rejected_by,
+                notes,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                normalized_guild_id,
+                normalized_user_id,
+                fields["state"],
+                now,
+                fields.get("completed_at"),
+                fields.get("approved_by"),
+                fields.get("rejected_by"),
+                fields.get("notes"),
+                now,
+                now,
+            ),
+        )
+    else:
+        _update_existing_record(
+            connection,
+            guild_id=normalized_guild_id,
+            user_id=normalized_user_id,
+            fields=fields,
+        )
+
+    after = get_onboarding_record(connection, normalized_guild_id, normalized_user_id)
+    if after is None:
+        raise RuntimeError("Failed to override onboarding_state row")
+
+    _record_audit(
+        connection,
+        guild_id=normalized_guild_id,
+        actor_user_id=normalized_actor_id,
+        action="onboarding.override",
+        target_user_id=normalized_user_id,
+        before=before,
+        after=after,
+    )
+    return before, after

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,6 +1,7 @@
 from services.audit_log import (
     deserialize_payload,
     list_audit_events,
+    list_audit_events_for_target,
     record_audit_event,
 )
 from services.database import initialize_database, managed_connection
@@ -55,3 +56,40 @@ def test_audit_event_limit_is_bounded(tmp_path):
 
         assert len(list_audit_events(connection, 123, limit=0)) == 1
         assert len(list_audit_events(connection, 123, limit=500)) == 3
+
+
+def test_list_audit_events_for_target_filters_rows(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        first = record_audit_event(
+            connection,
+            guild_id=123,
+            actor_user_id=456,
+            action="onboarding.start",
+            target="111",
+            created_at="2026-05-20T01:00:00+00:00",
+        )
+        second = record_audit_event(
+            connection,
+            guild_id=123,
+            actor_user_id=456,
+            action="onboarding.approve",
+            target="222",
+            created_at="2026-05-20T02:00:00+00:00",
+        )
+        third = record_audit_event(
+            connection,
+            guild_id=123,
+            actor_user_id=456,
+            action="onboarding.complete",
+            target="111",
+            created_at="2026-05-20T03:00:00+00:00",
+        )
+
+        events = list_audit_events_for_target(connection, 123, 111, limit=10)
+
+    assert first.id != second.id
+    assert [event.id for event in events] == [third.id, first.id]
+    assert all(event.target == "111" for event in events)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -24,6 +24,7 @@ def test_initialize_database_is_idempotent(tmp_path):
         assert "schema_migrations" in tables
         assert "guild_config" in tables
         assert "audit_log" in tables
+        assert "onboarding_state" in tables
         assert fetch_schema_versions(connection) == [CURRENT_SCHEMA_VERSION]
     finally:
         connection.close()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,203 @@
+from services import audit_log, onboarding
+from services.database import initialize_database, managed_connection
+
+
+def test_start_onboarding_creates_pending_record_and_audit(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        before, after = onboarding.start_onboarding(
+            connection,
+            123,
+            456,
+            actor_user_id=9001,
+            notes="arrived",
+        )
+        events = audit_log.list_audit_events(connection, 123)
+
+    assert before is None
+    assert after.guild_id == 123
+    assert after.user_id == 456
+    assert after.state == onboarding.PENDING
+    assert after.notes == "arrived"
+    assert len(events) == 1
+    assert events[0].action == "onboarding.start"
+    assert events[0].target == "456"
+
+
+def test_approve_then_complete_onboarding(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        before_approve, approved = onboarding.approve_onboarding(
+            connection,
+            123,
+            456,
+            actor_user_id=9002,
+            notes="approved manually",
+        )
+        before_complete, completed = onboarding.complete_onboarding(
+            connection,
+            123,
+            456,
+            actor_user_id=9003,
+        )
+        events = audit_log.list_audit_events(connection, 123, limit=10)
+
+    assert before_approve.state == onboarding.PENDING
+    assert approved.state == onboarding.APPROVED
+    assert approved.approved_by == 9002
+    assert approved.notes == "approved manually"
+    assert before_complete.state == onboarding.APPROVED
+    assert completed.state == onboarding.COMPLETED
+    assert completed.completed_at is not None
+    assert completed.approved_by == 9002
+    assert [event.action for event in reversed(events)] == [
+        "onboarding.start",
+        "onboarding.approve",
+        "onboarding.complete",
+    ]
+
+
+def test_reject_onboarding_sets_rejected_state(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        _, rejected = onboarding.reject_onboarding(
+            connection,
+            123,
+            456,
+            actor_user_id=9004,
+            notes="not ready",
+        )
+
+    assert rejected.state == onboarding.REJECTED
+    assert rejected.rejected_by == 9004
+    assert rejected.approved_by is None
+    assert rejected.notes == "not ready"
+
+
+def test_terminal_state_requires_override_for_different_transition(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        onboarding.reject_onboarding(connection, 123, 456, actor_user_id=9002)
+        try:
+            onboarding.approve_onboarding(connection, 123, 456, actor_user_id=9003)
+        except onboarding.InvalidOnboardingTransition as exc:
+            assert "terminal state" in str(exc)
+        else:
+            raise AssertionError("expected InvalidOnboardingTransition")
+
+
+def test_complete_requires_approved_state(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        try:
+            onboarding.complete_onboarding(connection, 123, 456, actor_user_id=9003)
+        except onboarding.InvalidOnboardingTransition as exc:
+            assert "only approved" in str(exc)
+        else:
+            raise AssertionError("expected InvalidOnboardingTransition")
+
+
+def test_override_state_creates_or_updates_record(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        before, after = onboarding.override_state(
+            connection,
+            123,
+            456,
+            state="approved",
+            actor_user_id=9001,
+            notes="manual correction",
+        )
+        fetched = onboarding.get_onboarding_record(connection, 123, 456)
+        events = audit_log.list_audit_events(connection, 123)
+
+    assert before is None
+    assert after.state == onboarding.APPROVED
+    assert after.approved_by == 9001
+    assert after.notes == "manual correction"
+    assert fetched == after
+    assert events[0].action == "onboarding.override"
+
+
+def test_list_onboarding_records_filters_by_state(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        onboarding.start_onboarding(connection, 123, 789, actor_user_id=9001)
+        onboarding.approve_onboarding(connection, 123, 789, actor_user_id=9002)
+
+        all_records = onboarding.list_onboarding_records(connection, 123)
+        approved_records = onboarding.list_onboarding_records(
+            connection,
+            123,
+            state="approved",
+        )
+
+    assert {record.user_id for record in all_records} == {456, 789}
+    assert [record.user_id for record in approved_records] == [789]
+
+
+def test_invalid_state_is_rejected(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        try:
+            onboarding.override_state(
+                connection,
+                123,
+                456,
+                state="banana",
+                actor_user_id=9001,
+            )
+        except onboarding.InvalidOnboardingState as exc:
+            assert "Unknown onboarding state" in str(exc)
+        else:
+            raise AssertionError("expected InvalidOnboardingState")
+
+
+def test_notes_are_trimmed_and_limited(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        _, after = onboarding.start_onboarding(
+            connection,
+            123,
+            456,
+            actor_user_id=9001,
+            notes="  hello  ",
+        )
+        try:
+            onboarding.override_state(
+                connection,
+                123,
+                456,
+                state="pending",
+                actor_user_id=9001,
+                notes="x" * 1001,
+            )
+        except onboarding.OnboardingError as exc:
+            assert "1000 characters" in str(exc)
+        else:
+            raise AssertionError("expected OnboardingError")
+
+    assert after.notes == "hello"

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -155,6 +155,89 @@ def test_list_onboarding_records_filters_by_state(tmp_path):
     assert [record.user_id for record in approved_records] == [789]
 
 
+def test_summarize_onboarding_counts_records_by_state(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 100, actor_user_id=9001)
+        onboarding.start_onboarding(connection, 123, 200, actor_user_id=9001)
+        onboarding.approve_onboarding(connection, 123, 200, actor_user_id=9002)
+        onboarding.start_onboarding(connection, 123, 300, actor_user_id=9001)
+        onboarding.reject_onboarding(connection, 123, 300, actor_user_id=9003)
+        onboarding.start_onboarding(connection, 123, 400, actor_user_id=9001)
+        onboarding.approve_onboarding(connection, 123, 400, actor_user_id=9002)
+        onboarding.complete_onboarding(connection, 123, 400, actor_user_id=9004)
+
+        summary = onboarding.summarize_onboarding(connection, 123)
+
+    assert summary.guild_id == 123
+    assert summary.total == 4
+    assert summary.pending == 1
+    assert summary.approved == 1
+    assert summary.rejected == 1
+    assert summary.completed == 1
+
+
+def test_update_notes_preserves_state_and_records_audit(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        before, after = onboarding.update_notes(
+            connection,
+            123,
+            456,
+            actor_user_id=9002,
+            notes="  updated note  ",
+        )
+        events = audit_log.list_audit_events(connection, 123, limit=10)
+
+    assert before.state == onboarding.PENDING
+    assert after.state == onboarding.PENDING
+    assert after.notes == "updated note"
+    assert events[0].action == "onboarding.update_notes"
+    assert events[0].target == "456"
+
+
+def test_update_notes_requires_existing_record(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        try:
+            onboarding.update_notes(
+                connection,
+                123,
+                456,
+                actor_user_id=9001,
+                notes="no record yet",
+            )
+        except onboarding.InvalidOnboardingTransition as exc:
+            assert "has not been started" in str(exc)
+        else:
+            raise AssertionError("expected InvalidOnboardingTransition")
+
+
+def test_list_onboarding_history_returns_user_audit_events(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        onboarding.start_onboarding(connection, 123, 456, actor_user_id=9001)
+        onboarding.update_notes(connection, 123, 456, actor_user_id=9002, notes="note")
+        onboarding.start_onboarding(connection, 123, 789, actor_user_id=9001)
+
+        history = onboarding.list_onboarding_history(connection, 123, 456, limit=10)
+
+    assert [event.action for event in history] == [
+        "onboarding.update_notes",
+        "onboarding.start",
+    ]
+    assert all(event.target == "456" for event in history)
+
+
 def test_invalid_state_is_rejected(tmp_path):
     database_path = tmp_path / "wilhelmina.sqlite3"
     initialize_database(database_path)


### PR DESCRIPTION
## Summary

Completes the Phase 4 onboarding state foundation.

Implemented:

- `onboarding_state` SQLite schema, schema version 2
- `services/onboarding.py`
- onboarding states: pending, approved, rejected, completed
- deterministic transitions: start, approve, reject, complete, override
- notes update support without state changes
- onboarding summary counts
- per-user onboarding history through audit log target lookup
- audit log integration for state and note changes
- `/admin onboarding summary`
- `/admin onboarding view`
- `/admin onboarding history`
- `/admin onboarding list`
- `/admin onboarding start`
- `/admin onboarding approve`
- `/admin onboarding reject`
- `/admin onboarding complete`
- `/admin onboarding notes`
- `/admin onboarding override`
- service tests for transitions, summaries, filtering, invalid states, notes, history, and audit rows
- database schema test update
- audit target lookup test
- ADR 0005

## Boundaries

This PR records and reports onboarding state only.

It does not add role changes, channel changes, permission edits, welcome messages, rules UI, scheduling, memory, server transformation, or Oracle/persona architecture.

## Validation

CI runs:

- `ruff check .`
- `pytest`

## Notes

This closes the ledger-first portion of Phase 4. Later automation can consume this state layer, but this PR performs no Discord server mutation.