### PR TITLE
Add Scheduled Daily Broadcasts foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ HOME_GUILD_ID=
 COMMAND_SYNC_MODE=guild
 
 # SQLite persistence
-# Stores guild config, audit logs, onboarding state, and rules acceptance.
+# Stores guild config, audit logs, onboarding state, rules acceptance, and broadcast state.
 # Relative paths resolve from the project root.
 DATABASE_PATH=data/wilhelmina.sqlite3
 
@@ -31,9 +31,11 @@ ENABLE_INVITE=false
 ENABLE_ROLL=false
 ENABLE_EIGHT_BALL=false
 ENABLE_FORTUNE=false
+ENABLE_BROADCASTS=false
 
 # AI support
-# Required only for AI-backed voice, /8ball, /fortune, help garnish, and rules ceremony copy.
+# Required only for AI-backed voice, /8ball, /fortune, help garnish, rules ceremony copy,
+# and generated daily broadcasts.
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 AI_TIMEOUT_SECONDS=8

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ cogs.invite        /invite
 cogs.roll          /roll
 cogs.eight_ball    /8ball
 cogs.fortune       /fortune
+cogs.broadcasts    /broadcast-admin ...
 ```
 
 Each optional feature has its own flag:
@@ -34,6 +35,7 @@ ENABLE_INVITE=false
 ENABLE_ROLL=false
 ENABLE_EIGHT_BALL=false
 ENABLE_FORTUNE=false
+ENABLE_BROADCASTS=false
 ```
 
 `ENABLE_ORACLES` is retained only as a temporary compatibility shim for old `.env` files. New configuration should not use it.
@@ -105,7 +107,7 @@ ENABLE_RULES=true
 
 ## SQLite persistence
 
-Wilhelmina stores dedicated-server configuration, administrative audit events, onboarding state, rules versions, and rules acceptance records in SQLite.
+Wilhelmina stores dedicated-server configuration, administrative audit events, onboarding state, rules versions, rules acceptance records, and broadcast state in SQLite.
 
 ```env
 DATABASE_PATH=data/wilhelmina.sqlite3
@@ -121,6 +123,9 @@ audit_log
 onboarding_state
 rules_versions
 rules_acceptance
+broadcast_settings
+broadcast_runs
+broadcast_text_history
 schema_migrations
 ```
 
@@ -130,7 +135,7 @@ The stored guild configuration is the source of truth for server role/channel ID
 
 `/help` opens Wilhelmina's dynamic public command grimoire. It reads the live slash-command tree, hides admin tooling, groups public commands into categories, and can show sealed future doors such as tarot, readings, rituals, welcome, and broadcast.
 
-The grimoire uses the Persona Engine's `guide` voice channel for short AI-polished intro text when `OPENAI_API_KEY` is configured. If AI is unavailable, it falls back to deterministic copy.
+The grimoire uses the Persona Engine's `help` feature profile for short AI-polished intro text when `OPENAI_API_KEY` is configured. If AI is unavailable, it falls back to deterministic copy.
 
 ## Covenant Gate rules UI
 
@@ -165,25 +170,69 @@ The `/admin config` commands are administrator-only and always respond ephemeral
 
 These commands only store, clear, validate, and audit configuration. They do **not** create roles, create channels, assign roles, onboard users, mutate permissions, schedule jobs, or transform a server.
 
-## Persona Engine
+## Scheduled Daily Broadcasts
 
-Wilhelmina now has a central Persona Engine with one base voice and feature-specific voice channels.
+`cogs.broadcasts` adds `/broadcast-admin` controls for Wilhelmina's automatic daily show system.
 
-Current voice channels:
+Segments:
 
 ```txt
-guide           /help
-ritual          /rules and rules acceptance
-oracle          /fortune
-administrative  admin/status copy hooks
-welcome         future welcome messages
+morning  The Vanguard Frequency   default 08:00 Asia/Riyadh
+evening  W.W.N. Broadcast          default 21:30 Asia/Riyadh
 ```
 
-This keeps Wilhelmina recognizable while allowing each feature to speak through the right channel. The old umbrella oracle/persona architecture remains removed.
+Admin commands:
+
+```txt
+/broadcast-admin status
+/broadcast-admin preview
+/broadcast-admin send-test
+/broadcast-admin enable
+/broadcast-admin disable
+/broadcast-admin set-channel
+/broadcast-admin set-time
+/broadcast-admin set-timezone
+```
+
+Broadcasts are disabled by default. The system stores schedule settings, run history, idempotency keys, and text-history hashes in SQLite. Until final news and astronomy providers are configured, previews and test sends use deterministic fallback copy and scheduled runs skip posting rather than inventing headlines or sky data.
+
+Recommended first setup:
+
+```env
+ENABLE_BROADCASTS=true
+```
+
+Then run:
+
+```txt
+/broadcast-admin set-channel target:default channel:#your-channel
+/broadcast-admin preview segment:morning
+/broadcast-admin send-test segment:evening
+/broadcast-admin enable segment:all
+```
+
+## Persona Engine
+
+Wilhelmina has a central Persona Engine with one base voice and feature-specific **feature profiles**.
+
+Current feature profiles:
+
+```txt
+help                 /help
+rules_intro          /rules intro copy
+rules_acceptance     rules acceptance copy
+admin                admin/status copy hooks
+fortune              /fortune
+welcome              future welcome messages
+broadcast_morning    The Vanguard Frequency generation
+broadcast_evening    W.W.N. Broadcast generation
+```
+
+This keeps Wilhelmina recognizable while allowing each feature to apply the right functional limits. The old umbrella oracle/persona architecture remains removed.
 
 ## AI-backed features
 
-`/8ball`, `/fortune`, `/help`, and `/rules` can use AI first when `OPENAI_API_KEY` is configured, then fall back to static or stored responses if AI is unavailable.
+`/8ball`, `/fortune`, `/help`, `/rules`, and `/broadcast-admin preview/send-test` can use AI first when `OPENAI_API_KEY` is configured, then fall back to static or stored responses if AI is unavailable.
 
 ```env
 OPENAI_API_KEY=
@@ -225,6 +274,5 @@ ENABLE_INVITE=false
 ENABLE_ROLL=false
 ENABLE_EIGHT_BALL=false
 ENABLE_FORTUNE=false
+ENABLE_BROADCASTS=false
 ```
-
-Required cogs fail startup when broken. Optional cogs are logged and skipped so unfinished features do not take down the runtime.

--- a/cogs/broadcasts.py
+++ b/cogs/broadcasts.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from services import audit_log, broadcasts, guild_config
+from services.database import initialize_database, managed_connection
+
+logger = logging.getLogger("wilhelmina.broadcasts")
+
+SEGMENT_CHOICES = [
+    app_commands.Choice(name="morning", value="morning"),
+    app_commands.Choice(name="evening", value="evening"),
+]
+ENABLE_CHOICES = [
+    app_commands.Choice(name="morning", value="morning"),
+    app_commands.Choice(name="evening", value="evening"),
+    app_commands.Choice(name="all", value="all"),
+]
+CHANNEL_TARGET_CHOICES = [
+    app_commands.Choice(name="default", value="default"),
+    app_commands.Choice(name="morning", value="morning"),
+    app_commands.Choice(name="evening", value="evening"),
+]
+
+
+def _format_channel(channel_id: int | None) -> str:
+    return f"<#{channel_id}>" if channel_id else "unset"
+
+
+def _format_bool(value: bool) -> str:
+    return "enabled" if value else "disabled"
+
+
+def _format_settings(settings: broadcasts.BroadcastSettings) -> str:
+    lines = [
+        "**Scheduled Daily Broadcasts**",
+        "```txt",
+        f"timezone          = {settings.timezone}",
+        f"default_channel   = {settings.default_channel_id or 'unset'}",
+        f"morning_channel   = {settings.morning_channel_id or 'default'}",
+        f"evening_channel   = {settings.evening_channel_id or 'default'}",
+        f"morning           = {_format_bool(settings.morning_enabled)} at {settings.morning_time}",
+        f"evening           = {_format_bool(settings.evening_enabled)} at {settings.evening_time}",
+        f"news_provider     = {settings.news_provider}",
+        f"astronomy_provider= {settings.astronomy_provider}",
+        f"sky_provider      = {settings.sky_provider}",
+        f"morning_categories= {settings.morning_categories}",
+        f"evening_categories= {settings.evening_categories}",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def _format_runs(runs: list[broadcasts.BroadcastRun]) -> str:
+    if not runs:
+        return "No broadcast runs recorded yet. Pristine. Suspicious."
+    lines = ["```txt"]
+    for run in runs:
+        fallback = " fallback" if run.fallback_used else ""
+        message = f" message={run.message_id}" if run.message_id else ""
+        error = f" error={run.error_code}" if run.error_code else ""
+        lines.append(
+            f"#{run.id} {run.logical_date} {run.segment}/{run.run_type} "
+            f"status={run.status}{fallback}{message}{error}"
+        )
+    lines.append("```")
+    return "\n".join(lines)
+
+
+@app_commands.guild_only()
+@app_commands.default_permissions(administrator=True)
+class BroadcastAdmin(commands.GroupCog, group_name="broadcast-admin"):
+    """Admin controls for scheduled morning and evening broadcasts."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        self.broadcast_scheduler.start()
+
+    def cog_unload(self) -> None:
+        self.broadcast_scheduler.cancel()
+
+    def _database_path(self) -> Path:
+        return Path(self.bot.settings.database_path)
+
+    async def _reject_non_admin(self, interaction: discord.Interaction) -> bool:
+        permissions = getattr(interaction.user, "guild_permissions", None)
+        if not permissions or not permissions.administrator:
+            await interaction.response.send_message("Admins only.", ephemeral=True)
+            return True
+        return False
+
+    async def _resolve_guild_id(self, interaction: discord.Interaction) -> int | None:
+        settings = self.bot.settings
+        home_guild_id = getattr(settings, "home_guild_id", None)
+        interaction_guild_id = interaction.guild_id
+
+        if home_guild_id is None:
+            await interaction.response.send_message(
+                "Cannot resolve a guild. Set `HOME_GUILD_ID` before using broadcast commands.",
+                ephemeral=True,
+            )
+            return None
+        if interaction_guild_id is None or int(interaction_guild_id) != int(home_guild_id):
+            await interaction.response.send_message(
+                "Run this command inside Wilhelmina's configured home guild.",
+                ephemeral=True,
+            )
+            return None
+        return int(home_guild_id)
+
+    async def _guard_admin_home_guild(self, interaction: discord.Interaction) -> int | None:
+        if await self._reject_non_admin(interaction):
+            return None
+        return await self._resolve_guild_id(interaction)
+
+    def _ensure_settings(self, guild_id: int) -> broadcasts.BroadcastSettings:
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            return broadcasts.ensure_broadcast_settings(connection, guild_id)
+
+    def _record_settings_audit(
+        self,
+        *,
+        guild_id: int,
+        actor_user_id: int,
+        action: str,
+        before: broadcasts.BroadcastSettings | None,
+        after: broadcasts.BroadcastSettings | None,
+    ) -> None:
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            audit_log.record_audit_event(
+                connection,
+                guild_id=guild_id,
+                actor_user_id=actor_user_id,
+                action=action,
+                target="broadcast_settings",
+                before=broadcasts.settings_to_audit_dict(before),
+                after=broadcasts.settings_to_audit_dict(after),
+            )
+
+    def _configured_channel_id(
+        self,
+        guild_id: int,
+        settings: broadcasts.BroadcastSettings,
+        segment: str,
+    ) -> int | None:
+        configured = settings.channel_id_for(segment)
+        if configured is not None:
+            return configured
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            config = guild_config.get_guild_config(connection, guild_id)
+        return config.broadcast_channel_id if config else None
+
+    def _resolve_text_channel(
+        self,
+        guild_id: int,
+        settings: broadcasts.BroadcastSettings,
+        segment: str,
+        override: discord.TextChannel | None = None,
+    ) -> discord.TextChannel | None:
+        if override is not None:
+            return override
+        channel_id = self._configured_channel_id(guild_id, settings, segment)
+        if channel_id is None:
+            return None
+        guild = self.bot.get_guild(guild_id)
+        channel = guild.get_channel(channel_id) if guild else self.bot.get_channel(channel_id)
+        if isinstance(channel, discord.TextChannel):
+            return channel
+        return None
+
+    async def _build_draft(
+        self,
+        guild_id: int,
+        settings: broadcasts.BroadcastSettings,
+        segment: str,
+    ) -> broadcasts.BroadcastDraft:
+        database_path = self._database_path()
+        evidence = broadcasts.build_empty_evidence(settings, segment)
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            recent_hashes = broadcasts.list_recent_text_hashes(connection, guild_id, segment)
+        return await broadcasts.generate_broadcast_draft(
+            settings=settings,
+            evidence=evidence,
+            recent_hashes=recent_hashes,
+        )
+
+    @tasks.loop(minutes=1)
+    async def broadcast_scheduler(self) -> None:
+        settings = getattr(self.bot, "settings", None)
+        guild_id = getattr(settings, "home_guild_id", None)
+        if guild_id is None:
+            return
+        await self._tick_guild(int(guild_id))
+
+    @broadcast_scheduler.before_loop
+    async def before_broadcast_scheduler(self) -> None:
+        await self.bot.wait_until_ready()
+
+    async def _tick_guild(self, guild_id: int) -> None:
+        try:
+            settings = self._ensure_settings(guild_id)
+        except Exception:
+            logger.exception("broadcast_settings_load_failed guild_id=%s", guild_id)
+            return
+
+        now = datetime.now(ZoneInfo(settings.timezone))
+        for segment in broadcasts.VALID_SEGMENTS:
+            if not settings.is_enabled(segment):
+                continue
+            if now.strftime("%H:%M") != settings.time_for(segment):
+                continue
+            await self._run_scheduled(guild_id, settings, segment, now=now)
+
+    async def _run_scheduled(
+        self,
+        guild_id: int,
+        settings: broadcasts.BroadcastSettings,
+        segment: str,
+        *,
+        now: datetime,
+    ) -> None:
+        scheduled_for = broadcasts.local_broadcast_datetime(settings, segment, now.date()).isoformat(
+            timespec="seconds"
+        )
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            run = broadcasts.claim_scheduled_run(
+                connection,
+                guild_id=guild_id,
+                segment=segment,
+                logical_date=now.date().isoformat(),
+                scheduled_for=scheduled_for,
+            )
+        if run is None:
+            return
+
+        evidence = broadcasts.build_empty_evidence(settings, segment, now=now)
+        if not broadcasts.has_publishable_evidence(evidence):
+            with managed_connection(database_path) as connection:
+                broadcasts.record_broadcast_run_result(
+                    connection,
+                    run.id,
+                    status="skipped",
+                    error_code="no_verified_sources",
+                )
+            return
+
+        channel = self._resolve_text_channel(guild_id, settings, segment)
+        if channel is None:
+            with managed_connection(database_path) as connection:
+                broadcasts.record_broadcast_run_result(
+                    connection,
+                    run.id,
+                    status="failed",
+                    error_code="missing_channel",
+                )
+            return
+
+        draft = await self._build_draft(guild_id, settings, segment)
+        try:
+            message = await channel.send(draft.content)
+        except discord.DiscordException:
+            logger.exception("broadcast_send_failed guild_id=%s segment=%s", guild_id, segment)
+            with managed_connection(database_path) as connection:
+                broadcasts.record_broadcast_run_result(
+                    connection,
+                    run.id,
+                    status="failed",
+                    fallback_used=draft.fallback_used,
+                    error_code="discord_send_failed",
+                )
+            return
+
+        with managed_connection(database_path) as connection:
+            broadcasts.record_broadcast_run_result(
+                connection,
+                run.id,
+                status="posted",
+                message_id=message.id,
+                fallback_used=draft.fallback_used,
+            )
+            broadcasts.record_text_history(
+                connection,
+                guild_id=guild_id,
+                segment=segment,
+                logical_date=evidence.logical_date,
+                content=draft.content,
+            )
+
+    @app_commands.command(name="status", description="Show scheduled broadcast settings and recent runs.")
+    async def status(self, interaction: discord.Interaction) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            settings = broadcasts.ensure_broadcast_settings(connection, guild_id)
+            runs = broadcasts.list_recent_runs(connection, guild_id, limit=5)
+        await interaction.response.send_message(
+            f"{_format_settings(settings)}\n{_format_runs(runs)}",
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="preview", description="Preview a generated broadcast without posting it.")
+    @app_commands.choices(segment=SEGMENT_CHOICES)
+    async def preview(
+        self,
+        interaction: discord.Interaction,
+        segment: app_commands.Choice[str],
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        settings = self._ensure_settings(guild_id)
+        draft = await self._build_draft(guild_id, settings, segment.value)
+        diagnostics = "fallback=yes" if draft.fallback_used else "fallback=no"
+        if draft.validation_errors:
+            diagnostics += f" validation={','.join(draft.validation_errors)}"
+        await interaction.edit_original_response(content=f"**Preview only** `{diagnostics}`\n\n{draft.content}")
+
+    @app_commands.command(name="send-test", description="Post a test broadcast now.")
+    @app_commands.choices(segment=SEGMENT_CHOICES)
+    async def send_test(
+        self,
+        interaction: discord.Interaction,
+        segment: app_commands.Choice[str],
+        channel: discord.TextChannel | None = None,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        settings = self._ensure_settings(guild_id)
+        target = self._resolve_text_channel(guild_id, settings, segment.value, override=channel)
+        if target is None:
+            await interaction.edit_original_response(
+                content="No broadcast channel is configured. Set one with `/broadcast-admin set-channel` first."
+            )
+            return
+
+        draft = await self._build_draft(guild_id, settings, segment.value)
+        try:
+            message = await target.send(f"**TEST BROADCAST**\n{draft.content}")
+        except discord.DiscordException as exc:
+            await interaction.edit_original_response(content=f"Discord send failed: {exc}")
+            return
+
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            broadcasts.record_test_run(
+                connection,
+                guild_id=guild_id,
+                segment=segment.value,
+                logical_date=broadcasts.current_local_date(settings),
+                message_id=message.id,
+                fallback_used=draft.fallback_used,
+            )
+            broadcasts.record_text_history(
+                connection,
+                guild_id=guild_id,
+                segment=segment.value,
+                logical_date=broadcasts.current_local_date(settings),
+                content=draft.content,
+            )
+        await interaction.edit_original_response(
+            content=f"Test {segment.value} broadcast posted to {_format_channel(target.id)}."
+        )
+
+    @app_commands.command(name="enable", description="Enable scheduled broadcast posting.")
+    @app_commands.choices(segment=ENABLE_CHOICES)
+    async def enable(
+        self,
+        interaction: discord.Interaction,
+        segment: app_commands.Choice[str],
+    ) -> None:
+        await self._set_enabled(interaction, segment.value, enabled=True)
+
+    @app_commands.command(name="disable", description="Disable scheduled broadcast posting.")
+    @app_commands.choices(segment=ENABLE_CHOICES)
+    async def disable(
+        self,
+        interaction: discord.Interaction,
+        segment: app_commands.Choice[str],
+    ) -> None:
+        await self._set_enabled(interaction, segment.value, enabled=False)
+
+    async def _set_enabled(
+        self,
+        interaction: discord.Interaction,
+        segment: str,
+        *,
+        enabled: bool,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            if segment == "all":
+                before, after = broadcasts.update_broadcast_settings(
+                    connection,
+                    guild_id,
+                    {"morning_enabled": enabled, "evening_enabled": enabled},
+                )
+            else:
+                before, after = broadcasts.set_segment_enabled(connection, guild_id, segment, enabled)
+        self._record_settings_audit(
+            guild_id=guild_id,
+            actor_user_id=interaction.user.id,
+            action="broadcast_enable" if enabled else "broadcast_disable",
+            before=before,
+            after=after,
+        )
+        await interaction.response.send_message(_format_settings(after), ephemeral=True)
+
+    @app_commands.command(name="set-channel", description="Set the default, morning, or evening channel.")
+    @app_commands.choices(target=CHANNEL_TARGET_CHOICES)
+    async def set_channel(
+        self,
+        interaction: discord.Interaction,
+        target: app_commands.Choice[str],
+        channel: discord.TextChannel,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        database_path = self._database_path()
+        initialize_database(database_path)
+        with managed_connection(database_path) as connection:
+            before, after = broadcasts.set_broadcast_channel(
+                connection,
+                guild_id,
+                target.value,
+                channel.id,
+            )
+        self._record_settings_audit(
+            guild_id=guild_id,
+            actor_user_id=interaction.user.id,
+            action="broadcast_set_channel",
+            before=before,
+            after=after,
+        )
+        await interaction.response.send_message(
+            f"Broadcast {target.value} channel set to {_format_channel(channel.id)}.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="set-time", description="Set a segment time in 24-hour HH:MM format.")
+    @app_commands.choices(segment=SEGMENT_CHOICES)
+    async def set_time(
+        self,
+        interaction: discord.Interaction,
+        segment: app_commands.Choice[str],
+        time: str,
+    ) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                before, after = broadcasts.set_segment_time(connection, guild_id, segment.value, time)
+        except broadcasts.BroadcastError as exc:
+            await interaction.response.send_message(f"Broadcast config error: {exc}", ephemeral=True)
+            return
+        self._record_settings_audit(
+            guild_id=guild_id,
+            actor_user_id=interaction.user.id,
+            action="broadcast_set_time",
+            before=before,
+            after=after,
+        )
+        await interaction.response.send_message(_format_settings(after), ephemeral=True)
+
+    @app_commands.command(name="set-timezone", description="Set the broadcast timezone.")
+    async def set_timezone(self, interaction: discord.Interaction, timezone: str) -> None:
+        guild_id = await self._guard_admin_home_guild(interaction)
+        if guild_id is None:
+            return
+        database_path = self._database_path()
+        initialize_database(database_path)
+        try:
+            with managed_connection(database_path) as connection:
+                before, after = broadcasts.set_broadcast_timezone(connection, guild_id, timezone)
+        except broadcasts.BroadcastError as exc:
+            await interaction.response.send_message(f"Broadcast config error: {exc}", ephemeral=True)
+            return
+        self._record_settings_audit(
+            guild_id=guild_id,
+            actor_user_id=interaction.user.id,
+            action="broadcast_set_timezone",
+            before=before,
+            after=after,
+        )
+        await interaction.response.send_message(_format_settings(after), ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BroadcastAdmin(bot))

--- a/config/settings.py
+++ b/config/settings.py
@@ -103,6 +103,12 @@ COG_FLAGS: tuple[CogFlag, ...] = (
         default_enabled=False,
         description="Fortune-cookie style generated message command.",
     ),
+    CogFlag(
+        extension="cogs.broadcasts",
+        env_var="ENABLE_BROADCASTS",
+        default_enabled=False,
+        description="Scheduled Daily Broadcasts: morning show and evening dispatch.",
+    ),
 )
 
 
@@ -330,6 +336,7 @@ ENABLE_INVITE = _get_bool_or_default("ENABLE_INVITE", default=False)
 ENABLE_ROLL = _get_bool_or_default("ENABLE_ROLL", default=False)
 ENABLE_EIGHT_BALL = _get_bool_or_default("ENABLE_EIGHT_BALL", default=False)
 ENABLE_FORTUNE = _get_bool_or_default("ENABLE_FORTUNE", default=False)
+ENABLE_BROADCASTS = _get_bool_or_default("ENABLE_BROADCASTS", default=False)
 
 # Legacy flag retained only as a compatibility shim. Do not use for new configuration.
 ENABLE_ORACLES = _get_bool_or_default("ENABLE_ORACLES", default=False)

--- a/docs/scheduled_daily_broadcasts.md
+++ b/docs/scheduled_daily_broadcasts.md
@@ -1,0 +1,96 @@
+# Scheduled Daily Broadcasts
+
+Scheduled Daily Broadcasts is Wilhelmina's automatic two-segment show system.
+
+## Segments
+
+| Segment | Title | Default time | Timezone | Status |
+|---|---|---:|---|---|
+| `morning` | The Vanguard Frequency | 08:00 | Asia/Riyadh | disabled by default |
+| `evening` | W.W.N. Broadcast | 21:30 | Asia/Riyadh | disabled by default |
+
+## Creative contracts
+
+### Morning: The Vanguard Frequency
+
+The morning segment is a gritty, defiant, pro-worker broadcast. It should use verified daily headlines about labor, economics, corporate power, and geopolitical struggle. It must not use generic morning tropes. It must not fabricate headlines, statistics, sponsors, weather, traffic, or sky data.
+
+Required sections:
+
+```txt
+TRANSMISSION INITIATION
+THE MATERIAL CONDITIONS
+THE TACTICAL SKY
+END OF TRANSMISSION
+```
+
+### Evening: W.W.N. Broadcast
+
+The evening segment is a deadpan late-night Witch Watch Network dispatch. It mixes factual news with dark, cynical, supernatural commentary. The factual layer must still come only from verified source packets.
+
+Required sections:
+
+```txt
+OPENING TRANSMISSION
+NEWS OF THE NIGHT
+PLANETARY FORECAST
+CLOSING INCANTATION
+```
+
+## Runtime behavior
+
+The scheduler checks the configured home guild once per minute. When a segment's local time matches the configured `HH:MM`, the cog claims a scheduled run for that guild, segment, and local date. The unique scheduled-run key prevents duplicate posts after restarts or repeated ticks.
+
+If no verified providers are configured, scheduled runs are marked `skipped` with `no_verified_sources`. Preview and test commands still render deterministic fallback copy so admins can test the Discord surface safely.
+
+## Storage
+
+The feature adds these SQLite tables:
+
+```txt
+broadcast_settings
+broadcast_runs
+broadcast_text_history
+```
+
+`broadcast_settings` stores channel overrides, enablement, local times, timezone, provider names, and category lists.
+
+`broadcast_runs` stores scheduled/test execution history, message IDs, fallback use, and failure codes.
+
+`broadcast_text_history` stores opener, closer, and full-message hashes for anti-repetition checks.
+
+## Admin commands
+
+```txt
+/broadcast-admin status
+/broadcast-admin preview segment:<morning|evening>
+/broadcast-admin send-test segment:<morning|evening> [channel]
+/broadcast-admin enable segment:<morning|evening|all>
+/broadcast-admin disable segment:<morning|evening|all>
+/broadcast-admin set-channel target:<default|morning|evening> channel:#channel
+/broadcast-admin set-time segment:<morning|evening> time:HH:MM
+/broadcast-admin set-timezone timezone:Asia/Riyadh
+```
+
+## Provider layer
+
+The implementation currently keeps provider choice abstract. The expected source layer is:
+
+```txt
+news provider       -> normalized Article records
+astronomy provider  -> normalized Article records
+sky provider        -> normalized SkyPacket for Riyadh
+```
+
+Until providers are wired, Wilhelmina refuses to invent facts. That is deliberate. A silent source is better than a confident lie in eyeliner.
+
+## Future provider candidates
+
+The source layer is ready for adapters such as:
+
+- Guardian Open Platform for editorial/news source material
+- GNews or NewsAPI for broader headline aggregation
+- NASA RSS feeds for astronomy bulletins
+- Skyfield/JPL or an astronomy API for Riyadh sky-state data
+
+Final provider selection remains TBA.

--- a/services/ai.py
+++ b/services/ai.py
@@ -53,7 +53,7 @@ def _read_int(name: str, *, default: int) -> int:
     try:
         return int(raw)
     except ValueError:
-        logger.warning("invalid_int_setting name=%s value=%r default=%s", name, raw, default)
+        logger.warning("invalid_int_setting name=%s value=%r default=%s", name, raw)
         return default
 
 
@@ -86,7 +86,12 @@ def ai_available() -> bool:
     return _get_openai_client() is not None
 
 
-def generate_text(prompt: str, *, config: AIConfig | None = None) -> str:
+def generate_text(
+    prompt: str,
+    *,
+    config: AIConfig | None = None,
+    preserve_newlines: bool = False,
+) -> str:
     """Generate text synchronously, returning an empty string on failure."""
 
     client = _get_openai_client()
@@ -103,6 +108,8 @@ def generate_text(prompt: str, *, config: AIConfig | None = None) -> str:
                 timeout=config.timeout_seconds,
             )
             text = response.output_text.strip()
+            if preserve_newlines:
+                return text
             return text.replace("\n", " ")
         except Exception:
             logger.exception(
@@ -115,7 +122,19 @@ def generate_text(prompt: str, *, config: AIConfig | None = None) -> str:
     return ""
 
 
+def generate_markdown(prompt: str, *, config: AIConfig | None = None) -> str:
+    """Generate Discord markdown while preserving line breaks."""
+
+    return generate_text(prompt, config=config, preserve_newlines=True)
+
+
 async def generate_text_async(prompt: str, *, config: AIConfig | None = None) -> str:
     """Run AI generation without blocking Discord's event loop."""
 
     return await asyncio.to_thread(generate_text, prompt, config=config)
+
+
+async def generate_markdown_async(prompt: str, *, config: AIConfig | None = None) -> str:
+    """Run markdown generation without blocking Discord's event loop."""
+
+    return await asyncio.to_thread(generate_markdown, prompt, config=config)

--- a/services/ai.py
+++ b/services/ai.py
@@ -53,7 +53,7 @@ def _read_int(name: str, *, default: int) -> int:
     try:
         return int(raw)
     except ValueError:
-        logger.warning("invalid_int_setting name=%s value=%r default=%s", name, raw)
+        logger.warning("invalid_int_setting name=%s value=%r default=%s", name, raw, default)
         return default
 
 

--- a/services/broadcasts.py
+++ b/services/broadcasts.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime
+from typing import Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from services.ai import generate_markdown_async
+from services.database import utc_now_iso
+from services.persona import BASE_VOICE, GLOBAL_LIMITS
+
+BroadcastSegment = Literal["morning", "evening"]
+
+VALID_SEGMENTS: tuple[BroadcastSegment, ...] = ("morning", "evening")
+DEFAULT_TIMEZONE = "Asia/Riyadh"
+DEFAULT_MORNING_TIME = "08:00"
+DEFAULT_EVENING_TIME = "21:30"
+DEFAULT_NEWS_PROVIDER = "tba"
+DEFAULT_ASTRONOMY_PROVIDER = "tba"
+DEFAULT_SKY_PROVIDER = "tba"
+DEFAULT_MORNING_CATEGORIES = "labor,economics,corporate,geopolitics"
+DEFAULT_EVENING_CATEGORIES = "corporate,environment,politics,world"
+MAX_BROADCAST_CHARS = 1900
+
+SETTING_FIELDS = frozenset(
+    {
+        "default_channel_id",
+        "morning_channel_id",
+        "evening_channel_id",
+        "timezone",
+        "morning_enabled",
+        "evening_enabled",
+        "morning_time",
+        "evening_time",
+        "news_provider",
+        "astronomy_provider",
+        "sky_provider",
+        "morning_categories",
+        "evening_categories",
+    }
+)
+
+MORNING_TITLE = "The Vanguard Frequency"
+EVENING_TITLE = "W.W.N. Broadcast"
+
+MORNING_GENERATION_CONTRACT = """
+DAILY GENERATION SKELETON: THE VANGUARD FREQUENCY
+
+Tone: gritty, defiant, revolutionary socialist/communist, analytical, pro-worker,
+and deeply critical of capitalist hegemony.
+
+Content rules: no hallucinations. Do not invent fake sponsors, fake traffic,
+fake scenarios, fake headlines, fake dates, fake statistics, fake celestial data,
+or fake server context. All news and sky data must come from the evidence packet.
+
+Anti-repetition protocol: avoid recurring morning tropes like coffee, waking up,
+Monday blues, and generic sunrise chatter. Opening, transition, and sign-off must
+be specific to the evidence packet and recent-history restrictions.
+
+Required structure:
+- TRANSMISSION INITIATION
+- THE MATERIAL CONDITIONS
+- THE TACTICAL SKY
+- END OF TRANSMISSION
+""".strip()
+
+EVENING_GENERATION_CONTRACT = """
+DAILY GENERATION SKELETON: W.W.N. BROADCAST
+
+Tone: deadpan, dark, late-night irony. Anti-capitalist sarcasm blended with
+supernatural dread.
+
+Content rules: news and astronomical data must be factually accurate for the day
+of generation. Commentary may be mystical and cynical, but factual claims must
+come from the evidence packet.
+
+Required structure:
+- OPENING TRANSMISSION
+- NEWS OF THE NIGHT
+- PLANETARY FORECAST
+- CLOSING INCANTATION
+""".strip()
+
+
+class BroadcastError(ValueError):
+    """Raised when broadcast configuration or generation input is invalid."""
+
+
+@dataclass(frozen=True)
+class BroadcastSettings:
+    guild_id: int
+    default_channel_id: int | None
+    morning_channel_id: int | None
+    evening_channel_id: int | None
+    timezone: str
+    morning_enabled: bool
+    evening_enabled: bool
+    morning_time: str
+    evening_time: str
+    news_provider: str
+    astronomy_provider: str
+    sky_provider: str
+    morning_categories: str
+    evening_categories: str
+    created_at: str
+    updated_at: str
+
+    def is_enabled(self, segment: str) -> bool:
+        segment = validate_segment(segment)
+        return self.morning_enabled if segment == "morning" else self.evening_enabled
+
+    def time_for(self, segment: str) -> str:
+        segment = validate_segment(segment)
+        return self.morning_time if segment == "morning" else self.evening_time
+
+    def channel_id_for(self, segment: str) -> int | None:
+        segment = validate_segment(segment)
+        if segment == "morning" and self.morning_channel_id is not None:
+            return self.morning_channel_id
+        if segment == "evening" and self.evening_channel_id is not None:
+            return self.evening_channel_id
+        return self.default_channel_id
+
+    def categories_for(self, segment: str) -> str:
+        segment = validate_segment(segment)
+        return self.morning_categories if segment == "morning" else self.evening_categories
+
+
+@dataclass(frozen=True)
+class Article:
+    title: str
+    summary: str
+    source_name: str
+    canonical_url: str = ""
+    published_at: str = ""
+    category: str = ""
+    provider: str = "manual"
+
+    @property
+    def evidence_key(self) -> str:
+        raw = f"{self.provider}|{self.source_name}|{self.title}|{self.canonical_url}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class SkyPacket:
+    provider: str
+    status: str
+    observer_name: str
+    timezone: str
+    local_date: str
+    moon_phase: str | None = None
+    moon_illumination: str | None = None
+    notable_events: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BroadcastEvidence:
+    segment: BroadcastSegment
+    logical_date: str
+    generated_for: str
+    news_items: tuple[Article, ...]
+    astronomy_items: tuple[Article, ...]
+    sky_packet: SkyPacket
+    source_notes: tuple[str, ...] = ()
+
+    @property
+    def has_publishable_facts(self) -> bool:
+        return bool(self.news_items or self.astronomy_items or self.sky_packet.status == "ready")
+
+
+@dataclass(frozen=True)
+class BroadcastDraft:
+    segment: BroadcastSegment
+    content: str
+    fallback_used: bool
+    validation_errors: tuple[str, ...]
+    evidence: BroadcastEvidence
+
+
+@dataclass(frozen=True)
+class BroadcastRun:
+    id: int
+    guild_id: int
+    segment: str
+    run_type: str
+    logical_date: str
+    scheduled_for: str | None
+    status: str
+    message_id: int | None
+    fallback_used: bool
+    error_code: str | None
+    created_at: str
+    updated_at: str
+
+
+def validate_segment(segment: str) -> BroadcastSegment:
+    normalized = (segment or "").strip().lower()
+    if normalized not in VALID_SEGMENTS:
+        raise BroadcastError(f"Unknown broadcast segment: {segment!r}")
+    return normalized  # type: ignore[return-value]
+
+
+def validate_time_string(value: str) -> str:
+    raw = (value or "").strip()
+    try:
+        parsed = datetime.strptime(raw, "%H:%M")
+    except ValueError as exc:
+        raise BroadcastError("Broadcast time must use 24-hour HH:MM format.") from exc
+    return parsed.strftime("%H:%M")
+
+
+def validate_timezone_name(value: str) -> str:
+    timezone = (value or "").strip()
+    if not timezone:
+        raise BroadcastError("Timezone must not be empty.")
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        raise BroadcastError(f"Unknown IANA timezone: {timezone!r}") from exc
+    return timezone
+
+
+def settings_to_audit_dict(settings: BroadcastSettings | None) -> dict[str, Any] | None:
+    if settings is None:
+        return None
+    return asdict(settings)
+
+
+def _bool_from_db(value: int | bool) -> bool:
+    return bool(int(value))
+
+
+def _row_to_settings(row: sqlite3.Row | None) -> BroadcastSettings | None:
+    if row is None:
+        return None
+    return BroadcastSettings(
+        guild_id=int(row["guild_id"]),
+        default_channel_id=row["default_channel_id"],
+        morning_channel_id=row["morning_channel_id"],
+        evening_channel_id=row["evening_channel_id"],
+        timezone=str(row["timezone"]),
+        morning_enabled=_bool_from_db(row["morning_enabled"]),
+        evening_enabled=_bool_from_db(row["evening_enabled"]),
+        morning_time=str(row["morning_time"]),
+        evening_time=str(row["evening_time"]),
+        news_provider=str(row["news_provider"]),
+        astronomy_provider=str(row["astronomy_provider"]),
+        sky_provider=str(row["sky_provider"]),
+        morning_categories=str(row["morning_categories"]),
+        evening_categories=str(row["evening_categories"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def get_broadcast_settings(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+) -> BroadcastSettings | None:
+    row = connection.execute(
+        "SELECT * FROM broadcast_settings WHERE guild_id = ?",
+        (int(guild_id),),
+    ).fetchone()
+    return _row_to_settings(row)
+
+
+def ensure_broadcast_settings(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    *,
+    timezone: str = DEFAULT_TIMEZONE,
+) -> BroadcastSettings:
+    normalized_guild_id = int(guild_id)
+    existing = get_broadcast_settings(connection, normalized_guild_id)
+    if existing is not None:
+        return existing
+
+    now = utc_now_iso()
+    connection.execute(
+        """
+        INSERT INTO broadcast_settings (
+            guild_id,
+            timezone,
+            morning_time,
+            evening_time,
+            news_provider,
+            astronomy_provider,
+            sky_provider,
+            morning_categories,
+            evening_categories,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            normalized_guild_id,
+            validate_timezone_name(timezone),
+            DEFAULT_MORNING_TIME,
+            DEFAULT_EVENING_TIME,
+            DEFAULT_NEWS_PROVIDER,
+            DEFAULT_ASTRONOMY_PROVIDER,
+            DEFAULT_SKY_PROVIDER,
+            DEFAULT_MORNING_CATEGORIES,
+            DEFAULT_EVENING_CATEGORIES,
+            now,
+            now,
+        ),
+    )
+    created = get_broadcast_settings(connection, normalized_guild_id)
+    if created is None:
+        raise RuntimeError("Failed to create broadcast settings row")
+    return created
+
+
+def update_broadcast_settings(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    changes: dict[str, int | str | bool | None],
+) -> tuple[BroadcastSettings | None, BroadcastSettings]:
+    normalized_guild_id = int(guild_id)
+    before = get_broadcast_settings(connection, normalized_guild_id)
+    ensure_broadcast_settings(connection, normalized_guild_id)
+
+    if not changes:
+        after = get_broadcast_settings(connection, normalized_guild_id)
+        if after is None:
+            raise RuntimeError("Failed to load broadcast settings row")
+        return before, after
+
+    normalized_changes: dict[str, int | str | None] = {}
+    for field, value in changes.items():
+        if field not in SETTING_FIELDS:
+            raise BroadcastError(f"Unknown broadcast settings field: {field!r}")
+        if field == "timezone":
+            normalized_changes[field] = validate_timezone_name(str(value or ""))
+        elif field.endswith("_time"):
+            normalized_changes[field] = validate_time_string(str(value or ""))
+        elif field.endswith("_enabled"):
+            normalized_changes[field] = 1 if bool(value) else 0
+        elif field.endswith("_channel_id") and value is not None:
+            normalized_changes[field] = int(value)
+        elif field.endswith("_provider"):
+            normalized_changes[field] = str(value or DEFAULT_NEWS_PROVIDER).strip().lower() or "tba"
+        elif field.endswith("_categories"):
+            normalized_changes[field] = str(value or "").strip()
+        else:
+            normalized_changes[field] = value  # type: ignore[assignment]
+
+    updated_at = utc_now_iso()
+    assignments = ", ".join(f"{field} = ?" for field in normalized_changes)
+    values = list(normalized_changes.values())
+    values.extend([updated_at, normalized_guild_id])
+    connection.execute(
+        f"""
+        UPDATE broadcast_settings
+        SET {assignments}, updated_at = ?
+        WHERE guild_id = ?
+        """,
+        values,
+    )
+    after = get_broadcast_settings(connection, normalized_guild_id)
+    if after is None:
+        raise RuntimeError("Failed to update broadcast settings row")
+    return before, after
+
+
+def set_segment_enabled(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    segment: str,
+    enabled: bool,
+) -> tuple[BroadcastSettings | None, BroadcastSettings]:
+    segment = validate_segment(segment)
+    return update_broadcast_settings(connection, guild_id, {f"{segment}_enabled": enabled})
+
+
+def set_segment_time(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    segment: str,
+    time_value: str,
+) -> tuple[BroadcastSettings | None, BroadcastSettings]:
+    segment = validate_segment(segment)
+    return update_broadcast_settings(connection, guild_id, {f"{segment}_time": time_value})
+
+
+def set_broadcast_channel(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    target: str,
+    channel_id: int | str | None,
+) -> tuple[BroadcastSettings | None, BroadcastSettings]:
+    normalized = (target or "").strip().lower()
+    if normalized == "default":
+        field = "default_channel_id"
+    elif normalized in VALID_SEGMENTS:
+        field = f"{normalized}_channel_id"
+    else:
+        raise BroadcastError("Channel target must be default, morning, or evening.")
+    return update_broadcast_settings(connection, guild_id, {field: channel_id})
+
+
+def set_broadcast_timezone(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    timezone: str,
+) -> tuple[BroadcastSettings | None, BroadcastSettings]:
+    return update_broadcast_settings(connection, guild_id, {"timezone": timezone})
+
+
+def _row_to_run(row: sqlite3.Row | None) -> BroadcastRun | None:
+    if row is None:
+        return None
+    return BroadcastRun(
+        id=int(row["id"]),
+        guild_id=int(row["guild_id"]),
+        segment=str(row["segment"]),
+        run_type=str(row["run_type"]),
+        logical_date=str(row["logical_date"]),
+        scheduled_for=row["scheduled_for"],
+        status=str(row["status"]),
+        message_id=row["message_id"],
+        fallback_used=_bool_from_db(row["fallback_used"]),
+        error_code=row["error_code"],
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def claim_scheduled_run(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    segment: str,
+    logical_date: str,
+    scheduled_for: str,
+) -> BroadcastRun | None:
+    segment = validate_segment(segment)
+    now = utc_now_iso()
+    try:
+        cursor = connection.execute(
+            """
+            INSERT INTO broadcast_runs (
+                guild_id,
+                segment,
+                run_type,
+                logical_date,
+                scheduled_for,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, 'scheduled', ?, ?, 'claimed', ?, ?)
+            """,
+            (guild_id, segment, logical_date, scheduled_for, now, now),
+        )
+    except sqlite3.IntegrityError:
+        return None
+
+    return _row_to_run(
+        connection.execute("SELECT * FROM broadcast_runs WHERE id = ?", (cursor.lastrowid,)).fetchone()
+    )
+
+
+def record_test_run(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    segment: str,
+    logical_date: str,
+    message_id: int | None,
+    fallback_used: bool,
+    status: str = "posted",
+    error_code: str | None = None,
+) -> BroadcastRun:
+    segment = validate_segment(segment)
+    now = utc_now_iso()
+    cursor = connection.execute(
+        """
+        INSERT INTO broadcast_runs (
+            guild_id,
+            segment,
+            run_type,
+            logical_date,
+            status,
+            message_id,
+            fallback_used,
+            error_code,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, 'test', ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            guild_id,
+            segment,
+            logical_date,
+            status,
+            message_id,
+            1 if fallback_used else 0,
+            error_code,
+            now,
+            now,
+        ),
+    )
+    run = _row_to_run(
+        connection.execute("SELECT * FROM broadcast_runs WHERE id = ?", (cursor.lastrowid,)).fetchone()
+    )
+    if run is None:
+        raise RuntimeError("Failed to record broadcast test run")
+    return run
+
+
+def record_broadcast_run_result(
+    connection: sqlite3.Connection,
+    run_id: int,
+    *,
+    status: str,
+    message_id: int | None = None,
+    fallback_used: bool = False,
+    error_code: str | None = None,
+) -> BroadcastRun:
+    connection.execute(
+        """
+        UPDATE broadcast_runs
+        SET status = ?, message_id = ?, fallback_used = ?, error_code = ?, updated_at = ?
+        WHERE id = ?
+        """,
+        (status, message_id, 1 if fallback_used else 0, error_code, utc_now_iso(), run_id),
+    )
+    run = _row_to_run(connection.execute("SELECT * FROM broadcast_runs WHERE id = ?", (run_id,)).fetchone())
+    if run is None:
+        raise RuntimeError("Failed to update broadcast run")
+    return run
+
+
+def list_recent_runs(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    *,
+    limit: int = 5,
+) -> list[BroadcastRun]:
+    rows = connection.execute(
+        """
+        SELECT * FROM broadcast_runs
+        WHERE guild_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+        """,
+        (int(guild_id), int(limit)),
+    ).fetchall()
+    return [run for row in rows if (run := _row_to_run(row)) is not None]
+
+
+def record_text_history(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    segment: str,
+    logical_date: str,
+    content: str,
+) -> None:
+    segment = validate_segment(segment)
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    opener = lines[0] if lines else ""
+    closer = lines[-1] if lines else ""
+    connection.execute(
+        """
+        INSERT INTO broadcast_text_history (
+            guild_id,
+            segment,
+            logical_date,
+            opener_hash,
+            closer_hash,
+            full_hash,
+            created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            guild_id,
+            segment,
+            logical_date,
+            _hash_text(opener),
+            _hash_text(closer),
+            _hash_text(content),
+            utc_now_iso(),
+        ),
+    )
+
+
+def list_recent_text_hashes(
+    connection: sqlite3.Connection,
+    guild_id: int | str,
+    segment: str,
+    *,
+    limit: int = 14,
+) -> list[str]:
+    segment = validate_segment(segment)
+    rows = connection.execute(
+        """
+        SELECT opener_hash, closer_hash, full_hash
+        FROM broadcast_text_history
+        WHERE guild_id = ? AND segment = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+        """,
+        (int(guild_id), segment, int(limit)),
+    ).fetchall()
+    hashes: list[str] = []
+    for row in rows:
+        hashes.extend([str(row["opener_hash"]), str(row["closer_hash"]), str(row["full_hash"])])
+    return hashes
+
+
+def build_empty_evidence(
+    settings: BroadcastSettings,
+    segment: str,
+    *,
+    now: datetime | None = None,
+) -> BroadcastEvidence:
+    segment = validate_segment(segment)
+    timezone = ZoneInfo(settings.timezone)
+    generated_at = now.astimezone(timezone) if now is not None else datetime.now(timezone)
+    sky_packet = SkyPacket(
+        provider=settings.sky_provider,
+        status="unavailable",
+        observer_name="Riyadh",
+        timezone=settings.timezone,
+        local_date=generated_at.date().isoformat(),
+    )
+    notes = (
+        "News provider is TBA; no headline facts were fetched.",
+        "Astronomy provider is TBA; no verified sky facts were fetched.",
+    )
+    return BroadcastEvidence(
+        segment=segment,
+        logical_date=generated_at.date().isoformat(),
+        generated_for=generated_at.isoformat(timespec="seconds"),
+        news_items=(),
+        astronomy_items=(),
+        sky_packet=sky_packet,
+        source_notes=notes,
+    )
+
+
+def build_broadcast_prompt(
+    *,
+    settings: BroadcastSettings,
+    evidence: BroadcastEvidence,
+    recent_hashes: list[str] | None = None,
+) -> str:
+    contract = MORNING_GENERATION_CONTRACT if evidence.segment == "morning" else EVENING_GENERATION_CONTRACT
+    title = MORNING_TITLE if evidence.segment == "morning" else EVENING_TITLE
+    recent_hashes = recent_hashes or []
+    return (
+        f"Base voice:\n{BASE_VOICE}\n\n"
+        f"Global limits:\n{GLOBAL_LIMITS}\n\n"
+        f"Broadcast title: {title}\n"
+        f"Segment: {evidence.segment}\n"
+        f"Generation target: {evidence.generated_for}\n"
+        f"Guild timezone: {settings.timezone}\n"
+        f"Categories: {settings.categories_for(evidence.segment)}\n\n"
+        f"Segment contract:\n{contract}\n\n"
+        f"Evidence packet:\n{_format_evidence(evidence)}\n\n"
+        f"Recent text hashes to avoid repeating exactly: {', '.join(recent_hashes) or 'none'}\n\n"
+        "Rules:\n"
+        "- Every factual claim must appear in the evidence packet.\n"
+        "- If a fact is missing, omit it instead of inventing it.\n"
+        "- Preserve the required segment structure and markdown headings.\n"
+        "- Do not include citations, source URLs, or internal validation notes in the final post.\n"
+        "- Do not use recurring generic greetings.\n"
+        f"- Stay under {MAX_BROADCAST_CHARS} characters.\n\n"
+        "Return only the final Discord-ready markdown broadcast."
+    )
+
+
+async def generate_broadcast_draft(
+    *,
+    settings: BroadcastSettings,
+    evidence: BroadcastEvidence,
+    recent_hashes: list[str] | None = None,
+) -> BroadcastDraft:
+    prompt = build_broadcast_prompt(settings=settings, evidence=evidence, recent_hashes=recent_hashes)
+    generated = await generate_markdown_async(prompt)
+    validation_errors = validate_broadcast_output(generated, evidence=evidence)
+    if generated and not validation_errors:
+        return BroadcastDraft(
+            segment=evidence.segment,
+            content=generated.strip(),
+            fallback_used=False,
+            validation_errors=(),
+            evidence=evidence,
+        )
+
+    fallback = render_deterministic_broadcast(evidence=evidence)
+    return BroadcastDraft(
+        segment=evidence.segment,
+        content=fallback,
+        fallback_used=True,
+        validation_errors=tuple(validation_errors or ["ai_unavailable"]),
+        evidence=evidence,
+    )
+
+
+def validate_broadcast_output(content: str, *, evidence: BroadcastEvidence) -> list[str]:
+    errors: list[str] = []
+    stripped = (content or "").strip()
+    if not stripped:
+        return ["empty_output"]
+    if len(stripped) > MAX_BROADCAST_CHARS:
+        errors.append("too_long")
+    expected_title = MORNING_TITLE if evidence.segment == "morning" else EVENING_TITLE
+    if expected_title not in stripped:
+        errors.append("missing_segment_title")
+    forbidden_placeholders = (
+        "Current Real-World News Story",
+        "Generate zinger",
+        "Generate critique",
+        "[",
+        "]",
+    )
+    if any(placeholder in stripped for placeholder in forbidden_placeholders):
+        errors.append("contains_template_placeholder")
+    return errors
+
+
+def render_deterministic_broadcast(*, evidence: BroadcastEvidence) -> str:
+    if evidence.segment == "morning":
+        return _render_morning_fallback(evidence)
+    return _render_evening_fallback(evidence)
+
+
+def has_publishable_evidence(evidence: BroadcastEvidence) -> bool:
+    return evidence.has_publishable_facts
+
+
+def _render_morning_fallback(evidence: BroadcastEvidence) -> str:
+    news_lines = _format_article_bullets(evidence.news_items)
+    sky_line = _format_sky_line(evidence.sky_packet)
+    notes = " ".join(evidence.source_notes)
+    return (
+        f"## {MORNING_TITLE}\n"
+        "**TRANSMISSION INITIATION**\n"
+        f"The date is {evidence.logical_date}. The machine wants a bulletin; "
+        "Wilhelmina refuses to fabricate one for its comfort.\n\n"
+        "### THE MATERIAL CONDITIONS\n"
+        f"{news_lines}\n\n"
+        "### THE TACTICAL SKY\n"
+        f"{sky_line}\n\n"
+        "### END OF TRANSMISSION\n"
+        f"Verified source coverage is incomplete. {notes} Configure providers, then run this again."
+    )[:MAX_BROADCAST_CHARS]
+
+
+def _render_evening_fallback(evidence: BroadcastEvidence) -> str:
+    news_lines = _format_article_bullets(evidence.news_items)
+    sky_line = _format_sky_line(evidence.sky_packet)
+    notes = " ".join(evidence.source_notes)
+    return (
+        f"## {EVENING_TITLE}\n"
+        "**OPENING TRANSMISSION**\n"
+        f"Witch Watch Network is standing by on {evidence.logical_date}. "
+        "The night may be dramatic; the facts are not available for decoration.\n\n"
+        "### NEWS OF THE NIGHT\n"
+        f"{news_lines}\n\n"
+        "### PLANETARY FORECAST\n"
+        f"{sky_line}\n\n"
+        "### CLOSING INCANTATION\n"
+        f"No unsupported prophecy will be issued. {notes} Configure providers, then let the dark little engine speak."
+    )[:MAX_BROADCAST_CHARS]
+
+
+def _format_article_bullets(articles: tuple[Article, ...]) -> str:
+    if not articles:
+        return "- No verified headline items were provided. No invention will be performed."
+    return "\n".join(
+        f"- **{article.title}** — {article.summary} ({article.source_name})" for article in articles
+    )
+
+
+def _format_sky_line(packet: SkyPacket) -> str:
+    if packet.status != "ready":
+        return "- Riyadh sky data is unavailable because no sky provider is configured."
+    parts = [f"- Observer: {packet.observer_name}, {packet.local_date}."]
+    if packet.moon_phase:
+        moon = packet.moon_phase
+        if packet.moon_illumination:
+            moon = f"{moon}, {packet.moon_illumination} illuminated"
+        parts.append(f"- Moon: {moon}.")
+    for event in packet.notable_events:
+        parts.append(f"- {event}")
+    return "\n".join(parts)
+
+
+def _format_evidence(evidence: BroadcastEvidence) -> str:
+    lines = [
+        f"logical_date: {evidence.logical_date}",
+        f"generated_for: {evidence.generated_for}",
+        "news_items:",
+    ]
+    if evidence.news_items:
+        for item in evidence.news_items:
+            lines.append(
+                f"- title={item.title!r}; summary={item.summary!r}; source={item.source_name!r}; "
+                f"published_at={item.published_at!r}; evidence_key={item.evidence_key}"
+            )
+    else:
+        lines.append("- none")
+    lines.append("astronomy_items:")
+    if evidence.astronomy_items:
+        for item in evidence.astronomy_items:
+            lines.append(
+                f"- title={item.title!r}; summary={item.summary!r}; source={item.source_name!r}; "
+                f"published_at={item.published_at!r}; evidence_key={item.evidence_key}"
+            )
+    else:
+        lines.append("- none")
+    lines.append("sky_packet:")
+    lines.append(f"- provider={evidence.sky_packet.provider!r}; status={evidence.sky_packet.status!r}")
+    lines.append(f"- observer={evidence.sky_packet.observer_name!r}; date={evidence.sky_packet.local_date!r}")
+    lines.append(f"- moon_phase={evidence.sky_packet.moon_phase!r}")
+    lines.append(f"- moon_illumination={evidence.sky_packet.moon_illumination!r}")
+    for event in evidence.sky_packet.notable_events:
+        lines.append(f"- event={event!r}")
+    if evidence.source_notes:
+        lines.append("source_notes:")
+        for note in evidence.source_notes:
+            lines.append(f"- {note}")
+    return "\n".join(lines)
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def local_broadcast_datetime(settings: BroadcastSettings, segment: str, day: date | None = None) -> datetime:
+    segment = validate_segment(segment)
+    timezone = ZoneInfo(settings.timezone)
+    local_day = day or datetime.now(timezone).date()
+    hour, minute = [int(part) for part in settings.time_for(segment).split(":")]
+    return datetime(
+        local_day.year,
+        local_day.month,
+        local_day.day,
+        hour,
+        minute,
+        tzinfo=timezone,
+    )
+
+
+def current_local_date(settings: BroadcastSettings) -> str:
+    return datetime.now(ZoneInfo(settings.timezone)).date().isoformat()
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/services/database.py
+++ b/services/database.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-CURRENT_SCHEMA_VERSION = 3
+CURRENT_SCHEMA_VERSION = 4
 DEFAULT_DATABASE_PATH = Path("data/wilhelmina.sqlite3")
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
@@ -109,6 +109,67 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE INDEX IF NOT EXISTS idx_rules_acceptance_guild_user
     ON rules_acceptance (guild_id, user_id, accepted_at DESC)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS broadcast_settings (
+        guild_id INTEGER PRIMARY KEY,
+        default_channel_id INTEGER,
+        morning_channel_id INTEGER,
+        evening_channel_id INTEGER,
+        timezone TEXT NOT NULL DEFAULT 'Asia/Riyadh',
+        morning_enabled INTEGER NOT NULL DEFAULT 0 CHECK (morning_enabled IN (0, 1)),
+        evening_enabled INTEGER NOT NULL DEFAULT 0 CHECK (evening_enabled IN (0, 1)),
+        morning_time TEXT NOT NULL DEFAULT '08:00',
+        evening_time TEXT NOT NULL DEFAULT '21:30',
+        news_provider TEXT NOT NULL DEFAULT 'tba',
+        astronomy_provider TEXT NOT NULL DEFAULT 'tba',
+        sky_provider TEXT NOT NULL DEFAULT 'tba',
+        morning_categories TEXT NOT NULL DEFAULT 'labor,economics,corporate,geopolitics',
+        evening_categories TEXT NOT NULL DEFAULT 'corporate,environment,politics,world',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS broadcast_runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        guild_id INTEGER NOT NULL,
+        segment TEXT NOT NULL CHECK (segment IN ('morning', 'evening')),
+        run_type TEXT NOT NULL CHECK (run_type IN ('scheduled', 'test')),
+        logical_date TEXT NOT NULL,
+        scheduled_for TEXT,
+        status TEXT NOT NULL,
+        message_id INTEGER,
+        fallback_used INTEGER NOT NULL DEFAULT 0 CHECK (fallback_used IN (0, 1)),
+        error_code TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_broadcast_runs_scheduled_unique
+    ON broadcast_runs (guild_id, segment, logical_date)
+    WHERE run_type = 'scheduled'
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_broadcast_runs_guild_created
+    ON broadcast_runs (guild_id, created_at DESC)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS broadcast_text_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        guild_id INTEGER NOT NULL,
+        segment TEXT NOT NULL CHECK (segment IN ('morning', 'evening')),
+        logical_date TEXT NOT NULL,
+        opener_hash TEXT NOT NULL,
+        closer_hash TEXT NOT NULL,
+        full_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_broadcast_text_history_lookup
+    ON broadcast_text_history (guild_id, segment, created_at DESC)
     """,
 )
 

--- a/services/persona.py
+++ b/services/persona.py
@@ -99,6 +99,18 @@ FEATURE_PROFILES: Mapping[str, FeatureProfile] = {
         fallback="Step inside. The house has already noticed you.",
         max_chars=500,
     ),
+    "broadcast_morning": FeatureProfile(
+        key="broadcast_morning",
+        label="Morning broadcast",
+        fallback="The Vanguard Frequency is standing by, but the source feed is not. Facts first; spectacle later.",
+        max_chars=1900,
+    ),
+    "broadcast_evening": FeatureProfile(
+        key="broadcast_evening",
+        label="Evening broadcast",
+        fallback="Witch Watch Network is silent until verified sources arrive. The void may improvise; Wilhelmina will not.",
+        max_chars=1900,
+    ),
 }
 
 DEFAULT_FEATURE_PROFILE = "help"

--- a/tests/test_broadcasts.py
+++ b/tests/test_broadcasts.py
@@ -1,0 +1,99 @@
+from datetime import date
+
+from services import broadcasts
+from services.database import initialize_database, managed_connection
+
+
+def test_default_broadcast_settings_are_riyadh_and_disabled(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        settings = broadcasts.ensure_broadcast_settings(connection, 123)
+
+    assert settings.timezone == "Asia/Riyadh"
+    assert settings.morning_time == "08:00"
+    assert settings.evening_time == "21:30"
+    assert settings.morning_enabled is False
+    assert settings.evening_enabled is False
+    assert settings.news_provider == "tba"
+
+
+def test_update_segment_time_and_enablement(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        broadcasts.ensure_broadcast_settings(connection, 123)
+        _, settings = broadcasts.set_segment_time(connection, 123, "evening", "21:30")
+        _, settings = broadcasts.set_segment_enabled(connection, 123, "evening", True)
+
+    assert settings.evening_time == "21:30"
+    assert settings.evening_enabled is True
+
+
+def test_scheduled_run_claim_is_idempotent(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        first = broadcasts.claim_scheduled_run(
+            connection,
+            guild_id=123,
+            segment="morning",
+            logical_date="2026-07-12",
+            scheduled_for="2026-07-12T08:00:00+03:00",
+        )
+        second = broadcasts.claim_scheduled_run(
+            connection,
+            guild_id=123,
+            segment="morning",
+            logical_date="2026-07-12",
+            scheduled_for="2026-07-12T08:00:00+03:00",
+        )
+
+    assert first is not None
+    assert second is None
+
+
+def test_prompt_preserves_contract_and_evidence_boundaries(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        settings = broadcasts.ensure_broadcast_settings(connection, 123)
+
+    evidence = broadcasts.build_empty_evidence(settings, "morning")
+    prompt = broadcasts.build_broadcast_prompt(settings=settings, evidence=evidence)
+
+    assert "The Vanguard Frequency" in prompt
+    assert "Evidence packet" in prompt
+    assert "Do not invent" in prompt or "omit it instead of inventing" in prompt
+    assert "News provider is TBA" in prompt
+
+
+def test_deterministic_fallback_refuses_to_fabricate(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        settings = broadcasts.ensure_broadcast_settings(connection, 123)
+
+    evidence = broadcasts.build_empty_evidence(settings, "evening")
+    fallback = broadcasts.render_deterministic_broadcast(evidence=evidence)
+
+    assert "W.W.N. Broadcast" in fallback
+    assert "No unsupported prophecy" in fallback
+    assert "no factual headline rundown" not in fallback
+
+
+def test_local_broadcast_datetime_uses_configured_segment_time(tmp_path):
+    database_path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(database_path)
+
+    with managed_connection(database_path) as connection:
+        settings = broadcasts.ensure_broadcast_settings(connection, 123)
+
+    scheduled = broadcasts.local_broadcast_datetime(settings, "morning", date(2026, 7, 12))
+
+    assert scheduled.isoformat(timespec="minutes") == "2026-07-12T08:00+03:00"


### PR DESCRIPTION
## Summary

Adds the first production slice of Wilhelmina's Scheduled Daily Broadcasts system:

- new `cogs.broadcasts` `/broadcast-admin` command group
- morning/evening scheduler loop with Riyadh defaults
- SQLite persistence for settings, runs, idempotency, and text-history hashes
- broadcast prompt/evidence/fallback service layer
- markdown-preserving AI generation helper
- broadcast persona profiles
- docs, README, `.env.example`, and tests

## Notes

Provider choice is intentionally still abstract/TBA. Until real news and astronomy providers are configured, scheduled runs are skipped with `no_verified_sources` instead of inventing headlines or sky data. Preview and send-test still render deterministic fallback copy so the admin surface can be tested safely.

## Test plan

- Added `tests/test_broadcasts.py`
- Expected CI: `ruff check .` and `pytest`
