### PR TITLE
Implement the Memory Ledger persistence foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,42 +2,51 @@
 
 ## Operating rules
 
-- Build from updated `main` after PR #25.
-- Keep Codex in review-only mode.
-- Do not let Codex own architecture or broad implementation.
+- Build from the latest target branch before starting a new tranche.
+- Keep architecture decisions explicit in project documentation and pull-request scope.
 - Do not revive `cogs.oracles`, `utils.persona`, or an Oracle umbrella module.
-- Keep the active pattern: one feature equals one cog and one service boundary when reusable logic exists.
-- Add tests with every behavior change.
-- Update README, `.env.example`, and ADR docs when architecture or runtime configuration changes.
+- Keep the active pattern: one feature equals one cog and one reusable service boundary when shared logic exists.
+- Add or update tests with every behavior change.
+- Update README, `.env.example`, and ADR or feature documentation whenever architecture or runtime configuration changes.
+- Do not commit secrets, tokens, database files, or live Discord identifiers.
 
-## Phase 2 scope
+## Current authorized scope
 
 Allowed:
 
 ```txt
 SQLite persistence
-guild_config storage
-audit_log storage
-admin config commands
-database settings
-tests
-docs
+guild_config and audit_log storage
+Covenant Gate and Coven Registry
+scheduled broadcasts
+Memory Ledger persistence and admin controls
+OpenAI integration behind explicit feature flags
+automatic Memory Ledger collection after its extractor and Discord event layer are reviewed
+open-chat integration after the one-channel reveal boundary is enforced
+tests and documentation
 ```
 
-Not allowed in Phase 2:
+Not allowed without a separate approved tranche:
 
 ```txt
-onboarding state machine
-role assignment automation
-scheduled jobs
-memory
-tarot/readings/ritual expansion
 server takeover
 channel archival
 server transformation
 automatic mass role/channel mutation
 new Oracle umbrella
+tarot/readings/ritual expansion outside their own approved feature work
+unreviewed public exposure of private Memory Ledger records
+committing or logging API keys, Discord tokens, or prohibited private data
 ```
+
+## Memory Ledger rules
+
+- The founder/admin controls collection globally; there is no member-level memory opt-out in the approved design.
+- A legacy `memory_opt_out` database column may remain temporarily for compatibility, but it is inert and must not affect collection.
+- Prohibited information must be rejected or redacted before any external AI request.
+- Ordinary replacement permanently deletes the superseded memory and receipts.
+- Conflicting gossip remains separate, attributed, and linked through cascading contradiction records.
+- Admin-authored memories use an admin receipt rather than fabricated Discord message metadata.
 
 ## Quality gates
 
@@ -48,4 +57,4 @@ ruff check .
 pytest
 ```
 
-A change is not done because code exists. It is done when the implementation, tests, docs, config examples, and rollback/migration notes are all aligned.
+A change is complete only when implementation, tests, docs, configuration examples, migration behavior, and rollback notes agree.

--- a/docs/coven_registry.md
+++ b/docs/coven_registry.md
@@ -38,7 +38,7 @@ Public commands expose only the Coven Mark, display name, classification, status
 
 Administrator commands expose the full operational file: Discord user ID, Registry number, join/departure timestamps, covenant version linkage, notice message ID, and persistence timestamps.
 
-The profile shell contains no inferred traits, conversation surveillance, personality judgments, likes, dislikes, or automatic notes. Future memory must be designed as a separate layer with review and deletion controls.
+The profile shell itself contains no inferred traits, conversation surveillance, personality judgments, likes, dislikes, or automatic notes. The separate [Memory Ledger](memory_ledger.md) defines the private memory layer, its administration controls, receipts, deletion behavior, and reveal boundary.
 
 ## Commands
 

--- a/docs/coven_registry.md
+++ b/docs/coven_registry.md
@@ -1,6 +1,6 @@
 # The Coven Registry
 
-The Coven Registry is Wilhelmina's persistent member ledger. It replaces a generic welcome-message flow with a numbered coven induction system and creates the profile shell that future memory features can extend.
+The Coven Registry is Wilhelmina's persistent member ledger. It replaces a generic welcome-message flow with a numbered coven induction system and creates the profile shell that the separate Memory Ledger extends.
 
 ## Coven Marks
 
@@ -38,7 +38,9 @@ Public commands expose only the Coven Mark, display name, classification, status
 
 Administrator commands expose the full operational file: Discord user ID, Registry number, join/departure timestamps, covenant version linkage, notice message ID, and persistence timestamps.
 
-The profile shell itself contains no inferred traits, conversation surveillance, personality judgments, likes, dislikes, or automatic notes. The separate [Memory Ledger](memory_ledger.md) defines the private memory layer, its administration controls, receipts, deletion behavior, and reveal boundary.
+The profile shell itself contains no inferred traits, personality judgments, likes, dislikes, or automatic notes. The separate [Memory Ledger](memory_ledger.md) defines the private memory layer, administration controls, receipts, deletion behavior, and reveal boundary.
+
+The existing `memory_opt_out` column is a legacy compatibility field only. It is not exposed by commands and does not alter Memory Ledger collection. Collection is controlled globally by the founder/admin under the approved Memory Ledger rules.
 
 ## Commands
 

--- a/docs/memory_ledger.md
+++ b/docs/memory_ledger.md
@@ -2,7 +2,7 @@
 
 The Memory Ledger is Wilhelmina's private, persistent record of what human members say in the home Discord server. It extends the Coven Registry profile shell without making member profiles public.
 
-This document is the implementation contract for the first Memory Ledger build. Manual Discord testing remains deferred until the project's final live-testing pass.
+This document is the implementation contract for the Memory Ledger. Manual Discord testing remains deferred until the project's final live-testing pass.
 
 ## Product rules
 
@@ -12,22 +12,24 @@ This document is the implementation contract for the first Memory Ledger build. 
 - Wilhelmina may collect from any guild channel she can read.
 - Direct messages are excluded.
 - Only human-authored Discord messages are eligible.
-- Bot messages, webhook messages, and automated integration output are ignored.
+- Bot messages, webhook messages, and automated integrations are ignored.
 - Only message text is analyzed.
-- Images, audio, video, uploaded files, and the contents of external links are not inspected.
-- Collection is silent. Wilhelmina does not react, reply, or notify members when a memory is saved.
+- Images, audio, video, uploaded files, and external-link contents are not inspected.
+- Collection is silent.
+- Collection is controlled globally by the founder/admin. There is no member-level opt-out in the approved design.
+- The legacy `coven_profile_shells.memory_opt_out` column is inert compatibility data and must not alter collection.
 
 ### Ownership and visibility
 
 - Each memory belongs to the Coven Registry profile of the human member who supplied it.
-- Third-party gossip does not create a standalone profile for the person being discussed. It remains attached to the member who submitted it.
-- Raw Memory Ledger records, receipts, searches, status output, and administration commands are visible only to the founder/admin.
+- Third-party gossip does not create a standalone profile for the person being discussed.
+- Raw records, receipts, searches, status output, and administration commands are visible only to the founder/admin.
 - Admin command responses must be ephemeral wherever Discord permits it.
-- Memories may later feed approved Wilhelmina features, but that does not make the raw ledger public.
+- Memories may feed later approved Wilhelmina features without making the raw ledger public.
 
-### Categories
+### Categories and labels
 
-The initial category set is:
+Categories:
 
 - `Identity`
 - `Preference`
@@ -42,21 +44,21 @@ The initial category set is:
 - `Wilhelmina impression`
 - `Gossip`
 
-Every automatically extracted record also carries one epistemic label:
+Epistemic labels:
 
 - `Fact`
 - `Inference`
 - `Impression`
 - `Gossip`
 
-Gossip must be presented internally as `Unverified gossip`. Accusations are stored as attributed claims, never as established facts.
+Gossip is presented internally as `Unverified gossip`. Accusations are stored as attributed claims, never established facts.
 
-### Information that must never be saved
+### Prohibited information
 
-The Ledger must reject or redact:
+The Ledger must reject or redact the following before any external AI request and before persistence:
 
 - passwords;
-- access tokens;
+- access tokens and API keys;
 - login credentials;
 - exact residential addresses;
 - banking or payment information;
@@ -65,101 +67,100 @@ The Ledger must reject or redact:
 - mental-health diagnoses;
 - private-message content.
 
-Explicit self-identification, reclaimed in-group language, inferred traits, gossip, accusations, and third-party information are otherwise allowed under the rules above.
+The future event listener must call the deterministic pre-extraction validator before sending text to the OpenAI extractor. If the validator rejects a message, no external request is made and no memory is created.
 
 ## Memory records
 
 A memory record stores:
 
 - guild ID;
-- owner user ID;
-- Coven Mark linkage;
+- owner user ID linked to a Coven Registry profile shell;
 - category;
 - epistemic label;
 - concise summary;
-- normalized topic key for duplicate and contradiction handling;
-- optional subject text for gossip or relationship context;
+- normalized duplicate key;
+- normalized topic key;
+- gossip marker;
 - active status;
-- first-seen timestamp;
-- last-confirmed timestamp;
-- created and updated timestamps.
+- creator ID;
+- created, updated, and last-confirmed timestamps.
 
-The active profile is permanent until an administrator edits, replaces, or deletes a record. Nothing expires automatically.
+Nothing expires automatically.
 
 ## Receipts
 
-Every memory must have at least one receipt. A receipt stores:
+Every memory has at least one receipt.
 
+### Discord receipt
+
+A Discord-derived receipt stores:
+
+- source kind `discord`;
 - message ID;
-- Discord jump URL;
+- jump URL;
 - author user ID;
 - channel ID;
 - original message timestamp;
 - original excerpt;
-- latest edited excerpt;
-- edit timestamp when applicable;
-- whether the source message was later deleted;
-- receipt creation and update timestamps.
+- latest edited excerpt and edit timestamp when applicable;
+- source-deletion timestamp when applicable.
 
-The Ledger preserves the original excerpt and the edited excerpt. If Discord later deletes the source message, the receipt remains and is marked `source deleted`.
+### Admin receipt
+
+An admin-authored memory uses source kind `admin` and stores:
+
+- administrator user ID;
+- the memory summary as the source excerpt;
+- creation timestamp;
+- no fabricated Discord message, channel, or jump URL.
+
+If Discord later deletes a source message, its stored receipt remains and is marked deleted.
 
 ## Duplicate and contradiction behavior
 
 ### Duplicate memories
 
-When a new message repeats an existing memory:
+A repeated memory keeps one record, adds another receipt, preserves every supporting link, and updates `last_confirmed_at`.
 
-- keep one memory record;
-- add the new receipt;
-- preserve all supporting message links;
-- update `last_confirmed_at`;
-- do not create a second copy.
+### Ordinary replacement
 
-### Normal contradictions
+For non-gossip records, a newer statement in the same replacement category permanently deletes the superseded record and its receipts before creating the new record.
 
-For non-gossip records, a newer statement replaces the older active memory. The older memory content is permanently deleted. A minimal audit event may record that a replacement occurred, but it must not preserve the deleted content.
+A minimal `memory.replaced` audit event may remain, but it stores no deleted memory content.
 
 ### Gossip contradictions
 
-Conflicting gossip from different speakers remains as separate, attributed claims. Records sharing a topic key may be linked as contradictory without merging their claims.
+Conflicting gossip remains as separate attributed claims. Records sharing a topic key are linked in `memory_contradictions`.
 
-Wilhelmina's future chat behavior is intentionally less formal than the storage model:
+Both contradiction foreign keys use `ON DELETE CASCADE`, so permanently deleting either memory also removes the relationship row.
 
-- if the contradiction occurs inside the designated Wilhelmina chat channel, she may call it out immediately;
-- if it occurs elsewhere, she stores it silently and may bring it up the next time the subject appears in the designated chat channel;
-- dialogue should sound conversational, messy, and instigating rather than like a tribunal or case-management system.
+Future chat behavior:
+
+- contradictions observed inside the designated Wilhelmina chat may be called out immediately;
+- contradictions observed elsewhere are stored silently and may be raised later in the designated chat;
+- dialogue should sound conversational and messy rather than judicial.
 
 ## Collection controls
 
-The Ledger has a persistent guild-level state:
+The Ledger stores a persistent guild-level state:
 
-- `active`;
-- `paused`.
+- active;
+- paused.
 
-Admin controls must support:
-
-- pause collection;
-- resume collection;
-- report current status.
-
-The state survives process restarts and Discord reconnections. Pausing collection does not delete or alter existing memories.
+Admin controls will support pause, resume, status, and designated-chat-channel configuration. The state survives process restarts and Discord reconnections. Pausing does not delete existing memories.
 
 ## Designated Wilhelmina chat channel
 
 Exactly one guild channel may be configured as Wilhelmina's conversation channel.
 
-- The Ledger collects from every readable guild channel.
+- Collection may occur in every readable guild channel.
 - Open use of memories is limited to the designated Wilhelmina chat channel.
-- Outside that channel, Wilhelmina may collect memories but must not reveal or weaponize them in conversation.
-- The full active profile for participating members is loaded for every future Wilhelmina chat response.
-- No profile compression or artificial limit is planned for the initial single-digit, low-activity server.
-- A technical overflow safeguard may be added later only if model context limits are reached.
+- Outside that channel, Wilhelmina may collect but must not reveal memories.
+- The full active profile is loaded for future Wilhelmina chat responses.
 
 ## Administration surface
 
-The first command group should be `/memory-admin` and remain founder/admin only.
-
-Recommended commands:
+The planned founder/admin-only command group is `/memory-admin`:
 
 ```text
 /memory-admin status
@@ -174,81 +175,31 @@ Recommended commands:
 /memory-admin receipt
 ```
 
-Expected behavior:
+All responses are private/ephemeral where Discord permits it.
 
-- `status` reports collection state, configured chat channel, record count, receipt count, and last collection error.
-- `profile` shows the full active memory file for one member.
-- `search` filters by member, category, label, subject, or text.
-- `add` creates an admin-authored record with an `Admin note` default category unless another category is chosen.
-- `edit` may change category, label, summary, subject, and normalized topic.
-- `delete` permanently erases the memory and its receipts, leaving only a content-free audit event.
-- `receipt` displays the stored source excerpt and jump link.
-
-## Proposed SQLite schema
-
-The implementation should add schema version 6 and create the following tables.
+## SQLite schema version 6
 
 ### `memory_ledger_settings`
 
-- `guild_id` primary key;
-- `collection_enabled` boolean, default true;
-- `chat_channel_id` nullable;
-- `last_error_code` nullable;
-- `last_error_at` nullable;
-- `created_at`;
-- `updated_at`.
+Stores guild collection state and the designated Wilhelmina channel.
 
 ### `memory_records`
 
-- `id` integer primary key;
-- `guild_id`;
-- `owner_user_id`;
-- `category`;
-- `epistemic_label`;
-- `summary`;
-- `topic_key`;
-- `subject_text` nullable;
-- `is_active` boolean;
-- `first_seen_at`;
-- `last_confirmed_at`;
-- `created_at`;
-- `updated_at`;
-- foreign key to `coven_profile_shells (guild_id, user_id)` with cascade deletion;
-- unique active duplicate key scoped to guild, owner, category, epistemic label, and topic key.
+Stores memory content and links `(guild_id, subject_user_id)` to `coven_profile_shells` with cascade deletion.
 
 ### `memory_receipts`
 
-- `id` integer primary key;
-- `memory_id` foreign key with cascade deletion;
-- `guild_id`;
-- `message_id`;
-- `channel_id`;
-- `author_user_id`;
-- `jump_url`;
-- `source_created_at`;
-- `source_edited_at` nullable;
-- `original_excerpt`;
-- `latest_excerpt`;
-- `source_deleted` boolean;
-- `created_at`;
-- `updated_at`;
-- unique key on memory ID and message ID.
+Stores either a `discord` source or an `admin` source. Receipts cascade when their memory is deleted.
 
 ### `memory_contradictions`
 
-- `id` integer primary key;
-- `guild_id`;
-- `left_memory_id`;
-- `right_memory_id`;
-- `topic_key`;
-- `created_at`;
-- unique unordered pair constraint enforced by normalized IDs in service code.
+Stores normalized unordered gossip-memory pairs. Both memory references cascade on deletion.
+
+`initialize_memory_schema()` initializes its Coven Registry dependency first, applies all Memory Ledger tables and indexes idempotently, and records schema version 6.
 
 ## Extraction contract
 
-Automatic extraction should use the existing AI service asynchronously and require strict JSON output. One Discord message may yield zero or more candidates.
-
-Each candidate must contain:
+Automatic extraction is a later tranche and will require strict structured output. One message may yield zero or more candidates:
 
 ```json
 {
@@ -256,121 +207,79 @@ Each candidate must contain:
   "epistemic_label": "Fact",
   "summary": "Prefers iced coffee",
   "topic_key": "drink.preference.coffee.temperature",
-  "subject_text": null,
   "relationship": "new|duplicate|replacement|contradictory_gossip",
   "existing_memory_id": null
 }
 ```
 
-Before persistence, deterministic validation must:
+Processing order is mandatory:
 
-- reject unknown categories and labels;
-- reject empty summaries or topic keys;
-- enforce length limits;
-- block prohibited information;
-- ensure gossip is labeled as gossip;
-- ensure accusations are phrased as attributed claims;
-- ignore AI output that cannot be parsed safely.
+1. reject DMs, bots, webhooks, empty text, and paused guilds;
+2. confirm a Coven Registry profile shell exists;
+3. run deterministic prohibited-information validation locally;
+4. only then send allowed text and current profile context to the extractor;
+5. validate the returned structure;
+6. merge duplicates, permanently replace ordinary memories, or preserve/link gossip contradictions;
+7. create the appropriate receipt.
 
-AI failure must never block Discord event handling. On extraction failure, the message is skipped, an operational error is logged, and no speculative memory is created.
+AI failure never blocks Discord event handling. Failed extraction creates no speculative memory.
 
-## Message-event flow
-
-### New message
-
-1. Reject DMs, bots, webhooks, empty text, and disabled or paused guilds.
-2. Confirm the author has a Coven Registry entry and profile shell.
-3. Send text plus the author's current active profile to the extractor.
-4. Validate candidates deterministically.
-5. Merge duplicates, replace normal contradictions, or preserve contradictory gossip.
-6. Create receipts and write content-free audit events for admin mutations or permanent deletion.
+## Message edits and deletions
 
 ### Edited message
 
-1. Locate receipts by message ID.
-2. Preserve the original excerpt.
-3. Update the latest excerpt and edit timestamp.
-4. Re-run extraction against the edited text.
-5. Reconcile memories created from that message without erasing receipts from unrelated messages.
+- preserve the original excerpt;
+- store the latest excerpt and edit timestamp;
+- validate the edited text before any future re-extraction;
+- reconcile only records connected to that source message.
 
 ### Deleted message
 
-1. Locate receipts by message ID.
-2. Mark them `source_deleted = true`.
-3. Keep the stored excerpts and memory records.
-4. Do not attempt to reconstruct content that was never captured.
+- mark matching Discord receipts as source deleted;
+- keep stored excerpts and memories;
+- do not reconstruct content that was never captured.
 
-## Prompt-loading interface
-
-The Ledger service should expose a deterministic formatter for future open chat, for example:
-
-```python
-render_full_profile_context(connection, guild_id=..., user_ids=[...]) -> str
-```
-
-The formatter should include categories, labels, summaries, subjects, confirmation dates, and contradiction markers. It should not include raw receipts unless a future prompt explicitly needs them.
-
-Open-chat integration is a later feature. The Memory Ledger build should provide the interface without inventing the chat system inside this PR.
-
-## Build order
+## Build status and order
 
 ### Phase 1 — Persistence foundation
 
+Implemented in PR #33:
+
 - schema version 6;
-- settings, record, receipt, and contradiction dataclasses;
-- CRUD and query service;
-- duplicate merge;
-- normal replacement;
-- gossip contradiction preservation;
-- permanent deletion with content-free audit event;
-- profile-context formatter;
-- unit tests.
+- settings, records, receipts, and contradiction relationships;
+- duplicate merging;
+- permanent ordinary replacement;
+- gossip preservation and contradiction links;
+- admin and Discord receipt variants;
+- permanent deletion with content-free audit events;
+- pre-extraction prohibited-content validation;
+- profile rendering;
+- automated tests.
 
 ### Phase 2 — Admin controls
 
 - feature flag;
-- ephemeral `/memory-admin` group;
-- status, pause, resume, channel, profile, search, add, edit, delete, and receipt commands;
+- ephemeral `/memory-admin` commands;
+- status, pause, resume, channel, profile, search, add, edit, delete, and receipt operations;
 - founder/admin authorization tests;
-- documentation and environment updates.
+- README and `.env.example` updates.
 
 ### Phase 3 — Automatic collection
 
-- message-content intent when the feature is enabled;
-- AI extraction prompt and strict parser;
-- new-message listener;
-- edit and delete listeners;
-- bot/webhook/DM/text-only filters;
-- failure logging and rate-control tests.
+- Message Content Intent when enabled;
+- shared OpenAI client and strict extractor;
+- new, edit, and delete message listeners;
+- human/guild/text-only filters;
+- pre-AI prohibited-data filtering;
+- failure logging and rate controls.
 
 ### Phase 4 — Open-chat bridge
 
-- load the full active profile for relevant participants;
-- enforce the one-channel reveal boundary;
-- immediate contradiction callouts inside the chat channel;
-- deferred contradiction use when contradictions are observed elsewhere;
-- conversational Wilhelmina behavior rather than formal dispute language.
-
-## Test requirements
-
-The automated suite must cover at least:
-
-- idempotent schema initialization;
-- persistent pause/resume state;
-- no history-import path;
-- human-only and guild-only filters;
-- duplicate merge with multiple receipts;
-- newer normal memory replacing older content;
-- contradictory gossip remaining separate and attributed;
-- edited receipt preserving original and latest excerpts;
-- deleted source retaining excerpts and marking deletion;
-- permanent admin deletion removing records and receipts;
-- content-free audit deletion event;
-- prohibited-information rejection;
-- admin-only ephemeral command behavior;
-- full-profile prompt formatting;
-- collection from readable channels while reveal remains restricted to the designated chat channel.
+- full active-profile loading;
+- one-channel reveal boundary;
+- immediate and deferred contradiction behavior;
+- Wilhelmina's conversational response generation.
 
 ## Deferred live testing
 
-The final Discord pass must verify privileged Message Content Intent configuration, collection from multiple readable channels, bot/webhook exclusion, ephemeral admin responses, pause persistence across restart and reconnection, edited/deleted receipt handling, duplicate merges, contradiction behavior, designated-channel reveal boundaries, and full-profile loading in live Wilhelmina chat.
+The final Discord pass must verify Message Content Intent, collection from multiple channels, bot/webhook exclusion, private admin responses, pause persistence, edited/deleted receipts, duplicate merges, permanent replacement, gossip contradiction links, designated-channel reveal boundaries, and full-profile loading.

--- a/docs/memory_ledger.md
+++ b/docs/memory_ledger.md
@@ -1,0 +1,376 @@
+# Memory Ledger
+
+The Memory Ledger is Wilhelmina's private, persistent record of what human members say in the home Discord server. It extends the Coven Registry profile shell without making member profiles public.
+
+This document is the implementation contract for the first Memory Ledger build. Manual Discord testing remains deferred until the project's final live-testing pass.
+
+## Product rules
+
+### Collection scope
+
+- Collection begins only after the feature is enabled. There is no history import or backfill.
+- Wilhelmina may collect from any guild channel she can read.
+- Direct messages are excluded.
+- Only human-authored Discord messages are eligible.
+- Bot messages, webhook messages, and automated integration output are ignored.
+- Only message text is analyzed.
+- Images, audio, video, uploaded files, and the contents of external links are not inspected.
+- Collection is silent. Wilhelmina does not react, reply, or notify members when a memory is saved.
+
+### Ownership and visibility
+
+- Each memory belongs to the Coven Registry profile of the human member who supplied it.
+- Third-party gossip does not create a standalone profile for the person being discussed. It remains attached to the member who submitted it.
+- Raw Memory Ledger records, receipts, searches, status output, and administration commands are visible only to the founder/admin.
+- Admin command responses must be ephemeral wherever Discord permits it.
+- Memories may later feed approved Wilhelmina features, but that does not make the raw ledger public.
+
+### Categories
+
+The initial category set is:
+
+- `Identity`
+- `Preference`
+- `Dislike`
+- `Boundary`
+- `Interest`
+- `Project`
+- `Relationship context`
+- `Communication style`
+- `Important event`
+- `Admin note`
+- `Wilhelmina impression`
+- `Gossip`
+
+Every automatically extracted record also carries one epistemic label:
+
+- `Fact`
+- `Inference`
+- `Impression`
+- `Gossip`
+
+Gossip must be presented internally as `Unverified gossip`. Accusations are stored as attributed claims, never as established facts.
+
+### Information that must never be saved
+
+The Ledger must reject or redact:
+
+- passwords;
+- access tokens;
+- login credentials;
+- exact residential addresses;
+- banking or payment information;
+- government or identity-document numbers;
+- medical diagnoses;
+- mental-health diagnoses;
+- private-message content.
+
+Explicit self-identification, reclaimed in-group language, inferred traits, gossip, accusations, and third-party information are otherwise allowed under the rules above.
+
+## Memory records
+
+A memory record stores:
+
+- guild ID;
+- owner user ID;
+- Coven Mark linkage;
+- category;
+- epistemic label;
+- concise summary;
+- normalized topic key for duplicate and contradiction handling;
+- optional subject text for gossip or relationship context;
+- active status;
+- first-seen timestamp;
+- last-confirmed timestamp;
+- created and updated timestamps.
+
+The active profile is permanent until an administrator edits, replaces, or deletes a record. Nothing expires automatically.
+
+## Receipts
+
+Every memory must have at least one receipt. A receipt stores:
+
+- message ID;
+- Discord jump URL;
+- author user ID;
+- channel ID;
+- original message timestamp;
+- original excerpt;
+- latest edited excerpt;
+- edit timestamp when applicable;
+- whether the source message was later deleted;
+- receipt creation and update timestamps.
+
+The Ledger preserves the original excerpt and the edited excerpt. If Discord later deletes the source message, the receipt remains and is marked `source deleted`.
+
+## Duplicate and contradiction behavior
+
+### Duplicate memories
+
+When a new message repeats an existing memory:
+
+- keep one memory record;
+- add the new receipt;
+- preserve all supporting message links;
+- update `last_confirmed_at`;
+- do not create a second copy.
+
+### Normal contradictions
+
+For non-gossip records, a newer statement replaces the older active memory. The older memory content is permanently deleted. A minimal audit event may record that a replacement occurred, but it must not preserve the deleted content.
+
+### Gossip contradictions
+
+Conflicting gossip from different speakers remains as separate, attributed claims. Records sharing a topic key may be linked as contradictory without merging their claims.
+
+Wilhelmina's future chat behavior is intentionally less formal than the storage model:
+
+- if the contradiction occurs inside the designated Wilhelmina chat channel, she may call it out immediately;
+- if it occurs elsewhere, she stores it silently and may bring it up the next time the subject appears in the designated chat channel;
+- dialogue should sound conversational, messy, and instigating rather than like a tribunal or case-management system.
+
+## Collection controls
+
+The Ledger has a persistent guild-level state:
+
+- `active`;
+- `paused`.
+
+Admin controls must support:
+
+- pause collection;
+- resume collection;
+- report current status.
+
+The state survives process restarts and Discord reconnections. Pausing collection does not delete or alter existing memories.
+
+## Designated Wilhelmina chat channel
+
+Exactly one guild channel may be configured as Wilhelmina's conversation channel.
+
+- The Ledger collects from every readable guild channel.
+- Open use of memories is limited to the designated Wilhelmina chat channel.
+- Outside that channel, Wilhelmina may collect memories but must not reveal or weaponize them in conversation.
+- The full active profile for participating members is loaded for every future Wilhelmina chat response.
+- No profile compression or artificial limit is planned for the initial single-digit, low-activity server.
+- A technical overflow safeguard may be added later only if model context limits are reached.
+
+## Administration surface
+
+The first command group should be `/memory-admin` and remain founder/admin only.
+
+Recommended commands:
+
+```text
+/memory-admin status
+/memory-admin pause
+/memory-admin resume
+/memory-admin set-chat-channel
+/memory-admin profile
+/memory-admin search
+/memory-admin add
+/memory-admin edit
+/memory-admin delete
+/memory-admin receipt
+```
+
+Expected behavior:
+
+- `status` reports collection state, configured chat channel, record count, receipt count, and last collection error.
+- `profile` shows the full active memory file for one member.
+- `search` filters by member, category, label, subject, or text.
+- `add` creates an admin-authored record with an `Admin note` default category unless another category is chosen.
+- `edit` may change category, label, summary, subject, and normalized topic.
+- `delete` permanently erases the memory and its receipts, leaving only a content-free audit event.
+- `receipt` displays the stored source excerpt and jump link.
+
+## Proposed SQLite schema
+
+The implementation should add schema version 6 and create the following tables.
+
+### `memory_ledger_settings`
+
+- `guild_id` primary key;
+- `collection_enabled` boolean, default true;
+- `chat_channel_id` nullable;
+- `last_error_code` nullable;
+- `last_error_at` nullable;
+- `created_at`;
+- `updated_at`.
+
+### `memory_records`
+
+- `id` integer primary key;
+- `guild_id`;
+- `owner_user_id`;
+- `category`;
+- `epistemic_label`;
+- `summary`;
+- `topic_key`;
+- `subject_text` nullable;
+- `is_active` boolean;
+- `first_seen_at`;
+- `last_confirmed_at`;
+- `created_at`;
+- `updated_at`;
+- foreign key to `coven_profile_shells (guild_id, user_id)` with cascade deletion;
+- unique active duplicate key scoped to guild, owner, category, epistemic label, and topic key.
+
+### `memory_receipts`
+
+- `id` integer primary key;
+- `memory_id` foreign key with cascade deletion;
+- `guild_id`;
+- `message_id`;
+- `channel_id`;
+- `author_user_id`;
+- `jump_url`;
+- `source_created_at`;
+- `source_edited_at` nullable;
+- `original_excerpt`;
+- `latest_excerpt`;
+- `source_deleted` boolean;
+- `created_at`;
+- `updated_at`;
+- unique key on memory ID and message ID.
+
+### `memory_contradictions`
+
+- `id` integer primary key;
+- `guild_id`;
+- `left_memory_id`;
+- `right_memory_id`;
+- `topic_key`;
+- `created_at`;
+- unique unordered pair constraint enforced by normalized IDs in service code.
+
+## Extraction contract
+
+Automatic extraction should use the existing AI service asynchronously and require strict JSON output. One Discord message may yield zero or more candidates.
+
+Each candidate must contain:
+
+```json
+{
+  "category": "Preference",
+  "epistemic_label": "Fact",
+  "summary": "Prefers iced coffee",
+  "topic_key": "drink.preference.coffee.temperature",
+  "subject_text": null,
+  "relationship": "new|duplicate|replacement|contradictory_gossip",
+  "existing_memory_id": null
+}
+```
+
+Before persistence, deterministic validation must:
+
+- reject unknown categories and labels;
+- reject empty summaries or topic keys;
+- enforce length limits;
+- block prohibited information;
+- ensure gossip is labeled as gossip;
+- ensure accusations are phrased as attributed claims;
+- ignore AI output that cannot be parsed safely.
+
+AI failure must never block Discord event handling. On extraction failure, the message is skipped, an operational error is logged, and no speculative memory is created.
+
+## Message-event flow
+
+### New message
+
+1. Reject DMs, bots, webhooks, empty text, and disabled or paused guilds.
+2. Confirm the author has a Coven Registry entry and profile shell.
+3. Send text plus the author's current active profile to the extractor.
+4. Validate candidates deterministically.
+5. Merge duplicates, replace normal contradictions, or preserve contradictory gossip.
+6. Create receipts and write content-free audit events for admin mutations or permanent deletion.
+
+### Edited message
+
+1. Locate receipts by message ID.
+2. Preserve the original excerpt.
+3. Update the latest excerpt and edit timestamp.
+4. Re-run extraction against the edited text.
+5. Reconcile memories created from that message without erasing receipts from unrelated messages.
+
+### Deleted message
+
+1. Locate receipts by message ID.
+2. Mark them `source_deleted = true`.
+3. Keep the stored excerpts and memory records.
+4. Do not attempt to reconstruct content that was never captured.
+
+## Prompt-loading interface
+
+The Ledger service should expose a deterministic formatter for future open chat, for example:
+
+```python
+render_full_profile_context(connection, guild_id=..., user_ids=[...]) -> str
+```
+
+The formatter should include categories, labels, summaries, subjects, confirmation dates, and contradiction markers. It should not include raw receipts unless a future prompt explicitly needs them.
+
+Open-chat integration is a later feature. The Memory Ledger build should provide the interface without inventing the chat system inside this PR.
+
+## Build order
+
+### Phase 1 — Persistence foundation
+
+- schema version 6;
+- settings, record, receipt, and contradiction dataclasses;
+- CRUD and query service;
+- duplicate merge;
+- normal replacement;
+- gossip contradiction preservation;
+- permanent deletion with content-free audit event;
+- profile-context formatter;
+- unit tests.
+
+### Phase 2 — Admin controls
+
+- feature flag;
+- ephemeral `/memory-admin` group;
+- status, pause, resume, channel, profile, search, add, edit, delete, and receipt commands;
+- founder/admin authorization tests;
+- documentation and environment updates.
+
+### Phase 3 — Automatic collection
+
+- message-content intent when the feature is enabled;
+- AI extraction prompt and strict parser;
+- new-message listener;
+- edit and delete listeners;
+- bot/webhook/DM/text-only filters;
+- failure logging and rate-control tests.
+
+### Phase 4 — Open-chat bridge
+
+- load the full active profile for relevant participants;
+- enforce the one-channel reveal boundary;
+- immediate contradiction callouts inside the chat channel;
+- deferred contradiction use when contradictions are observed elsewhere;
+- conversational Wilhelmina behavior rather than formal dispute language.
+
+## Test requirements
+
+The automated suite must cover at least:
+
+- idempotent schema initialization;
+- persistent pause/resume state;
+- no history-import path;
+- human-only and guild-only filters;
+- duplicate merge with multiple receipts;
+- newer normal memory replacing older content;
+- contradictory gossip remaining separate and attributed;
+- edited receipt preserving original and latest excerpts;
+- deleted source retaining excerpts and marking deletion;
+- permanent admin deletion removing records and receipts;
+- content-free audit deletion event;
+- prohibited-information rejection;
+- admin-only ephemeral command behavior;
+- full-profile prompt formatting;
+- collection from readable channels while reveal remains restricted to the designated chat channel.
+
+## Deferred live testing
+
+The final Discord pass must verify privileged Message Content Intent configuration, collection from multiple readable channels, bot/webhook exclusion, ephemeral admin responses, pause persistence across restart and reconnection, edited/deleted receipt handling, duplicate merges, contradiction behavior, designated-channel reveal boundaries, and full-profile loading in live Wilhelmina chat.

--- a/services/memory_ledger.py
+++ b/services/memory_ledger.py
@@ -28,10 +28,20 @@ VALID_CATEGORIES = (
 VALID_LABELS = ("Fact", "Inference", "Impression", "Gossip")
 BLOCKED_PATTERNS = (
     re.compile(r"\bpassword\b", re.IGNORECASE),
-    re.compile(r"\b(?:api[ _-]?key|access[ _-]?token|refresh[ _-]?token|bearer token)\b", re.IGNORECASE),
-    re.compile(r"\b(?:bank account|routing number|credit card|debit card|cvv)\b", re.IGNORECASE),
-    re.compile(r"\b(?:passport|national id|social security|ssn)\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:api[ _-]?key|access[ _-]?token|refresh[ _-]?token|bearer token|login credential)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:bank account|routing number|credit card|debit card|cvv|iban)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:passport|national id|identity document|social security|ssn)\b",
+        re.IGNORECASE,
+    ),
     re.compile(r"\b(?:diagnosed|diagnosis)\b", re.IGNORECASE),
+    re.compile(r"\b(?:home address|residential address)\b", re.IGNORECASE),
 )
 
 
@@ -65,6 +75,7 @@ class MemoryRecord:
     epistemic_label: str
     summary: str
     normalized_key: str
+    topic_key: str
     is_gossip: bool
     active: bool
     created_by: int
@@ -78,10 +89,11 @@ class MemoryReceipt:
     id: int
     memory_id: int
     guild_id: int
+    source_kind: str
     author_user_id: int
-    channel_id: int
-    message_id: int
-    jump_url: str
+    channel_id: int | None
+    message_id: int | None
+    jump_url: str | None
     original_excerpt: str
     edited_excerpt: str | None
     source_created_at: str
@@ -91,12 +103,22 @@ class MemoryReceipt:
 
 
 @dataclass(frozen=True)
+class MemoryContradiction:
+    id: int
+    guild_id: int
+    left_memory_id: int
+    right_memory_id: int
+    topic_key: str
+    created_at: str
+
+
+@dataclass(frozen=True)
 class UpsertResult:
     memory: MemoryRecord
     created: bool
     merged: bool
     replaced_memory_ids: tuple[int, ...]
-    receipt: MemoryReceipt | None
+    receipt: MemoryReceipt
 
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
@@ -118,12 +140,16 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         epistemic_label TEXT NOT NULL,
         summary TEXT NOT NULL,
         normalized_key TEXT NOT NULL,
+        topic_key TEXT NOT NULL,
         is_gossip INTEGER NOT NULL DEFAULT 0 CHECK (is_gossip IN (0, 1)),
         active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
         created_by INTEGER NOT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
-        last_confirmed_at TEXT NOT NULL
+        last_confirmed_at TEXT NOT NULL,
+        FOREIGN KEY (guild_id, subject_user_id)
+            REFERENCES coven_profile_shells (guild_id, user_id)
+            ON DELETE CASCADE
     )
     """,
     """
@@ -136,18 +162,19 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     ON memory_records (guild_id, subject_user_id, active, category, updated_at DESC)
     """,
     """
-    CREATE INDEX IF NOT EXISTS idx_memory_gossip
-    ON memory_records (guild_id, subject_user_id, is_gossip, active, updated_at DESC)
+    CREATE INDEX IF NOT EXISTS idx_memory_gossip_topic
+    ON memory_records (guild_id, subject_user_id, topic_key, is_gossip, active)
     """,
     """
     CREATE TABLE IF NOT EXISTS memory_receipts (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         memory_id INTEGER NOT NULL,
         guild_id INTEGER NOT NULL,
+        source_kind TEXT NOT NULL CHECK (source_kind IN ('discord', 'admin')),
         author_user_id INTEGER NOT NULL,
-        channel_id INTEGER NOT NULL,
-        message_id INTEGER NOT NULL,
-        jump_url TEXT NOT NULL,
+        channel_id INTEGER,
+        message_id INTEGER,
+        jump_url TEXT,
         original_excerpt TEXT NOT NULL,
         edited_excerpt TEXT,
         source_created_at TEXT NOT NULL,
@@ -155,19 +182,45 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         source_deleted_at TEXT,
         created_at TEXT NOT NULL,
         FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE,
-        UNIQUE (memory_id, message_id)
+        CHECK (
+            (source_kind = 'admin' AND channel_id IS NULL AND message_id IS NULL AND jump_url IS NULL)
+            OR
+            (source_kind = 'discord' AND channel_id IS NOT NULL AND message_id IS NOT NULL AND jump_url IS NOT NULL)
+        )
     )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_receipts_discord_message
+    ON memory_receipts (memory_id, message_id)
+    WHERE message_id IS NOT NULL
     """,
     """
     CREATE INDEX IF NOT EXISTS idx_memory_receipts_message
     ON memory_receipts (guild_id, message_id)
     """,
+    """
+    CREATE TABLE IF NOT EXISTS memory_contradictions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        guild_id INTEGER NOT NULL,
+        left_memory_id INTEGER NOT NULL,
+        right_memory_id INTEGER NOT NULL,
+        topic_key TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (left_memory_id) REFERENCES memory_records (id) ON DELETE CASCADE,
+        FOREIGN KEY (right_memory_id) REFERENCES memory_records (id) ON DELETE CASCADE,
+        CHECK (left_memory_id < right_memory_id),
+        UNIQUE (left_memory_id, right_memory_id)
+    )
+    """,
 )
 
 
 def initialize_memory_schema(connection: sqlite3.Connection) -> None:
-    """Create Memory Ledger tables idempotently and record schema version 6."""
+    """Create the Registry dependency and Memory Ledger schema idempotently."""
 
+    from services import coven_registry
+
+    coven_registry.initialize_registry_schema(connection)
     for statement in SCHEMA_STATEMENTS:
         connection.execute(statement)
     connection.execute(
@@ -199,6 +252,7 @@ def _row_to_memory(row: sqlite3.Row) -> MemoryRecord:
         epistemic_label=str(row["epistemic_label"]),
         summary=str(row["summary"]),
         normalized_key=str(row["normalized_key"]),
+        topic_key=str(row["topic_key"]),
         is_gossip=bool(row["is_gossip"]),
         active=bool(row["active"]),
         created_by=int(row["created_by"]),
@@ -213,10 +267,11 @@ def _row_to_receipt(row: sqlite3.Row) -> MemoryReceipt:
         id=int(row["id"]),
         memory_id=int(row["memory_id"]),
         guild_id=int(row["guild_id"]),
+        source_kind=str(row["source_kind"]),
         author_user_id=int(row["author_user_id"]),
-        channel_id=int(row["channel_id"]),
-        message_id=int(row["message_id"]),
-        jump_url=str(row["jump_url"]),
+        channel_id=_optional_int(row["channel_id"]),
+        message_id=_optional_int(row["message_id"]),
+        jump_url=row["jump_url"],
         original_excerpt=str(row["original_excerpt"]),
         edited_excerpt=row["edited_excerpt"],
         source_created_at=str(row["source_created_at"]),
@@ -226,10 +281,23 @@ def _row_to_receipt(row: sqlite3.Row) -> MemoryReceipt:
     )
 
 
-def _clean_text(value: str, *, field: str) -> str:
+def _row_to_contradiction(row: sqlite3.Row) -> MemoryContradiction:
+    return MemoryContradiction(
+        id=int(row["id"]),
+        guild_id=int(row["guild_id"]),
+        left_memory_id=int(row["left_memory_id"]),
+        right_memory_id=int(row["right_memory_id"]),
+        topic_key=str(row["topic_key"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def _clean_text(value: str, *, field: str, limit: int = 1000) -> str:
     cleaned = " ".join(value.strip().split())
     if not cleaned:
         raise MemoryLedgerError(f"{field} cannot be empty")
+    if len(cleaned) > limit:
+        raise MemoryLedgerError(f"{field} exceeds {limit} characters")
     return cleaned
 
 
@@ -240,12 +308,24 @@ def _validate_content(*values: str) -> None:
             raise BlockedMemoryContent("Memory contains prohibited sensitive information")
 
 
-def normalize_memory_key(category: str, summary: str) -> str:
-    """Return a stable duplicate key for ordinary memories."""
+def validate_extractable_text(text: str) -> str:
+    """Reject prohibited information before text is sent to an external extractor."""
 
+    cleaned = _clean_text(text, field="message text", limit=4000)
+    _validate_content(cleaned)
+    return cleaned
+
+
+def normalize_memory_key(category: str, summary: str) -> str:
     normalized = re.sub(r"[^a-z0-9]+", " ", summary.lower()).strip()
-    digest = hashlib.sha256(f"{category.lower()}:{normalized}".encode("utf-8")).hexdigest()
-    return digest
+    return hashlib.sha256(f"{category.lower()}:{normalized}".encode("utf-8")).hexdigest()
+
+
+def normalize_topic_key(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", ".", value.lower()).strip(".")
+    if not normalized:
+        raise MemoryLedgerError("topic_key cannot be empty")
+    return normalized[:255]
 
 
 def get_or_create_settings(connection: sqlite3.Connection, guild_id: int) -> LedgerSettings:
@@ -277,11 +357,7 @@ def set_collection_enabled(
     before = get_or_create_settings(connection, guild_id)
     timestamp = utc_now_iso()
     connection.execute(
-        """
-        UPDATE memory_ledger_settings
-        SET collection_enabled = ?, updated_at = ?
-        WHERE guild_id = ?
-        """,
+        "UPDATE memory_ledger_settings SET collection_enabled = ?, updated_at = ? WHERE guild_id = ?",
         (1 if enabled else 0, timestamp, int(guild_id)),
     )
     after = get_or_create_settings(connection, guild_id)
@@ -323,15 +399,22 @@ def set_wilhelmina_channel(
     return after
 
 
-def get_memory(connection: sqlite3.Connection, memory_id: int, *, required: bool = True) -> MemoryRecord | None:
+def get_memory(
+    connection: sqlite3.Connection,
+    memory_id: int,
+    *,
+    required: bool = True,
+) -> MemoryRecord | None:
     initialize_memory_schema(connection)
-    row = connection.execute("SELECT * FROM memory_records WHERE id = ?", (int(memory_id),)).fetchone()
+    row = connection.execute(
+        "SELECT * FROM memory_records WHERE id = ?", (int(memory_id),)
+    ).fetchone()
     if row is None and required:
         raise MemoryNotFound("No Memory Ledger record exists with that ID")
     return _row_to_memory(row) if row else None
 
 
-def _insert_receipt(
+def _insert_discord_receipt(
     connection: sqlite3.Connection,
     *,
     memory_id: int,
@@ -347,13 +430,20 @@ def _insert_receipt(
     connection.execute(
         """
         INSERT OR IGNORE INTO memory_receipts (
-            memory_id, guild_id, author_user_id, channel_id, message_id, jump_url,
-            original_excerpt, source_created_at, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            memory_id, guild_id, source_kind, author_user_id, channel_id, message_id,
+            jump_url, original_excerpt, source_created_at, created_at
+        ) VALUES (?, ?, 'discord', ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            int(memory_id), int(guild_id), int(author_user_id), int(channel_id), int(message_id),
-            jump_url.strip(), excerpt.strip(), source_created_at, timestamp,
+            int(memory_id),
+            int(guild_id),
+            int(author_user_id),
+            int(channel_id),
+            int(message_id),
+            jump_url.strip(),
+            excerpt.strip(),
+            source_created_at,
+            timestamp,
         ),
     )
     row = connection.execute(
@@ -361,8 +451,58 @@ def _insert_receipt(
         (int(memory_id), int(message_id)),
     ).fetchone()
     if row is None:
-        raise RuntimeError("Failed to create memory receipt")
+        raise RuntimeError("Failed to create Discord memory receipt")
     return _row_to_receipt(row)
+
+
+def _insert_admin_receipt(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int,
+    guild_id: int,
+    actor_user_id: int,
+    excerpt: str,
+) -> MemoryReceipt:
+    timestamp = utc_now_iso()
+    cursor = connection.execute(
+        """
+        INSERT INTO memory_receipts (
+            memory_id, guild_id, source_kind, author_user_id,
+            original_excerpt, source_created_at, created_at
+        ) VALUES (?, ?, 'admin', ?, ?, ?, ?)
+        """,
+        (int(memory_id), int(guild_id), int(actor_user_id), excerpt.strip(), timestamp, timestamp),
+    )
+    row = connection.execute(
+        "SELECT * FROM memory_receipts WHERE id = ?", (int(cursor.lastrowid),)
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("Failed to create admin memory receipt")
+    return _row_to_receipt(row)
+
+
+def _record_contradictions_for_gossip(
+    connection: sqlite3.Connection,
+    memory: MemoryRecord,
+) -> None:
+    rows = connection.execute(
+        """
+        SELECT id FROM memory_records
+        WHERE guild_id = ? AND subject_user_id = ? AND topic_key = ?
+          AND is_gossip = 1 AND active = 1 AND id != ?
+        """,
+        (memory.guild_id, memory.subject_user_id, memory.topic_key, memory.id),
+    ).fetchall()
+    for row in rows:
+        left_id, right_id = sorted((memory.id, int(row["id"])))
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO memory_contradictions (
+                guild_id, left_memory_id, right_memory_id, topic_key, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (memory.guild_id, left_id, right_id, memory.topic_key, utc_now_iso()),
+        )
 
 
 def add_memory(
@@ -374,6 +514,7 @@ def add_memory(
     epistemic_label: str,
     summary: str,
     actor_user_id: int,
+    topic_key: str | None = None,
     author_user_id: int | None = None,
     channel_id: int | None = None,
     message_id: int | None = None,
@@ -382,16 +523,17 @@ def add_memory(
     source_created_at: str | None = None,
     replace_normal_category: bool = True,
 ) -> UpsertResult:
-    """Create or merge a memory while preserving gossip contradictions."""
+    """Create or merge a memory and permanently replace superseded ordinary records."""
 
     initialize_memory_schema(connection)
-    category = _clean_text(category, field="category")
-    epistemic_label = _clean_text(epistemic_label, field="epistemic_label")
+    category = _clean_text(category, field="category", limit=100)
+    epistemic_label = _clean_text(epistemic_label, field="epistemic_label", limit=100)
     summary = _clean_text(summary, field="summary")
     if category not in VALID_CATEGORIES:
         raise MemoryLedgerError(f"Unknown memory category: {category}")
     if epistemic_label not in VALID_LABELS:
         raise MemoryLedgerError(f"Unknown epistemic label: {epistemic_label}")
+
     is_gossip = category == "Gossip" or epistemic_label == "Gossip"
     if is_gossip:
         category = "Gossip"
@@ -399,19 +541,21 @@ def add_memory(
     _validate_content(summary, excerpt or "")
 
     timestamp = utc_now_iso()
-    key = normalize_memory_key(category, summary)
+    duplicate_key = normalize_memory_key(category, summary)
+    resolved_topic_key = normalize_topic_key(topic_key or summary)
     existing = connection.execute(
         """
         SELECT * FROM memory_records
         WHERE guild_id = ? AND subject_user_id = ? AND normalized_key = ? AND active = 1
         ORDER BY id DESC LIMIT 1
         """,
-        (int(guild_id), int(subject_user_id), key),
+        (int(guild_id), int(subject_user_id), duplicate_key),
     ).fetchone()
 
-    created = False
+    created = existing is None
     merged = existing is not None
     replaced_ids: list[int] = []
+
     if existing is not None:
         memory = _row_to_memory(existing)
         connection.execute(
@@ -422,46 +566,63 @@ def add_memory(
         if not is_gossip and replace_normal_category:
             rows = connection.execute(
                 """
-                SELECT * FROM memory_records
+                SELECT id FROM memory_records
                 WHERE guild_id = ? AND subject_user_id = ? AND category = ?
                   AND active = 1 AND is_gossip = 0
                 """,
                 (int(guild_id), int(subject_user_id), category),
             ).fetchall()
             replaced_ids = [int(row["id"]) for row in rows]
-            if replaced_ids:
-                placeholders = ",".join("?" for _ in replaced_ids)
-                connection.execute(
-                    f"UPDATE memory_records SET active = 0, updated_at = ? WHERE id IN ({placeholders})",
-                    (timestamp, *replaced_ids),
+            for replaced_id in replaced_ids:
+                connection.execute("DELETE FROM memory_records WHERE id = ?", (replaced_id,))
+                audit_log.record_audit_event(
+                    connection,
+                    guild_id=guild_id,
+                    actor_user_id=actor_user_id,
+                    action="memory.replaced",
+                    target=f"memory:{replaced_id}",
+                    before=None,
+                    after=None,
                 )
+
         cursor = connection.execute(
             """
             INSERT INTO memory_records (
-                guild_id, subject_user_id, category, epistemic_label, summary, normalized_key,
-                is_gossip, active, created_by, created_at, updated_at, last_confirmed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+                guild_id, subject_user_id, category, epistemic_label, summary,
+                normalized_key, topic_key, is_gossip, active, created_by,
+                created_at, updated_at, last_confirmed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
             """,
             (
-                int(guild_id), int(subject_user_id), category, epistemic_label, summary, key,
-                1 if is_gossip else 0, int(actor_user_id), timestamp, timestamp, timestamp,
+                int(guild_id),
+                int(subject_user_id),
+                category,
+                epistemic_label,
+                summary,
+                duplicate_key,
+                resolved_topic_key,
+                1 if is_gossip else 0,
+                int(actor_user_id),
+                timestamp,
+                timestamp,
+                timestamp,
             ),
         )
         memory = get_memory(connection, int(cursor.lastrowid))
         if memory is None:
             raise RuntimeError("Failed to create memory")
-        created = True
+        if memory.is_gossip:
+            _record_contradictions_for_gossip(connection, memory)
 
     memory = get_memory(connection, memory.id)
     if memory is None:
         raise RuntimeError("Failed to load memory")
 
-    receipt = None
-    receipt_fields = (author_user_id, channel_id, message_id, jump_url, excerpt, source_created_at)
-    if any(value is not None for value in receipt_fields):
-        if not all(value is not None for value in receipt_fields):
-            raise MemoryLedgerError("All receipt fields are required when attaching a receipt")
-        receipt = _insert_receipt(
+    discord_fields = (author_user_id, channel_id, message_id, jump_url, excerpt, source_created_at)
+    if any(value is not None for value in discord_fields):
+        if not all(value is not None for value in discord_fields):
+            raise MemoryLedgerError("All Discord receipt fields are required together")
+        receipt = _insert_discord_receipt(
             connection,
             memory_id=memory.id,
             guild_id=guild_id,
@@ -472,6 +633,14 @@ def add_memory(
             excerpt=str(excerpt),
             source_created_at=str(source_created_at),
         )
+    else:
+        receipt = _insert_admin_receipt(
+            connection,
+            memory_id=memory.id,
+            guild_id=guild_id,
+            actor_user_id=actor_user_id,
+            excerpt=summary,
+        )
 
     audit_log.record_audit_event(
         connection,
@@ -479,7 +648,7 @@ def add_memory(
         actor_user_id=actor_user_id,
         action="memory.created" if created else "memory.confirmed",
         target=f"memory:{memory.id}",
-        before={"replaced_memory_ids": replaced_ids} if replaced_ids else None,
+        before=None,
         after=asdict(memory),
     )
     return UpsertResult(memory, created, merged, tuple(replaced_ids), receipt)
@@ -493,16 +662,22 @@ def update_memory(
     summary: str | None = None,
     category: str | None = None,
     epistemic_label: str | None = None,
+    topic_key: str | None = None,
 ) -> MemoryRecord:
     before = get_memory(connection, memory_id)
     if before is None:
         raise MemoryNotFound("No Memory Ledger record exists with that ID")
-    new_category = before.category if category is None else _clean_text(category, field="category")
-    new_label = before.epistemic_label if epistemic_label is None else _clean_text(epistemic_label, field="epistemic_label")
+
+    new_category = before.category if category is None else _clean_text(category, field="category", limit=100)
+    new_label = before.epistemic_label if epistemic_label is None else _clean_text(
+        epistemic_label, field="epistemic_label", limit=100
+    )
     new_summary = before.summary if summary is None else _clean_text(summary, field="summary")
+    new_topic = before.topic_key if topic_key is None else normalize_topic_key(topic_key)
     if new_category not in VALID_CATEGORIES or new_label not in VALID_LABELS:
         raise MemoryLedgerError("Invalid category or epistemic label")
     _validate_content(new_summary)
+
     is_gossip = new_category == "Gossip" or new_label == "Gossip"
     if is_gossip:
         new_category = new_label = "Gossip"
@@ -511,17 +686,26 @@ def update_memory(
         """
         UPDATE memory_records
         SET category = ?, epistemic_label = ?, summary = ?, normalized_key = ?,
-            is_gossip = ?, updated_at = ?, last_confirmed_at = ?
+            topic_key = ?, is_gossip = ?, updated_at = ?, last_confirmed_at = ?
         WHERE id = ?
         """,
         (
-            new_category, new_label, new_summary, normalize_memory_key(new_category, new_summary),
-            1 if is_gossip else 0, timestamp, timestamp, int(memory_id),
+            new_category,
+            new_label,
+            new_summary,
+            normalize_memory_key(new_category, new_summary),
+            new_topic,
+            1 if is_gossip else 0,
+            timestamp,
+            timestamp,
+            int(memory_id),
         ),
     )
     after = get_memory(connection, memory_id)
     if after is None:
         raise RuntimeError("Failed to update memory")
+    if after.is_gossip:
+        _record_contradictions_for_gossip(connection, after)
     audit_log.record_audit_event(
         connection,
         guild_id=after.guild_id,
@@ -535,7 +719,7 @@ def update_memory(
 
 
 def delete_memory(connection: sqlite3.Connection, *, memory_id: int, actor_user_id: int) -> None:
-    """Permanently delete a memory and its receipts, retaining only a minimal audit event."""
+    """Permanently delete a memory; receipts and contradiction links cascade."""
 
     memory = get_memory(connection, memory_id)
     if memory is None:
@@ -581,6 +765,28 @@ def list_receipts(connection: sqlite3.Connection, memory_id: int) -> list[Memory
     return [_row_to_receipt(row) for row in rows]
 
 
+def list_contradictions(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int | None = None,
+) -> list[MemoryContradiction]:
+    initialize_memory_schema(connection)
+    if memory_id is None:
+        rows = connection.execute(
+            "SELECT * FROM memory_contradictions ORDER BY id ASC"
+        ).fetchall()
+    else:
+        rows = connection.execute(
+            """
+            SELECT * FROM memory_contradictions
+            WHERE left_memory_id = ? OR right_memory_id = ?
+            ORDER BY id ASC
+            """,
+            (int(memory_id), int(memory_id)),
+        ).fetchall()
+    return [_row_to_contradiction(row) for row in rows]
+
+
 def mark_message_edited(
     connection: sqlite3.Connection,
     *,
@@ -589,12 +795,12 @@ def mark_message_edited(
     edited_excerpt: str,
     edited_at: str,
 ) -> int:
-    _validate_content(edited_excerpt)
+    validate_extractable_text(edited_excerpt)
     cursor = connection.execute(
         """
         UPDATE memory_receipts
         SET edited_excerpt = ?, source_edited_at = ?
-        WHERE guild_id = ? AND message_id = ?
+        WHERE guild_id = ? AND message_id = ? AND source_kind = 'discord'
         """,
         (edited_excerpt.strip(), edited_at, int(guild_id), int(message_id)),
     )
@@ -612,7 +818,7 @@ def mark_message_deleted(
         """
         UPDATE memory_receipts
         SET source_deleted_at = ?
-        WHERE guild_id = ? AND message_id = ?
+        WHERE guild_id = ? AND message_id = ? AND source_kind = 'discord'
         """,
         (deleted_at or utc_now_iso(), int(guild_id), int(message_id)),
     )
@@ -620,8 +826,6 @@ def mark_message_deleted(
 
 
 def render_profile_for_prompt(memories: Iterable[MemoryRecord]) -> str:
-    """Render the full active profile for the future designated chat prompt."""
-
     rows = list(memories)
     if not rows:
         return "No saved memories."

--- a/services/memory_ledger.py
+++ b/services/memory_ledger.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+from services import audit_log
+from services.database import utc_now_iso
+
+MEMORY_SCHEMA_VERSION = 6
+
+VALID_CATEGORIES = (
+    "Identity",
+    "Preference",
+    "Dislike",
+    "Boundary",
+    "Interest",
+    "Project",
+    "Relationship context",
+    "Communication style",
+    "Important event",
+    "Admin note",
+    "Wilhelmina impression",
+    "Gossip",
+)
+VALID_LABELS = ("Fact", "Inference", "Impression", "Gossip")
+BLOCKED_PATTERNS = (
+    re.compile(r"\bpassword\b", re.IGNORECASE),
+    re.compile(r"\b(?:api[ _-]?key|access[ _-]?token|refresh[ _-]?token|bearer token)\b", re.IGNORECASE),
+    re.compile(r"\b(?:bank account|routing number|credit card|debit card|cvv)\b", re.IGNORECASE),
+    re.compile(r"\b(?:passport|national id|social security|ssn)\b", re.IGNORECASE),
+    re.compile(r"\b(?:diagnosed|diagnosis)\b", re.IGNORECASE),
+)
+
+
+class MemoryLedgerError(RuntimeError):
+    """Base error for Memory Ledger operations."""
+
+
+class MemoryNotFound(MemoryLedgerError):
+    """Raised when a memory record cannot be found."""
+
+
+class BlockedMemoryContent(MemoryLedgerError):
+    """Raised when prohibited sensitive content is submitted."""
+
+
+@dataclass(frozen=True)
+class LedgerSettings:
+    guild_id: int
+    collection_enabled: bool
+    wilhelmina_channel_id: int | None
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    id: int
+    guild_id: int
+    subject_user_id: int
+    category: str
+    epistemic_label: str
+    summary: str
+    normalized_key: str
+    is_gossip: bool
+    active: bool
+    created_by: int
+    created_at: str
+    updated_at: str
+    last_confirmed_at: str
+
+
+@dataclass(frozen=True)
+class MemoryReceipt:
+    id: int
+    memory_id: int
+    guild_id: int
+    author_user_id: int
+    channel_id: int
+    message_id: int
+    jump_url: str
+    original_excerpt: str
+    edited_excerpt: str | None
+    source_created_at: str
+    source_edited_at: str | None
+    source_deleted_at: str | None
+    created_at: str
+
+
+@dataclass(frozen=True)
+class UpsertResult:
+    memory: MemoryRecord
+    created: bool
+    merged: bool
+    replaced_memory_ids: tuple[int, ...]
+    receipt: MemoryReceipt | None
+
+
+SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS memory_ledger_settings (
+        guild_id INTEGER PRIMARY KEY,
+        collection_enabled INTEGER NOT NULL DEFAULT 1 CHECK (collection_enabled IN (0, 1)),
+        wilhelmina_channel_id INTEGER,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS memory_records (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        guild_id INTEGER NOT NULL,
+        subject_user_id INTEGER NOT NULL,
+        category TEXT NOT NULL,
+        epistemic_label TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        normalized_key TEXT NOT NULL,
+        is_gossip INTEGER NOT NULL DEFAULT 0 CHECK (is_gossip IN (0, 1)),
+        active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+        created_by INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        last_confirmed_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_active_non_gossip_key
+    ON memory_records (guild_id, subject_user_id, normalized_key)
+    WHERE active = 1 AND is_gossip = 0
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_memory_profile
+    ON memory_records (guild_id, subject_user_id, active, category, updated_at DESC)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_memory_gossip
+    ON memory_records (guild_id, subject_user_id, is_gossip, active, updated_at DESC)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS memory_receipts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_id INTEGER NOT NULL,
+        guild_id INTEGER NOT NULL,
+        author_user_id INTEGER NOT NULL,
+        channel_id INTEGER NOT NULL,
+        message_id INTEGER NOT NULL,
+        jump_url TEXT NOT NULL,
+        original_excerpt TEXT NOT NULL,
+        edited_excerpt TEXT,
+        source_created_at TEXT NOT NULL,
+        source_edited_at TEXT,
+        source_deleted_at TEXT,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE,
+        UNIQUE (memory_id, message_id)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_memory_receipts_message
+    ON memory_receipts (guild_id, message_id)
+    """,
+)
+
+
+def initialize_memory_schema(connection: sqlite3.Connection) -> None:
+    """Create Memory Ledger tables idempotently and record schema version 6."""
+
+    for statement in SCHEMA_STATEMENTS:
+        connection.execute(statement)
+    connection.execute(
+        "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+        (MEMORY_SCHEMA_VERSION, utc_now_iso()),
+    )
+
+
+def _optional_int(value: object) -> int | None:
+    return None if value is None else int(value)
+
+
+def _row_to_settings(row: sqlite3.Row) -> LedgerSettings:
+    return LedgerSettings(
+        guild_id=int(row["guild_id"]),
+        collection_enabled=bool(row["collection_enabled"]),
+        wilhelmina_channel_id=_optional_int(row["wilhelmina_channel_id"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _row_to_memory(row: sqlite3.Row) -> MemoryRecord:
+    return MemoryRecord(
+        id=int(row["id"]),
+        guild_id=int(row["guild_id"]),
+        subject_user_id=int(row["subject_user_id"]),
+        category=str(row["category"]),
+        epistemic_label=str(row["epistemic_label"]),
+        summary=str(row["summary"]),
+        normalized_key=str(row["normalized_key"]),
+        is_gossip=bool(row["is_gossip"]),
+        active=bool(row["active"]),
+        created_by=int(row["created_by"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+        last_confirmed_at=str(row["last_confirmed_at"]),
+    )
+
+
+def _row_to_receipt(row: sqlite3.Row) -> MemoryReceipt:
+    return MemoryReceipt(
+        id=int(row["id"]),
+        memory_id=int(row["memory_id"]),
+        guild_id=int(row["guild_id"]),
+        author_user_id=int(row["author_user_id"]),
+        channel_id=int(row["channel_id"]),
+        message_id=int(row["message_id"]),
+        jump_url=str(row["jump_url"]),
+        original_excerpt=str(row["original_excerpt"]),
+        edited_excerpt=row["edited_excerpt"],
+        source_created_at=str(row["source_created_at"]),
+        source_edited_at=row["source_edited_at"],
+        source_deleted_at=row["source_deleted_at"],
+        created_at=str(row["created_at"]),
+    )
+
+
+def _clean_text(value: str, *, field: str) -> str:
+    cleaned = " ".join(value.strip().split())
+    if not cleaned:
+        raise MemoryLedgerError(f"{field} cannot be empty")
+    return cleaned
+
+
+def _validate_content(*values: str) -> None:
+    joined = "\n".join(values)
+    for pattern in BLOCKED_PATTERNS:
+        if pattern.search(joined):
+            raise BlockedMemoryContent("Memory contains prohibited sensitive information")
+
+
+def normalize_memory_key(category: str, summary: str) -> str:
+    """Return a stable duplicate key for ordinary memories."""
+
+    normalized = re.sub(r"[^a-z0-9]+", " ", summary.lower()).strip()
+    digest = hashlib.sha256(f"{category.lower()}:{normalized}".encode("utf-8")).hexdigest()
+    return digest
+
+
+def get_or_create_settings(connection: sqlite3.Connection, guild_id: int) -> LedgerSettings:
+    initialize_memory_schema(connection)
+    timestamp = utc_now_iso()
+    connection.execute(
+        """
+        INSERT OR IGNORE INTO memory_ledger_settings (
+            guild_id, collection_enabled, wilhelmina_channel_id, created_at, updated_at
+        ) VALUES (?, 1, NULL, ?, ?)
+        """,
+        (int(guild_id), timestamp, timestamp),
+    )
+    row = connection.execute(
+        "SELECT * FROM memory_ledger_settings WHERE guild_id = ?", (int(guild_id),)
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("Failed to create Memory Ledger settings")
+    return _row_to_settings(row)
+
+
+def set_collection_enabled(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    enabled: bool,
+    actor_user_id: int,
+) -> LedgerSettings:
+    before = get_or_create_settings(connection, guild_id)
+    timestamp = utc_now_iso()
+    connection.execute(
+        """
+        UPDATE memory_ledger_settings
+        SET collection_enabled = ?, updated_at = ?
+        WHERE guild_id = ?
+        """,
+        (1 if enabled else 0, timestamp, int(guild_id)),
+    )
+    after = get_or_create_settings(connection, guild_id)
+    audit_log.record_audit_event(
+        connection,
+        guild_id=guild_id,
+        actor_user_id=actor_user_id,
+        action="memory.collection_enabled" if enabled else "memory.collection_paused",
+        target=str(guild_id),
+        before=before,
+        after=after,
+    )
+    return after
+
+
+def set_wilhelmina_channel(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    channel_id: int | None,
+    actor_user_id: int,
+) -> LedgerSettings:
+    before = get_or_create_settings(connection, guild_id)
+    timestamp = utc_now_iso()
+    connection.execute(
+        "UPDATE memory_ledger_settings SET wilhelmina_channel_id = ?, updated_at = ? WHERE guild_id = ?",
+        (_optional_int(channel_id), timestamp, int(guild_id)),
+    )
+    after = get_or_create_settings(connection, guild_id)
+    audit_log.record_audit_event(
+        connection,
+        guild_id=guild_id,
+        actor_user_id=actor_user_id,
+        action="memory.channel_set",
+        target=str(guild_id),
+        before=before,
+        after=after,
+    )
+    return after
+
+
+def get_memory(connection: sqlite3.Connection, memory_id: int, *, required: bool = True) -> MemoryRecord | None:
+    initialize_memory_schema(connection)
+    row = connection.execute("SELECT * FROM memory_records WHERE id = ?", (int(memory_id),)).fetchone()
+    if row is None and required:
+        raise MemoryNotFound("No Memory Ledger record exists with that ID")
+    return _row_to_memory(row) if row else None
+
+
+def _insert_receipt(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int,
+    guild_id: int,
+    author_user_id: int,
+    channel_id: int,
+    message_id: int,
+    jump_url: str,
+    excerpt: str,
+    source_created_at: str,
+) -> MemoryReceipt:
+    timestamp = utc_now_iso()
+    connection.execute(
+        """
+        INSERT OR IGNORE INTO memory_receipts (
+            memory_id, guild_id, author_user_id, channel_id, message_id, jump_url,
+            original_excerpt, source_created_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            int(memory_id), int(guild_id), int(author_user_id), int(channel_id), int(message_id),
+            jump_url.strip(), excerpt.strip(), source_created_at, timestamp,
+        ),
+    )
+    row = connection.execute(
+        "SELECT * FROM memory_receipts WHERE memory_id = ? AND message_id = ?",
+        (int(memory_id), int(message_id)),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("Failed to create memory receipt")
+    return _row_to_receipt(row)
+
+
+def add_memory(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_user_id: int,
+    category: str,
+    epistemic_label: str,
+    summary: str,
+    actor_user_id: int,
+    author_user_id: int | None = None,
+    channel_id: int | None = None,
+    message_id: int | None = None,
+    jump_url: str | None = None,
+    excerpt: str | None = None,
+    source_created_at: str | None = None,
+    replace_normal_category: bool = True,
+) -> UpsertResult:
+    """Create or merge a memory while preserving gossip contradictions."""
+
+    initialize_memory_schema(connection)
+    category = _clean_text(category, field="category")
+    epistemic_label = _clean_text(epistemic_label, field="epistemic_label")
+    summary = _clean_text(summary, field="summary")
+    if category not in VALID_CATEGORIES:
+        raise MemoryLedgerError(f"Unknown memory category: {category}")
+    if epistemic_label not in VALID_LABELS:
+        raise MemoryLedgerError(f"Unknown epistemic label: {epistemic_label}")
+    is_gossip = category == "Gossip" or epistemic_label == "Gossip"
+    if is_gossip:
+        category = "Gossip"
+        epistemic_label = "Gossip"
+    _validate_content(summary, excerpt or "")
+
+    timestamp = utc_now_iso()
+    key = normalize_memory_key(category, summary)
+    existing = connection.execute(
+        """
+        SELECT * FROM memory_records
+        WHERE guild_id = ? AND subject_user_id = ? AND normalized_key = ? AND active = 1
+        ORDER BY id DESC LIMIT 1
+        """,
+        (int(guild_id), int(subject_user_id), key),
+    ).fetchone()
+
+    created = False
+    merged = existing is not None
+    replaced_ids: list[int] = []
+    if existing is not None:
+        memory = _row_to_memory(existing)
+        connection.execute(
+            "UPDATE memory_records SET last_confirmed_at = ?, updated_at = ? WHERE id = ?",
+            (timestamp, timestamp, memory.id),
+        )
+    else:
+        if not is_gossip and replace_normal_category:
+            rows = connection.execute(
+                """
+                SELECT * FROM memory_records
+                WHERE guild_id = ? AND subject_user_id = ? AND category = ?
+                  AND active = 1 AND is_gossip = 0
+                """,
+                (int(guild_id), int(subject_user_id), category),
+            ).fetchall()
+            replaced_ids = [int(row["id"]) for row in rows]
+            if replaced_ids:
+                placeholders = ",".join("?" for _ in replaced_ids)
+                connection.execute(
+                    f"UPDATE memory_records SET active = 0, updated_at = ? WHERE id IN ({placeholders})",
+                    (timestamp, *replaced_ids),
+                )
+        cursor = connection.execute(
+            """
+            INSERT INTO memory_records (
+                guild_id, subject_user_id, category, epistemic_label, summary, normalized_key,
+                is_gossip, active, created_by, created_at, updated_at, last_confirmed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+            """,
+            (
+                int(guild_id), int(subject_user_id), category, epistemic_label, summary, key,
+                1 if is_gossip else 0, int(actor_user_id), timestamp, timestamp, timestamp,
+            ),
+        )
+        memory = get_memory(connection, int(cursor.lastrowid))
+        if memory is None:
+            raise RuntimeError("Failed to create memory")
+        created = True
+
+    memory = get_memory(connection, memory.id)
+    if memory is None:
+        raise RuntimeError("Failed to load memory")
+
+    receipt = None
+    receipt_fields = (author_user_id, channel_id, message_id, jump_url, excerpt, source_created_at)
+    if any(value is not None for value in receipt_fields):
+        if not all(value is not None for value in receipt_fields):
+            raise MemoryLedgerError("All receipt fields are required when attaching a receipt")
+        receipt = _insert_receipt(
+            connection,
+            memory_id=memory.id,
+            guild_id=guild_id,
+            author_user_id=int(author_user_id),
+            channel_id=int(channel_id),
+            message_id=int(message_id),
+            jump_url=str(jump_url),
+            excerpt=str(excerpt),
+            source_created_at=str(source_created_at),
+        )
+
+    audit_log.record_audit_event(
+        connection,
+        guild_id=guild_id,
+        actor_user_id=actor_user_id,
+        action="memory.created" if created else "memory.confirmed",
+        target=f"memory:{memory.id}",
+        before={"replaced_memory_ids": replaced_ids} if replaced_ids else None,
+        after=asdict(memory),
+    )
+    return UpsertResult(memory, created, merged, tuple(replaced_ids), receipt)
+
+
+def update_memory(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int,
+    actor_user_id: int,
+    summary: str | None = None,
+    category: str | None = None,
+    epistemic_label: str | None = None,
+) -> MemoryRecord:
+    before = get_memory(connection, memory_id)
+    if before is None:
+        raise MemoryNotFound("No Memory Ledger record exists with that ID")
+    new_category = before.category if category is None else _clean_text(category, field="category")
+    new_label = before.epistemic_label if epistemic_label is None else _clean_text(epistemic_label, field="epistemic_label")
+    new_summary = before.summary if summary is None else _clean_text(summary, field="summary")
+    if new_category not in VALID_CATEGORIES or new_label not in VALID_LABELS:
+        raise MemoryLedgerError("Invalid category or epistemic label")
+    _validate_content(new_summary)
+    is_gossip = new_category == "Gossip" or new_label == "Gossip"
+    if is_gossip:
+        new_category = new_label = "Gossip"
+    timestamp = utc_now_iso()
+    connection.execute(
+        """
+        UPDATE memory_records
+        SET category = ?, epistemic_label = ?, summary = ?, normalized_key = ?,
+            is_gossip = ?, updated_at = ?, last_confirmed_at = ?
+        WHERE id = ?
+        """,
+        (
+            new_category, new_label, new_summary, normalize_memory_key(new_category, new_summary),
+            1 if is_gossip else 0, timestamp, timestamp, int(memory_id),
+        ),
+    )
+    after = get_memory(connection, memory_id)
+    if after is None:
+        raise RuntimeError("Failed to update memory")
+    audit_log.record_audit_event(
+        connection,
+        guild_id=after.guild_id,
+        actor_user_id=actor_user_id,
+        action="memory.updated",
+        target=f"memory:{after.id}",
+        before=before,
+        after=after,
+    )
+    return after
+
+
+def delete_memory(connection: sqlite3.Connection, *, memory_id: int, actor_user_id: int) -> None:
+    """Permanently delete a memory and its receipts, retaining only a minimal audit event."""
+
+    memory = get_memory(connection, memory_id)
+    if memory is None:
+        raise MemoryNotFound("No Memory Ledger record exists with that ID")
+    connection.execute("DELETE FROM memory_records WHERE id = ?", (int(memory_id),))
+    audit_log.record_audit_event(
+        connection,
+        guild_id=memory.guild_id,
+        actor_user_id=actor_user_id,
+        action="memory.deleted",
+        target=f"memory:{memory.id}",
+        before=None,
+        after=None,
+    )
+
+
+def list_profile(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_user_id: int,
+    include_inactive: bool = False,
+) -> list[MemoryRecord]:
+    initialize_memory_schema(connection)
+    active_clause = "" if include_inactive else "AND active = 1"
+    rows = connection.execute(
+        f"""
+        SELECT * FROM memory_records
+        WHERE guild_id = ? AND subject_user_id = ? {active_clause}
+        ORDER BY category ASC, updated_at DESC, id DESC
+        """,
+        (int(guild_id), int(subject_user_id)),
+    ).fetchall()
+    return [_row_to_memory(row) for row in rows]
+
+
+def list_receipts(connection: sqlite3.Connection, memory_id: int) -> list[MemoryReceipt]:
+    initialize_memory_schema(connection)
+    rows = connection.execute(
+        "SELECT * FROM memory_receipts WHERE memory_id = ? ORDER BY source_created_at ASC, id ASC",
+        (int(memory_id),),
+    ).fetchall()
+    return [_row_to_receipt(row) for row in rows]
+
+
+def mark_message_edited(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    message_id: int,
+    edited_excerpt: str,
+    edited_at: str,
+) -> int:
+    _validate_content(edited_excerpt)
+    cursor = connection.execute(
+        """
+        UPDATE memory_receipts
+        SET edited_excerpt = ?, source_edited_at = ?
+        WHERE guild_id = ? AND message_id = ?
+        """,
+        (edited_excerpt.strip(), edited_at, int(guild_id), int(message_id)),
+    )
+    return int(cursor.rowcount)
+
+
+def mark_message_deleted(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    message_id: int,
+    deleted_at: str | None = None,
+) -> int:
+    cursor = connection.execute(
+        """
+        UPDATE memory_receipts
+        SET source_deleted_at = ?
+        WHERE guild_id = ? AND message_id = ?
+        """,
+        (deleted_at or utc_now_iso(), int(guild_id), int(message_id)),
+    )
+    return int(cursor.rowcount)
+
+
+def render_profile_for_prompt(memories: Iterable[MemoryRecord]) -> str:
+    """Render the full active profile for the future designated chat prompt."""
+
+    rows = list(memories)
+    if not rows:
+        return "No saved memories."
+    lines = ["MEMORY LEDGER — ACTIVE PROFILE"]
+    for memory in rows:
+        qualifier = "Unverified gossip" if memory.is_gossip else memory.epistemic_label
+        lines.append(f"- [{memory.category} | {qualifier}] {memory.summary}")
+    return "\n".join(lines)

--- a/tests/test_memory_ledger.py
+++ b/tests/test_memory_ledger.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
-from services import audit_log, memory_ledger
+from services import audit_log, coven_registry, memory_ledger
 from services.database import initialize_database, managed_connection
 
 
@@ -10,6 +12,16 @@ from services.database import initialize_database, managed_connection
 def database_path(tmp_path):
     path = tmp_path / "wilhelmina.sqlite3"
     initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        memory_ledger.initialize_memory_schema(connection)
     return path
 
 
@@ -17,10 +29,22 @@ def test_schema_initializes_idempotently(database_path):
     with managed_connection(database_path) as connection:
         memory_ledger.initialize_memory_schema(connection)
         memory_ledger.initialize_memory_schema(connection)
+        tables = {
+            row["name"]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
         versions = connection.execute(
             "SELECT version FROM schema_migrations ORDER BY version"
         ).fetchall()
 
+    assert {
+        "memory_ledger_settings",
+        "memory_records",
+        "memory_receipts",
+        "memory_contradictions",
+    }.issubset(tables)
     assert memory_ledger.MEMORY_SCHEMA_VERSION in [int(row["version"]) for row in versions]
 
 
@@ -30,7 +54,7 @@ def test_settings_default_active_and_persist_pause(database_path):
         assert settings.collection_enabled is True
 
         paused = memory_ledger.set_collection_enabled(
-            connection, guild_id=100, enabled=False, actor_user_id=1
+            connection, guild_id=100, enabled=False, actor_user_id=2
         )
         assert paused.collection_enabled is False
 
@@ -42,7 +66,7 @@ def test_settings_default_active_and_persist_pause(database_path):
 def test_designated_channel_persists(database_path):
     with managed_connection(database_path) as connection:
         settings = memory_ledger.set_wilhelmina_channel(
-            connection, guild_id=100, channel_id=555, actor_user_id=1
+            connection, guild_id=100, channel_id=555, actor_user_id=2
         )
         assert settings.wilhelmina_channel_id == 555
 
@@ -50,14 +74,14 @@ def test_designated_channel_persists(database_path):
         assert memory_ledger.get_or_create_settings(connection, 100).wilhelmina_channel_id == 555
 
 
-def test_duplicate_memory_merges_receipts(database_path):
+def test_duplicate_memory_merges_discord_receipts(database_path):
     kwargs = dict(
         guild_id=100,
         subject_user_id=2,
         category="Preference",
         epistemic_label="Fact",
         summary="Prefers black coffee",
-        actor_user_id=1,
+        actor_user_id=2,
     )
     with managed_connection(database_path) as connection:
         first = memory_ledger.add_memory(
@@ -85,10 +109,32 @@ def test_duplicate_memory_merges_receipts(database_path):
         assert second.created is False
         assert second.merged is True
         assert second.memory.id == first.memory.id
-        assert len(memory_ledger.list_receipts(connection, first.memory.id)) == 2
+        receipts = memory_ledger.list_receipts(connection, first.memory.id)
+        assert len(receipts) == 2
+        assert all(receipt.source_kind == "discord" for receipt in receipts)
 
 
-def test_new_normal_memory_replaces_old_same_category(database_path):
+def test_admin_memory_gets_admin_receipt(database_path):
+    with managed_connection(database_path) as connection:
+        created = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Admin note",
+            epistemic_label="Fact",
+            summary="Founder-added note",
+            actor_user_id=2,
+        )
+        receipts = memory_ledger.list_receipts(connection, created.memory.id)
+
+    assert len(receipts) == 1
+    assert receipts[0].source_kind == "admin"
+    assert receipts[0].message_id is None
+    assert receipts[0].channel_id is None
+    assert receipts[0].jump_url is None
+
+
+def test_new_normal_memory_permanently_replaces_old_same_category(database_path):
     with managed_connection(database_path) as connection:
         old = memory_ledger.add_memory(
             connection,
@@ -97,7 +143,7 @@ def test_new_normal_memory_replaces_old_same_category(database_path):
             category="Preference",
             epistemic_label="Fact",
             summary="Prefers tea",
-            actor_user_id=1,
+            actor_user_id=2,
         )
         new = memory_ledger.add_memory(
             connection,
@@ -106,20 +152,24 @@ def test_new_normal_memory_replaces_old_same_category(database_path):
             category="Preference",
             epistemic_label="Fact",
             summary="Prefers coffee",
-            actor_user_id=1,
+            actor_user_id=2,
         )
 
         assert new.replaced_memory_ids == (old.memory.id,)
+        assert memory_ledger.get_memory(connection, old.memory.id, required=False) is None
+        assert memory_ledger.list_receipts(connection, old.memory.id) == []
         active = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
-        all_records = memory_ledger.list_profile(
-            connection, guild_id=100, subject_user_id=2, include_inactive=True
-        )
         assert [record.summary for record in active] == ["Prefers coffee"]
-        assert len(all_records) == 2
-        assert memory_ledger.get_memory(connection, old.memory.id).active is False
+
+        events = audit_log.list_audit_events_for_target(
+            connection, 100, f"memory:{old.memory.id}"
+        )
+        replacement = next(event for event in events if event.action == "memory.replaced")
+        assert replacement.before_json is None
+        assert replacement.after_json is None
 
 
-def test_conflicting_gossip_is_preserved(database_path):
+def test_conflicting_gossip_is_preserved_and_linked(database_path):
     with managed_connection(database_path) as connection:
         first = memory_ledger.add_memory(
             connection,
@@ -128,7 +178,8 @@ def test_conflicting_gossip_is_preserved(database_path):
             category="Gossip",
             epistemic_label="Gossip",
             summary="Sam says Alex quit the project",
-            actor_user_id=1,
+            topic_key="alex.project.departure",
+            actor_user_id=2,
         )
         second = memory_ledger.add_memory(
             connection,
@@ -137,13 +188,51 @@ def test_conflicting_gossip_is_preserved(database_path):
             category="Gossip",
             epistemic_label="Gossip",
             summary="Jordan says Alex was removed from the project",
-            actor_user_id=1,
+            topic_key="alex.project.departure",
+            actor_user_id=2,
         )
 
         profile = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
-        assert first.memory.id != second.memory.id
-        assert len(profile) == 2
-        assert all(record.is_gossip for record in profile)
+        links = memory_ledger.list_contradictions(connection)
+
+    assert first.memory.id != second.memory.id
+    assert len(profile) == 2
+    assert all(record.is_gossip for record in profile)
+    assert len(links) == 1
+    assert {links[0].left_memory_id, links[0].right_memory_id} == {
+        first.memory.id,
+        second.memory.id,
+    }
+
+
+def test_deleting_gossip_cascades_contradiction_link(database_path):
+    with managed_connection(database_path) as connection:
+        first = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Gossip",
+            epistemic_label="Gossip",
+            summary="First claim",
+            topic_key="shared.topic",
+            actor_user_id=2,
+        )
+        memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Gossip",
+            epistemic_label="Gossip",
+            summary="Second claim",
+            topic_key="shared.topic",
+            actor_user_id=2,
+        )
+        assert len(memory_ledger.list_contradictions(connection)) == 1
+
+        memory_ledger.delete_memory(
+            connection, memory_id=first.memory.id, actor_user_id=2
+        )
+        assert memory_ledger.list_contradictions(connection) == []
 
 
 def test_delete_is_permanent_and_audit_contains_no_content(database_path):
@@ -155,7 +244,7 @@ def test_delete_is_permanent_and_audit_contains_no_content(database_path):
             category="Boundary",
             epistemic_label="Fact",
             summary="Do not mention spiders",
-            actor_user_id=1,
+            actor_user_id=2,
             author_user_id=2,
             channel_id=10,
             message_id=1000,
@@ -164,14 +253,11 @@ def test_delete_is_permanent_and_audit_contains_no_content(database_path):
             source_created_at="2026-07-27T00:00:00+00:00",
         )
         memory_ledger.delete_memory(
-            connection, memory_id=created.memory.id, actor_user_id=1
+            connection, memory_id=created.memory.id, actor_user_id=2
         )
 
         assert memory_ledger.get_memory(connection, created.memory.id, required=False) is None
-        receipts = connection.execute(
-            "SELECT * FROM memory_receipts WHERE memory_id = ?", (created.memory.id,)
-        ).fetchall()
-        assert receipts == []
+        assert memory_ledger.list_receipts(connection, created.memory.id) == []
         events = audit_log.list_audit_events_for_target(
             connection, 100, f"memory:{created.memory.id}"
         )
@@ -189,7 +275,7 @@ def test_receipt_tracks_edit_and_delete_without_erasing_excerpt(database_path):
             category="Interest",
             epistemic_label="Fact",
             summary="Interested in astronomy",
-            actor_user_id=1,
+            actor_user_id=2,
             author_user_id=2,
             channel_id=10,
             message_id=1000,
@@ -217,7 +303,10 @@ def test_receipt_tracks_edit_and_delete_without_erasing_excerpt(database_path):
         assert receipt.source_deleted_at == "2026-07-27T00:10:00+00:00"
 
 
-def test_blocked_sensitive_content_is_rejected(database_path):
+def test_prohibited_content_is_rejected_before_extraction(database_path):
+    with pytest.raises(memory_ledger.BlockedMemoryContent):
+        memory_ledger.validate_extractable_text("My password is hunter2")
+
     with managed_connection(database_path) as connection:
         with pytest.raises(memory_ledger.BlockedMemoryContent):
             memory_ledger.add_memory(
@@ -227,7 +316,39 @@ def test_blocked_sensitive_content_is_rejected(database_path):
                 category="Admin note",
                 epistemic_label="Fact",
                 summary="Their password is hunter2",
-                actor_user_id=1,
+                actor_user_id=2,
+            )
+
+
+def test_legacy_member_opt_out_is_inert(database_path):
+    with managed_connection(database_path) as connection:
+        connection.execute(
+            "UPDATE coven_profile_shells SET memory_opt_out = 1 WHERE guild_id = 100 AND user_id = 2"
+        )
+        created = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Interest",
+            epistemic_label="Fact",
+            summary="Likes old horror films",
+            actor_user_id=2,
+        )
+
+    assert created.created is True
+
+
+def test_profile_foreign_key_requires_registry_shell(database_path):
+    with managed_connection(database_path) as connection:
+        with pytest.raises(sqlite3.IntegrityError):
+            memory_ledger.add_memory(
+                connection,
+                guild_id=100,
+                subject_user_id=404,
+                category="Interest",
+                epistemic_label="Fact",
+                summary="Unknown member interest",
+                actor_user_id=2,
             )
 
 
@@ -240,7 +361,7 @@ def test_prompt_renderer_labels_gossip(database_path):
             category="Gossip",
             epistemic_label="Gossip",
             summary="Sam claims Alex stole the charger",
-            actor_user_id=1,
+            actor_user_id=2,
         )
         profile = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
 

--- a/tests/test_memory_ledger.py
+++ b/tests/test_memory_ledger.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from services import audit_log, memory_ledger
+from services.database import initialize_database, managed_connection
+
+
+@pytest.fixture()
+def database_path(tmp_path):
+    path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(path)
+    return path
+
+
+def test_schema_initializes_idempotently(database_path):
+    with managed_connection(database_path) as connection:
+        memory_ledger.initialize_memory_schema(connection)
+        memory_ledger.initialize_memory_schema(connection)
+        versions = connection.execute(
+            "SELECT version FROM schema_migrations ORDER BY version"
+        ).fetchall()
+
+    assert memory_ledger.MEMORY_SCHEMA_VERSION in [int(row["version"]) for row in versions]
+
+
+def test_settings_default_active_and_persist_pause(database_path):
+    with managed_connection(database_path) as connection:
+        settings = memory_ledger.get_or_create_settings(connection, 100)
+        assert settings.collection_enabled is True
+
+        paused = memory_ledger.set_collection_enabled(
+            connection, guild_id=100, enabled=False, actor_user_id=1
+        )
+        assert paused.collection_enabled is False
+
+    with managed_connection(database_path) as connection:
+        persisted = memory_ledger.get_or_create_settings(connection, 100)
+        assert persisted.collection_enabled is False
+
+
+def test_designated_channel_persists(database_path):
+    with managed_connection(database_path) as connection:
+        settings = memory_ledger.set_wilhelmina_channel(
+            connection, guild_id=100, channel_id=555, actor_user_id=1
+        )
+        assert settings.wilhelmina_channel_id == 555
+
+    with managed_connection(database_path) as connection:
+        assert memory_ledger.get_or_create_settings(connection, 100).wilhelmina_channel_id == 555
+
+
+def test_duplicate_memory_merges_receipts(database_path):
+    kwargs = dict(
+        guild_id=100,
+        subject_user_id=2,
+        category="Preference",
+        epistemic_label="Fact",
+        summary="Prefers black coffee",
+        actor_user_id=1,
+    )
+    with managed_connection(database_path) as connection:
+        first = memory_ledger.add_memory(
+            connection,
+            **kwargs,
+            author_user_id=2,
+            channel_id=10,
+            message_id=1000,
+            jump_url="https://discord.com/channels/100/10/1000",
+            excerpt="I prefer black coffee.",
+            source_created_at="2026-07-27T00:00:00+00:00",
+        )
+        second = memory_ledger.add_memory(
+            connection,
+            **kwargs,
+            author_user_id=2,
+            channel_id=11,
+            message_id=1001,
+            jump_url="https://discord.com/channels/100/11/1001",
+            excerpt="Black coffee, obviously.",
+            source_created_at="2026-07-27T01:00:00+00:00",
+        )
+
+        assert first.created is True
+        assert second.created is False
+        assert second.merged is True
+        assert second.memory.id == first.memory.id
+        assert len(memory_ledger.list_receipts(connection, first.memory.id)) == 2
+
+
+def test_new_normal_memory_replaces_old_same_category(database_path):
+    with managed_connection(database_path) as connection:
+        old = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Preference",
+            epistemic_label="Fact",
+            summary="Prefers tea",
+            actor_user_id=1,
+        )
+        new = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Preference",
+            epistemic_label="Fact",
+            summary="Prefers coffee",
+            actor_user_id=1,
+        )
+
+        assert new.replaced_memory_ids == (old.memory.id,)
+        active = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
+        all_records = memory_ledger.list_profile(
+            connection, guild_id=100, subject_user_id=2, include_inactive=True
+        )
+        assert [record.summary for record in active] == ["Prefers coffee"]
+        assert len(all_records) == 2
+        assert memory_ledger.get_memory(connection, old.memory.id).active is False
+
+
+def test_conflicting_gossip_is_preserved(database_path):
+    with managed_connection(database_path) as connection:
+        first = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Gossip",
+            epistemic_label="Gossip",
+            summary="Sam says Alex quit the project",
+            actor_user_id=1,
+        )
+        second = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Gossip",
+            epistemic_label="Gossip",
+            summary="Jordan says Alex was removed from the project",
+            actor_user_id=1,
+        )
+
+        profile = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
+        assert first.memory.id != second.memory.id
+        assert len(profile) == 2
+        assert all(record.is_gossip for record in profile)
+
+
+def test_delete_is_permanent_and_audit_contains_no_content(database_path):
+    with managed_connection(database_path) as connection:
+        created = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Boundary",
+            epistemic_label="Fact",
+            summary="Do not mention spiders",
+            actor_user_id=1,
+            author_user_id=2,
+            channel_id=10,
+            message_id=1000,
+            jump_url="https://discord.com/channels/100/10/1000",
+            excerpt="Do not mention spiders.",
+            source_created_at="2026-07-27T00:00:00+00:00",
+        )
+        memory_ledger.delete_memory(
+            connection, memory_id=created.memory.id, actor_user_id=1
+        )
+
+        assert memory_ledger.get_memory(connection, created.memory.id, required=False) is None
+        receipts = connection.execute(
+            "SELECT * FROM memory_receipts WHERE memory_id = ?", (created.memory.id,)
+        ).fetchall()
+        assert receipts == []
+        events = audit_log.list_audit_events_for_target(
+            connection, 100, f"memory:{created.memory.id}"
+        )
+        deletion = next(event for event in events if event.action == "memory.deleted")
+        assert deletion.before_json is None
+        assert deletion.after_json is None
+
+
+def test_receipt_tracks_edit_and_delete_without_erasing_excerpt(database_path):
+    with managed_connection(database_path) as connection:
+        created = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Interest",
+            epistemic_label="Fact",
+            summary="Interested in astronomy",
+            actor_user_id=1,
+            author_user_id=2,
+            channel_id=10,
+            message_id=1000,
+            jump_url="https://discord.com/channels/100/10/1000",
+            excerpt="I like astronomy.",
+            source_created_at="2026-07-27T00:00:00+00:00",
+        )
+        assert memory_ledger.mark_message_edited(
+            connection,
+            guild_id=100,
+            message_id=1000,
+            edited_excerpt="I love astronomy.",
+            edited_at="2026-07-27T00:05:00+00:00",
+        ) == 1
+        assert memory_ledger.mark_message_deleted(
+            connection,
+            guild_id=100,
+            message_id=1000,
+            deleted_at="2026-07-27T00:10:00+00:00",
+        ) == 1
+
+        receipt = memory_ledger.list_receipts(connection, created.memory.id)[0]
+        assert receipt.original_excerpt == "I like astronomy."
+        assert receipt.edited_excerpt == "I love astronomy."
+        assert receipt.source_deleted_at == "2026-07-27T00:10:00+00:00"
+
+
+def test_blocked_sensitive_content_is_rejected(database_path):
+    with managed_connection(database_path) as connection:
+        with pytest.raises(memory_ledger.BlockedMemoryContent):
+            memory_ledger.add_memory(
+                connection,
+                guild_id=100,
+                subject_user_id=2,
+                category="Admin note",
+                epistemic_label="Fact",
+                summary="Their password is hunter2",
+                actor_user_id=1,
+            )
+
+
+def test_prompt_renderer_labels_gossip(database_path):
+    with managed_connection(database_path) as connection:
+        memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Gossip",
+            epistemic_label="Gossip",
+            summary="Sam claims Alex stole the charger",
+            actor_user_id=1,
+        )
+        profile = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
+
+    rendered = memory_ledger.render_profile_for_prompt(profile)
+    assert "Unverified gossip" in rendered
+    assert "Sam claims Alex stole the charger" in rendered

--- a/tests/test_memory_ledger.py
+++ b/tests/test_memory_ledger.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sqlite3
-
 import pytest
 
 from services import audit_log, memory_ledger


### PR DESCRIPTION
## Summary

- records the complete Memory Ledger product, privacy, receipt, contradiction, and designated-chat contract
- authorizes Memory Ledger work in repository governance documentation
- adds schema version 6 and the SQLite persistence service
- adds persistent collection settings and designated Wilhelmina channel storage
- adds memory CRUD, duplicate merging, permanent ordinary replacement, gossip preservation, contradiction links, and profile rendering
- adds distinct Discord and admin receipt types without fabricated message metadata
- adds local prohibited-content validation that must run before any future OpenAI extraction request
- treats the legacy member `memory_opt_out` column as inert compatibility data under the founder-controlled collection policy
- adds cascading Registry/profile, receipt, and contradiction relationships
- adds expanded tests for persistence, receipts, replacement, gossip links, deletion, privacy validation, and Registry linkage

## Runtime scope

This PR does **not** enable live message collection. It does not add Discord listeners, `/memory-admin` commands, AI extraction, Message Content Intent handling, or open-chat integration.

## Review resolutions

- Memory Ledger work is now formally in scope.
- The member-level opt-out concept is disabled; the legacy column remains inert for compatibility.
- Prohibited information is rejected locally before any future external extractor call.
- Admin-created memories receive an admin receipt.
- Contradiction links cascade when either memory is deleted.
- Ordinary replacement permanently deletes the superseded record and receipts.
- Memory records require an existing Coven Registry profile shell.

## Validation

- `ruff check .` — passed
- `pytest` — passed
- GitHub Actions CI run `30975721440` — passed
- all review threads resolved

## Next build tranche

Build the founder/admin-only ephemeral `/memory-admin` command surface: status, pause, resume, designated channel, profile, search, add, edit, delete, and receipt operations. Automatic collection and OpenAI extraction remain the following tranche.