### PR TITLE
Build the member identity foundation

### DIFF
--- a/cogs/member_identity.py
+++ b/cogs/member_identity.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from services import coven_registry as registry
+from services import guild_config
+from services import member_profiles
+from services import rules as rules_service
+from services.database import initialize_database, managed_connection
+from services.member_identity import MemberIdentityError
+
+logger = logging.getLogger("wilhelmina.identity")
+CONSENT_PHRASE = "I CONSENT"
+STALE_COVENANT = "This covenant is outdated. Use `/rules` for the current one."
+
+
+def _database_path(bot: commands.Bot) -> Path:
+    return Path(bot.settings.database_path)
+
+
+def _home_guild_id(bot: commands.Bot) -> int | None:
+    value = getattr(bot.settings, "home_guild_id", None)
+    return int(value) if value is not None else None
+
+
+def _guild_today(connection, guild_id: int):
+    config = guild_config.ensure_guild_config(connection, guild_id)
+    return datetime.now(ZoneInfo(config.timezone)).date()
+
+
+def _ensure_registry_entry(connection, member: discord.Member) -> registry.RegistryEntry:
+    existing = registry.get_entry(
+        connection,
+        guild_id=member.guild.id,
+        user_id=member.id,
+        required=False,
+    )
+    if existing is not None:
+        return existing
+    result = registry.register_pending_member(
+        connection,
+        guild_id=member.guild.id,
+        user_id=member.id,
+        display_name=member.display_name,
+        joined_at=member.joined_at.isoformat() if member.joined_at else None,
+        actor_user_id=member.id,
+    )
+    return result.entry
+
+
+def _is_private_identity_admin(interaction: discord.Interaction, bot: commands.Bot) -> bool:
+    if interaction.guild_id is None or interaction.guild_id != _home_guild_id(bot):
+        return False
+    if not isinstance(interaction.user, discord.Member):
+        return False
+    if interaction.user.guild_permissions.manage_guild:
+        return True
+    initialize_database(_database_path(bot))
+    with managed_connection(_database_path(bot)) as connection:
+        settings = registry.get_settings(connection, interaction.guild_id)
+    return settings is not None and settings.founder_user_id == interaction.user.id
+
+
+class MemberInductionModal(discord.ui.Modal, title="Complete your induction"):
+    preferred_name = discord.ui.TextInput(
+        label="What should Wilhelmina call you?",
+        placeholder="The name you actually want used",
+        required=True,
+        max_length=80,
+    )
+    birth_date = discord.ui.TextInput(
+        label="Full birth date",
+        placeholder="YYYY-MM-DD",
+        required=True,
+        min_length=10,
+        max_length=10,
+    )
+    consent = discord.ui.TextInput(
+        label="Type I CONSENT to adult memory",
+        placeholder=CONSENT_PHRASE,
+        required=True,
+        max_length=20,
+    )
+
+    def __init__(self, *, bot: commands.Bot, guild_id: int, rules_version_id: int) -> None:
+        super().__init__(timeout=600)
+        self.bot = bot
+        self.guild_id = int(guild_id)
+        self.rules_version_id = int(rules_version_id)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if interaction.guild_id != self.guild_id or not isinstance(interaction.user, discord.Member):
+            await interaction.response.send_message(
+                "Finish induction inside Wilhelmina's configured server.",
+                ephemeral=True,
+            )
+            return
+        if self.guild_id != _home_guild_id(self.bot):
+            await interaction.response.send_message(
+                "This induction belongs to a different server.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        initialize_database(_database_path(self.bot))
+        try:
+            with managed_connection(_database_path(self.bot)) as connection:
+                rules = rules_service.get_rules_version_by_id(connection, self.rules_version_id)
+                if not rules.is_active or rules.guild_id != self.guild_id:
+                    await interaction.followup.send(STALE_COVENANT, ephemeral=True)
+                    return
+
+                if str(self.consent.value).strip().upper() != CONSENT_PHRASE:
+                    raise MemberIdentityError(
+                        f"Type {CONSENT_PHRASE} exactly to confirm the adult memory experience."
+                    )
+
+                _ensure_registry_entry(connection, interaction.user)
+                member_profiles.save_member_identity(
+                    connection,
+                    guild_id=self.guild_id,
+                    user_id=interaction.user.id,
+                    discord_display_name=interaction.user.display_name,
+                    preferred_name=str(self.preferred_name.value),
+                    birth_date=str(self.birth_date.value),
+                    today=_guild_today(connection, self.guild_id),
+                    adult_memory_consent=True,
+                    actor_user_id=interaction.user.id,
+                )
+                acceptance = rules_service.accept_rules_version(
+                    connection,
+                    guild_id=self.guild_id,
+                    user_id=interaction.user.id,
+                    rules_version_id=rules.id,
+                    accepted_via="button+identity",
+                    actor_user_id=interaction.user.id,
+                )
+        except (MemberIdentityError, rules_service.RulesError, registry.RegistryError) as exc:
+            await interaction.followup.send(str(exc), ephemeral=True)
+            return
+        except Exception:
+            logger.exception(
+                "identity_induction_failed guild_id=%s user_id=%s",
+                self.guild_id,
+                interaction.user.id,
+            )
+            await interaction.followup.send(
+                "Induction hit a technical failure. Nothing half-recorded was kept.",
+                ephemeral=True,
+            )
+            return
+
+        if acceptance.already_accepted:
+            message = "Your identity profile is recorded, and that covenant was already accepted."
+        else:
+            message = "Induction complete. I have the name you gave me, your screen name, and your birthday."
+        await interaction.followup.send(message, ephemeral=True)
+
+
+async def begin_covenant_acceptance(
+    interaction: discord.Interaction,
+    *,
+    bot: commands.Bot,
+    guild_id: int,
+    rules_version_id: int,
+) -> None:
+    """Accept directly for known adults; otherwise collect the private identity profile first."""
+
+    initialize_database(_database_path(bot))
+    with managed_connection(_database_path(bot)) as connection:
+        rules = rules_service.get_rules_version_by_id(connection, rules_version_id)
+        if not rules.is_active or rules.guild_id != int(guild_id):
+            await interaction.response.send_message(STALE_COVENANT, ephemeral=True)
+            return
+        profile = member_profiles.get_member_identity(
+            connection,
+            guild_id=int(guild_id),
+            user_id=interaction.user.id,
+            required=False,
+        )
+        if profile is not None:
+            result = rules_service.accept_rules_version(
+                connection,
+                guild_id=int(guild_id),
+                user_id=interaction.user.id,
+                rules_version_id=rules.id,
+                accepted_via="button",
+                actor_user_id=interaction.user.id,
+            )
+            message = (
+                "Already accepted. The ledger did not forget you."
+                if result.already_accepted
+                else "Recorded. You accepted the covenant."
+            )
+            await interaction.response.send_message(message, ephemeral=True)
+            return
+
+    await interaction.response.send_modal(
+        MemberInductionModal(
+            bot=bot,
+            guild_id=guild_id,
+            rules_version_id=rules_version_id,
+        )
+    )
+
+
+class MemberIdentityEvents(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member) -> None:
+        if after.bot or after.guild.id != _home_guild_id(self.bot):
+            return
+        if before.display_name == after.display_name:
+            return
+
+        initialize_database(_database_path(self.bot))
+        try:
+            with managed_connection(_database_path(self.bot)) as connection:
+                if registry.get_entry(
+                    connection,
+                    guild_id=after.guild.id,
+                    user_id=after.id,
+                    required=False,
+                ) is None:
+                    return
+                member_profiles.refresh_discord_display_name(
+                    connection,
+                    guild_id=after.guild.id,
+                    user_id=after.id,
+                    discord_display_name=after.display_name,
+                    actor_user_id=self.bot.user.id if self.bot.user else None,
+                )
+        except Exception:
+            logger.exception(
+                "identity_display_name_refresh_failed guild_id=%s user_id=%s",
+                after.guild.id,
+                after.id,
+            )
+
+
+@app_commands.guild_only()
+class MemberIdentityAdmin(commands.GroupCog, group_name="identity-admin"):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _guard(self, interaction: discord.Interaction) -> bool:
+        if _is_private_identity_admin(interaction, self.bot):
+            return True
+        await interaction.response.send_message(
+            "That identity file is founder/admin only.",
+            ephemeral=True,
+        )
+        return False
+
+    @app_commands.command(name="show", description="Privately inspect one member identity profile.")
+    async def show(self, interaction: discord.Interaction, member: discord.Member) -> None:
+        if not await self._guard(interaction):
+            return
+
+        initialize_database(_database_path(self.bot))
+        with managed_connection(_database_path(self.bot)) as connection:
+            profile = member_profiles.get_member_identity(
+                connection,
+                guild_id=interaction.guild_id,
+                user_id=member.id,
+                required=False,
+            )
+            if profile is None:
+                await interaction.response.send_message(
+                    "That member has not completed the private identity profile.",
+                    ephemeral=True,
+                )
+                return
+            context = profile.trusted_chat_context(
+                on_date=_guild_today(connection, interaction.guild_id)
+            )
+
+        await interaction.response.send_message(
+            "**Private identity profile**\n"
+            "```txt\n"
+            f"discord_name = {context.discord_display_name}\n"
+            f"preferred    = {context.preferred_name}\n"
+            f"birth_date   = {context.birth_date}\n"
+            f"age          = {context.age}\n"
+            f"consent_at   = {profile.adult_memory_consent_at}\n"
+            "```",
+            ephemeral=True,
+        )
+
+
+async def install_member_identity(bot: commands.Bot) -> None:
+    if bot.get_cog("MemberIdentityEvents") is None:
+        await bot.add_cog(MemberIdentityEvents(bot))
+    if bot.get_cog("MemberIdentityAdmin") is None:
+        await bot.add_cog(MemberIdentityAdmin(bot))

--- a/cogs/rules.py
+++ b/cogs/rules.py
@@ -6,15 +6,13 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from cogs.member_identity import begin_covenant_acceptance, install_member_identity
 from services import rules as rules_service
 from services.database import initialize_database, managed_connection
 from services.persona import render_persona_text
 
 RULES_FIELD_LIMIT = 900
 NO_ACTIVE_COVENANT = "No active covenant is configured yet."
-STALE_COVENANT = "This covenant is outdated. Use `/rules` for the current one."
-ACCEPTED_COVENANT = "Recorded. You accepted the covenant. Try honoring it."
-ALREADY_ACCEPTED_COVENANT = "Already accepted. The ledger did not forget you."
 MISSING_HOME_GUILD = "This is not configured yet. Someone with keys needs to fix that."
 DEFAULT_ACCEPT_LABEL = "I Accept the Covenant"
 
@@ -56,7 +54,10 @@ def _guild_id(interaction: discord.Interaction) -> int:
 
 def _chunk_text(value: str) -> list[str]:
     text = value.strip() or "No rules text has been written yet."
-    return [text[index : index + RULES_FIELD_LIMIT] for index in range(0, len(text), RULES_FIELD_LIMIT)]
+    return [
+        text[index : index + RULES_FIELD_LIMIT]
+        for index in range(0, len(text), RULES_FIELD_LIMIT)
+    ]
 
 
 async def build_rules_embed(
@@ -116,40 +117,19 @@ class CovenantGateView(discord.ui.View):
         return False
 
     @discord.ui.button(label=DEFAULT_ACCEPT_LABEL, style=discord.ButtonStyle.success)
-    async def accept_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+    async def accept_button(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
         if not await _guard_home_guild(interaction, self.bot):
             return
-
-        await interaction.response.defer(ephemeral=True, thinking=True)
-        initialize_database(_database_path(self.bot))
-        with managed_connection(_database_path(self.bot)) as connection:
-            rules = rules_service.get_rules_version_by_id(connection, self.rules_version_id)
-            if not rules.is_active:
-                await interaction.followup.send(STALE_COVENANT, ephemeral=True)
-                return
-            result = rules_service.accept_rules_version(
-                connection,
-                guild_id=self.guild_id,
-                user_id=interaction.user.id,
-                rules_version_id=rules.id,
-                accepted_via="button",
-                actor_user_id=interaction.user.id,
-            )
-
-        message = await render_persona_text(
-            feature_key="rules_acceptance",
-            task=(
-                "Write one short confirmation that the user accepted the server covenant. "
-                "If they had already accepted, acknowledge that without scolding."
-            ),
-            context={
-                "guild": interaction.guild.name if interaction.guild else "unknown guild",
-                "version": rules.version_tag,
-                "already_accepted": result.already_accepted,
-            },
-            fallback=(ALREADY_ACCEPTED_COVENANT if result.already_accepted else ACCEPTED_COVENANT),
+        await begin_covenant_acceptance(
+            interaction,
+            bot=self.bot,
+            guild_id=self.guild_id,
+            rules_version_id=self.rules_version_id,
         )
-        await interaction.followup.send(message, ephemeral=True)
 
 
 @app_commands.guild_only()
@@ -169,14 +149,22 @@ class Rules(commands.Cog):
         initialize_database(_database_path(self.bot))
         try:
             with managed_connection(_database_path(self.bot)) as connection:
-                active_rules = rules_service.get_active_rules(connection, guild_id=_guild_id(interaction))
+                active_rules = rules_service.get_active_rules(
+                    connection,
+                    guild_id=_guild_id(interaction),
+                )
         except rules_service.RulesNotConfigured:
             await interaction.edit_original_response(content=NO_ACTIVE_COVENANT)
             return
         if active_rules is None:
             await interaction.edit_original_response(content=NO_ACTIVE_COVENANT)
             return
-        embed = await build_rules_embed(interaction=interaction, rules=active_rules, mode="preview")
+
+        embed = await build_rules_embed(
+            interaction=interaction,
+            rules=active_rules,
+            mode="preview",
+        )
         view = CovenantGateView(
             bot=self.bot,
             guild_id=_guild_id(interaction),
@@ -271,8 +259,15 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
             ephemeral=True,
         )
 
-    @app_commands.command(name="preview", description="Preview a covenant version without publishing it.")
-    async def preview(self, interaction: discord.Interaction, version_tag: str | None = None) -> None:
+    @app_commands.command(
+        name="preview",
+        description="Preview a covenant version without publishing it.",
+    )
+    async def preview(
+        self,
+        interaction: discord.Interaction,
+        version_tag: str | None = None,
+    ) -> None:
         if not await self._guard(interaction):
             return
 
@@ -287,7 +282,10 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
                         version_tag=version_tag,
                     )
                 else:
-                    rules = rules_service.get_active_rules(connection, guild_id=_guild_id(interaction))
+                    rules = rules_service.get_active_rules(
+                        connection,
+                        guild_id=_guild_id(interaction),
+                    )
         except rules_service.RulesError as exc:
             await interaction.edit_original_response(content=f"Rules error: {exc}")
             return
@@ -296,11 +294,19 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
             await interaction.edit_original_response(content="No covenant version is available.")
             return
 
-        embed = await build_rules_embed(interaction=interaction, rules=rules, mode="admin-preview")
+        embed = await build_rules_embed(
+            interaction=interaction,
+            rules=rules,
+            mode="admin-preview",
+        )
         await interaction.edit_original_response(embed=embed)
 
     @app_commands.command(name="publish", description="Publish the active Covenant Gate to a channel.")
-    async def publish(self, interaction: discord.Interaction, channel: discord.TextChannel) -> None:
+    async def publish(
+        self,
+        interaction: discord.Interaction,
+        channel: discord.TextChannel,
+    ) -> None:
         if not await self._guard(interaction):
             return
 
@@ -308,7 +314,10 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
         initialize_database(_database_path(self.bot))
         try:
             with managed_connection(_database_path(self.bot)) as connection:
-                active_rules = rules_service.get_active_rules(connection, guild_id=_guild_id(interaction))
+                active_rules = rules_service.get_active_rules(
+                    connection,
+                    guild_id=_guild_id(interaction),
+                )
         except rules_service.RulesError as exc:
             await interaction.edit_original_response(content=f"Rules error: {exc}")
             return
@@ -317,7 +326,11 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
             await interaction.edit_original_response(content=NO_ACTIVE_COVENANT)
             return
 
-        embed = await build_rules_embed(interaction=interaction, rules=active_rules, mode="publish")
+        embed = await build_rules_embed(
+            interaction=interaction,
+            rules=active_rules,
+            mode="publish",
+        )
         view = CovenantGateView(
             bot=self.bot,
             guild_id=_guild_id(interaction),
@@ -349,7 +362,10 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
         initialize_database(_database_path(self.bot))
         try:
             with managed_connection(_database_path(self.bot)) as connection:
-                summary = rules_service.summarize_acceptance(connection, guild_id=_guild_id(interaction))
+                summary = rules_service.summarize_acceptance(
+                    connection,
+                    guild_id=_guild_id(interaction),
+                )
         except rules_service.RulesError as exc:
             await interaction.response.send_message(f"Rules error: {exc}", ephemeral=True)
             return
@@ -372,7 +388,10 @@ class RulesAdmin(commands.GroupCog, group_name="rules-admin"):
         initialize_database(_database_path(self.bot))
         try:
             with managed_connection(_database_path(self.bot)) as connection:
-                active_rules = rules_service.get_active_rules(connection, guild_id=_guild_id(interaction))
+                active_rules = rules_service.get_active_rules(
+                    connection,
+                    guild_id=_guild_id(interaction),
+                )
                 acceptance = rules_service.get_acceptance_for_user(
                     connection,
                     guild_id=_guild_id(interaction),
@@ -457,4 +476,5 @@ def _register_persistent_views(bot: commands.Bot) -> None:
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Rules(bot))
     await bot.add_cog(RulesAdmin(bot))
+    await install_member_identity(bot)
     _register_persistent_views(bot)

--- a/docs/member_identity.md
+++ b/docs/member_identity.md
@@ -1,0 +1,31 @@
+# Member identity contract
+
+Wilhelmina keeps two distinct names for every inducted adult member:
+
+- the current Discord display name, refreshed when Discord changes it;
+- the preferred name the member gives Wilhelmina during induction.
+
+Neither name replaces the other. Approved memory-aware chat may use either name and may explicitly notice the difference between them.
+
+## Birth date and age
+
+Induction collects the member's full self-reported birth date in ISO `YYYY-MM-DD` format. The full date is the canonical source of truth. Age is never stored as a permanent number because it becomes stale; trusted local code recalculates it using the configured server date.
+
+The trusted identity context for the designated Wilhelmina channel and direct conversations in which she participates contains:
+
+- current Discord display name;
+- preferred name;
+- full birth date;
+- current calculated age.
+
+This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her adult conversational persona.
+
+The same information must not be copied into general-purpose commands, operational logs, public Registry cards, error messages, or unrelated AI features. Local code decides whether the current channel or DM is approved before constructing the trusted identity context.
+
+## Adult gate
+
+A birth date that calculates to under eighteen blocks completion of the adult induction flow. Future dates and malformed dates are rejected. February 29 birthdays use February 28 as the anniversary in non-leap years for age calculation.
+
+## OpenAI boundary
+
+The model receives identity data only through an explicit allow-listed context assembled by trusted Python code. The model does not decide whose profile to load, whether the channel is authorised, or how age is calculated. OpenAI requests remain asynchronous, response storage remains disabled, and prompts or identity values must not enter operational logs.

--- a/services/member_identity.py
+++ b/services/member_identity.py
@@ -22,6 +22,26 @@ def _clean_name(value: str, *, field_name: str, max_length: int) -> str:
     return normalized
 
 
+def normalize_discord_display_name(value: str) -> str:
+    """Normalize a Discord-visible member name for trusted identity storage."""
+
+    return _clean_name(
+        value,
+        field_name="discord_display_name",
+        max_length=MAX_DISPLAY_NAME_LENGTH,
+    )
+
+
+def normalize_preferred_name(value: str) -> str:
+    """Normalize the separate name a member asks Wilhelmina to use."""
+
+    return _clean_name(
+        value,
+        field_name="preferred_name",
+        max_length=MAX_PREFERRED_NAME_LENGTH,
+    )
+
+
 def parse_birth_date(value: str | date) -> date:
     """Parse an ISO birth date without calculating or storing a stale age."""
 
@@ -87,16 +107,8 @@ class MemberIdentity:
                 f"member must be at least {minimum_age} years old for the adult server experience"
             )
         return cls(
-            discord_display_name=_clean_name(
-                discord_display_name,
-                field_name="discord_display_name",
-                max_length=MAX_DISPLAY_NAME_LENGTH,
-            ),
-            preferred_name=_clean_name(
-                preferred_name,
-                field_name="preferred_name",
-                max_length=MAX_PREFERRED_NAME_LENGTH,
-            ),
+            discord_display_name=normalize_discord_display_name(discord_display_name),
+            preferred_name=normalize_preferred_name(preferred_name),
             birth_date=parsed_birth_date,
         )
 

--- a/services/member_identity.py
+++ b/services/member_identity.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from calendar import isleap
+from dataclasses import dataclass
+from datetime import date
+
+MAX_PREFERRED_NAME_LENGTH = 80
+MAX_DISPLAY_NAME_LENGTH = 100
+ADULT_AGE = 18
+
+
+class MemberIdentityError(ValueError):
+    """Raised when member-supplied identity data is invalid."""
+
+
+def _clean_name(value: str, *, field_name: str, max_length: int) -> str:
+    normalized = " ".join((value or "").split())
+    if not normalized:
+        raise MemberIdentityError(f"{field_name} cannot be empty")
+    if len(normalized) > max_length:
+        raise MemberIdentityError(f"{field_name} must be {max_length} characters or fewer")
+    return normalized
+
+
+def parse_birth_date(value: str | date) -> date:
+    """Parse an ISO birth date without calculating or storing a stale age."""
+
+    if isinstance(value, date):
+        return value
+    try:
+        return date.fromisoformat((value or "").strip())
+    except ValueError as exc:
+        raise MemberIdentityError("birth_date must use YYYY-MM-DD") from exc
+
+
+def _birthday_in_year(birth_date: date, year: int) -> date:
+    """Return the birthday anniversary, treating Feb 29 as Feb 28 in non-leap years."""
+
+    if birth_date.month == 2 and birth_date.day == 29 and not isleap(year):
+        return date(year, 2, 28)
+    return birth_date.replace(year=year)
+
+
+def calculate_age(birth_date: date, *, on_date: date) -> int:
+    """Calculate age locally from the full birth date for a specific server date."""
+
+    if birth_date > on_date:
+        raise MemberIdentityError("birth_date cannot be in the future")
+    age = on_date.year - birth_date.year
+    if on_date < _birthday_in_year(birth_date, on_date.year):
+        age -= 1
+    return age
+
+
+@dataclass(frozen=True)
+class TrustedIdentityContext:
+    """Identity fields allowed in designated Wilhelmina chat and participating DMs."""
+
+    discord_display_name: str
+    preferred_name: str
+    birth_date: str
+    age: int
+
+
+@dataclass(frozen=True)
+class MemberIdentity:
+    """Member-supplied identity plus the current Discord-visible name."""
+
+    discord_display_name: str
+    preferred_name: str
+    birth_date: date
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        discord_display_name: str,
+        preferred_name: str,
+        birth_date: str | date,
+        today: date,
+        minimum_age: int = ADULT_AGE,
+    ) -> "MemberIdentity":
+        parsed_birth_date = parse_birth_date(birth_date)
+        age = calculate_age(parsed_birth_date, on_date=today)
+        if age < minimum_age:
+            raise MemberIdentityError(
+                f"member must be at least {minimum_age} years old for the adult server experience"
+            )
+        return cls(
+            discord_display_name=_clean_name(
+                discord_display_name,
+                field_name="discord_display_name",
+                max_length=MAX_DISPLAY_NAME_LENGTH,
+            ),
+            preferred_name=_clean_name(
+                preferred_name,
+                field_name="preferred_name",
+                max_length=MAX_PREFERRED_NAME_LENGTH,
+            ),
+            birth_date=parsed_birth_date,
+        )
+
+    def age_on(self, on_date: date) -> int:
+        return calculate_age(self.birth_date, on_date=on_date)
+
+    def trusted_chat_context(self, *, on_date: date) -> TrustedIdentityContext:
+        """Expose both names, full birth date, and current age to approved chat assembly."""
+
+        return TrustedIdentityContext(
+            discord_display_name=self.discord_display_name,
+            preferred_name=self.preferred_name,
+            birth_date=self.birth_date.isoformat(),
+            age=self.age_on(on_date),
+        )

--- a/services/member_profiles.py
+++ b/services/member_profiles.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+
+from services import audit_log
+from services import coven_registry as registry
+from services.database import utc_now_iso
+from services.member_identity import (
+    MemberIdentity,
+    MemberIdentityError,
+    TrustedIdentityContext,
+    normalize_discord_display_name,
+)
+
+MEMBER_IDENTITY_SCHEMA_VERSION = 7
+
+
+class MemberIdentityProfileNotFound(LookupError):
+    """Raised when a member has no completed identity profile."""
+
+
+@dataclass(frozen=True)
+class StoredMemberIdentity:
+    """Private persisted identity joined with the current Discord-visible name."""
+
+    guild_id: int
+    user_id: int
+    discord_display_name: str
+    preferred_name: str
+    birth_date: str
+    adult_memory_consent_at: str
+    created_at: str
+    updated_at: str
+
+    def to_domain(self, *, today: date) -> MemberIdentity:
+        """Revalidate persisted data before it enters a trusted conversational context."""
+
+        return MemberIdentity.create(
+            discord_display_name=self.discord_display_name,
+            preferred_name=self.preferred_name,
+            birth_date=self.birth_date,
+            today=today,
+        )
+
+    def trusted_chat_context(self, *, on_date: date) -> TrustedIdentityContext:
+        return self.to_domain(today=on_date).trusted_chat_context(on_date=on_date)
+
+
+SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS coven_member_identity_profiles (
+        guild_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL,
+        preferred_name TEXT NOT NULL CHECK (
+            length(trim(preferred_name)) BETWEEN 1 AND 80
+        ),
+        birth_date TEXT NOT NULL CHECK (birth_date GLOB '????-??-??'),
+        adult_memory_consent_at TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (guild_id, user_id),
+        FOREIGN KEY (guild_id, user_id)
+            REFERENCES coven_registry_entries (guild_id, user_id)
+            ON DELETE CASCADE
+    )
+    """,
+)
+
+
+def initialize_member_identity_schema(connection: sqlite3.Connection) -> None:
+    """Create the private member-identity table idempotently."""
+
+    registry.initialize_registry_schema(connection)
+    for statement in SCHEMA_STATEMENTS:
+        connection.execute(statement)
+    connection.execute(
+        """
+        INSERT OR IGNORE INTO schema_migrations (version, applied_at)
+        VALUES (?, ?)
+        """,
+        (MEMBER_IDENTITY_SCHEMA_VERSION, utc_now_iso()),
+    )
+
+
+def _row_to_identity(row: sqlite3.Row) -> StoredMemberIdentity:
+    return StoredMemberIdentity(
+        guild_id=int(row["guild_id"]),
+        user_id=int(row["user_id"]),
+        discord_display_name=str(row["display_name"]),
+        preferred_name=str(row["preferred_name"]),
+        birth_date=str(row["birth_date"]),
+        adult_memory_consent_at=str(row["adult_memory_consent_at"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def get_member_identity(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    required: bool = False,
+) -> StoredMemberIdentity | None:
+    """Load one private identity profile, scoped to its Discord guild."""
+
+    initialize_member_identity_schema(connection)
+    row = connection.execute(
+        """
+        SELECT
+            profile.guild_id,
+            profile.user_id,
+            entry.display_name,
+            profile.preferred_name,
+            profile.birth_date,
+            profile.adult_memory_consent_at,
+            profile.created_at,
+            profile.updated_at
+        FROM coven_member_identity_profiles AS profile
+        JOIN coven_registry_entries AS entry
+          ON entry.guild_id = profile.guild_id
+         AND entry.user_id = profile.user_id
+        WHERE profile.guild_id = ? AND profile.user_id = ?
+        """,
+        (int(guild_id), int(user_id)),
+    ).fetchone()
+    if row is None and required:
+        raise MemberIdentityProfileNotFound("Member identity profile has not been completed")
+    return _row_to_identity(row) if row is not None else None
+
+
+def save_member_identity(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    discord_display_name: str,
+    preferred_name: str,
+    birth_date: str | date,
+    today: date,
+    adult_memory_consent: bool,
+    actor_user_id: int,
+    consent_at: str | None = None,
+) -> StoredMemberIdentity:
+    """Validate and persist both names, full birth date, and adult-memory consent."""
+
+    initialize_member_identity_schema(connection)
+    if not adult_memory_consent:
+        raise MemberIdentityError("adult memory consent is required to complete induction")
+
+    identity = MemberIdentity.create(
+        discord_display_name=discord_display_name,
+        preferred_name=preferred_name,
+        birth_date=birth_date,
+        today=today,
+    )
+    entry = registry.get_entry(
+        connection,
+        guild_id=int(guild_id),
+        user_id=int(user_id),
+        required=True,
+    )
+    assert entry is not None
+    before = get_member_identity(
+        connection,
+        guild_id=int(guild_id),
+        user_id=int(user_id),
+        required=False,
+    )
+    timestamp = utc_now_iso()
+    consent_timestamp = (consent_at or timestamp).strip()
+    if not consent_timestamp:
+        raise MemberIdentityError("consent_at cannot be empty")
+
+    connection.execute(
+        """
+        UPDATE coven_registry_entries
+        SET display_name = ?, updated_at = ?
+        WHERE guild_id = ? AND user_id = ?
+        """,
+        (
+            identity.discord_display_name,
+            timestamp,
+            int(guild_id),
+            int(user_id),
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO coven_member_identity_profiles (
+            guild_id,
+            user_id,
+            preferred_name,
+            birth_date,
+            adult_memory_consent_at,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (guild_id, user_id) DO UPDATE SET
+            preferred_name = excluded.preferred_name,
+            birth_date = excluded.birth_date,
+            adult_memory_consent_at = excluded.adult_memory_consent_at,
+            updated_at = excluded.updated_at
+        """,
+        (
+            int(guild_id),
+            int(user_id),
+            identity.preferred_name,
+            identity.birth_date.isoformat(),
+            consent_timestamp,
+            timestamp,
+            timestamp,
+        ),
+    )
+
+    after = get_member_identity(
+        connection,
+        guild_id=int(guild_id),
+        user_id=int(user_id),
+        required=True,
+    )
+    assert after is not None
+    audit_log.record_audit_event(
+        connection,
+        guild_id=int(guild_id),
+        actor_user_id=int(actor_user_id),
+        action="identity.save",
+        target=str(user_id),
+        before={"profile_existed": before is not None},
+        after={
+            "profile_created": before is None,
+            "discord_display_name_changed": entry.display_name != after.discord_display_name,
+            "preferred_name_changed": before is None
+            or before.preferred_name != after.preferred_name,
+            "birth_date_changed": before is None or before.birth_date != after.birth_date,
+            "adult_memory_consent_recorded": True,
+        },
+    )
+    return after
+
+
+def refresh_discord_display_name(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    discord_display_name: str,
+    actor_user_id: int | None = None,
+) -> registry.RegistryEntry:
+    """Refresh the current screen name without overwriting the preferred name."""
+
+    initialize_member_identity_schema(connection)
+    normalized = normalize_discord_display_name(discord_display_name)
+    before = registry.get_entry(
+        connection,
+        guild_id=int(guild_id),
+        user_id=int(user_id),
+        required=True,
+    )
+    assert before is not None
+    if before.display_name == normalized:
+        return before
+
+    connection.execute(
+        """
+        UPDATE coven_registry_entries
+        SET display_name = ?, updated_at = ?
+        WHERE guild_id = ? AND user_id = ?
+        """,
+        (normalized, utc_now_iso(), int(guild_id), int(user_id)),
+    )
+    after = registry.get_entry(
+        connection,
+        guild_id=int(guild_id),
+        user_id=int(user_id),
+        required=True,
+    )
+    assert after is not None
+    if actor_user_id is not None:
+        audit_log.record_audit_event(
+            connection,
+            guild_id=int(guild_id),
+            actor_user_id=int(actor_user_id),
+            action="identity.refresh_discord_display_name",
+            target=str(user_id),
+            before={"display_name_changed": False},
+            after={"display_name_changed": True},
+        )
+    return after
+
+
+def get_trusted_identity_context(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    on_date: date,
+) -> TrustedIdentityContext:
+    """Build the allow-listed identity context for an already-authorised chat request."""
+
+    stored = get_member_identity(
+        connection,
+        guild_id=int(guild_id),
+        user_id=int(user_id),
+        required=True,
+    )
+    assert stored is not None
+    return stored.trusted_chat_context(on_date=on_date)

--- a/tests/test_member_identity.py
+++ b/tests/test_member_identity.py
@@ -1,0 +1,67 @@
+from datetime import date
+
+import pytest
+
+from services.member_identity import MemberIdentity, MemberIdentityError, calculate_age
+
+
+def test_identity_preserves_both_names_and_full_birth_date() -> None:
+    identity = MemberIdentity.create(
+        discord_display_name="xXDarkSylveonXx",
+        preferred_name="Jessica",
+        birth_date="1991-10-31",
+        today=date(2026, 8, 6),
+    )
+
+    context = identity.trusted_chat_context(on_date=date(2026, 8, 6))
+
+    assert context.discord_display_name == "xXDarkSylveonXx"
+    assert context.preferred_name == "Jessica"
+    assert context.birth_date == "1991-10-31"
+    assert context.age == 34
+
+
+def test_age_changes_on_birthday() -> None:
+    birth_date = date(1991, 10, 31)
+
+    assert calculate_age(birth_date, on_date=date(2026, 10, 30)) == 34
+    assert calculate_age(birth_date, on_date=date(2026, 10, 31)) == 35
+
+
+def test_leap_day_birthday_uses_february_28_in_non_leap_year() -> None:
+    birth_date = date(1992, 2, 29)
+
+    assert calculate_age(birth_date, on_date=date(2025, 2, 27)) == 32
+    assert calculate_age(birth_date, on_date=date(2025, 2, 28)) == 33
+
+
+def test_future_birth_date_is_rejected() -> None:
+    with pytest.raises(MemberIdentityError, match="future"):
+        MemberIdentity.create(
+            discord_display_name="Member",
+            preferred_name="Member",
+            birth_date="2027-01-01",
+            today=date(2026, 8, 6),
+        )
+
+
+def test_underage_identity_is_rejected() -> None:
+    with pytest.raises(MemberIdentityError, match="at least 18"):
+        MemberIdentity.create(
+            discord_display_name="Member",
+            preferred_name="Member",
+            birth_date="2010-01-01",
+            today=date(2026, 8, 6),
+        )
+
+
+def test_names_are_normalized_but_remain_distinct() -> None:
+    identity = MemberIdentity.create(
+        discord_display_name="  Screen   Name  ",
+        preferred_name="  Real   Name  ",
+        birth_date="1990-01-01",
+        today=date(2026, 8, 6),
+    )
+
+    assert identity.discord_display_name == "Screen Name"
+    assert identity.preferred_name == "Real Name"

--- a/tests/test_member_profiles.py
+++ b/tests/test_member_profiles.py
@@ -1,0 +1,263 @@
+from datetime import date
+
+import pytest
+
+from services import audit_log
+from services import coven_registry as registry
+from services import member_profiles
+from services.database import connect, initialize_database, managed_connection
+from services.member_identity import MemberIdentityError
+
+
+def _bootstrap(path, *, guild_id: int = 1) -> None:
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        registry.bootstrap_registry(
+            connection,
+            guild_id=guild_id,
+            wilhelmina_user_id=100 + guild_id,
+            founder_user_id=200 + guild_id,
+            founder_name="Founder",
+            actor_user_id=200 + guild_id,
+        )
+        registry.register_pending_member(
+            connection,
+            guild_id=guild_id,
+            user_id=300,
+            display_name="Old Screen Name",
+            actor_user_id=300,
+        )
+
+
+def test_identity_persists_both_names_full_birth_date_and_consent(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        stored = member_profiles.save_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="  xXDarkSylveonXx  ",
+            preferred_name="  Jessica  ",
+            birth_date="1991-10-31",
+            today=date(2026, 8, 6),
+            adult_memory_consent=True,
+            consent_at="2026-08-06T20:00:00+00:00",
+            actor_user_id=300,
+        )
+        context = member_profiles.get_trusted_identity_context(
+            connection,
+            guild_id=1,
+            user_id=300,
+            on_date=date(2026, 10, 31),
+        )
+
+    assert stored.discord_display_name == "xXDarkSylveonXx"
+    assert stored.preferred_name == "Jessica"
+    assert stored.birth_date == "1991-10-31"
+    assert stored.adult_memory_consent_at == "2026-08-06T20:00:00+00:00"
+    assert context.discord_display_name == "xXDarkSylveonXx"
+    assert context.preferred_name == "Jessica"
+    assert context.birth_date == "1991-10-31"
+    assert context.age == 35
+
+
+def test_identity_survives_a_new_database_connection(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="Screen Name",
+            preferred_name="Real Name",
+            birth_date="1990-01-01",
+            today=date(2026, 8, 6),
+            adult_memory_consent=True,
+            actor_user_id=300,
+        )
+
+    with managed_connection(path) as connection:
+        stored = member_profiles.get_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            required=True,
+        )
+
+    assert stored is not None
+    assert stored.discord_display_name == "Screen Name"
+    assert stored.preferred_name == "Real Name"
+    assert stored.birth_date == "1990-01-01"
+
+
+def test_adult_memory_consent_is_required(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        with pytest.raises(MemberIdentityError, match="consent"):
+            member_profiles.save_member_identity(
+                connection,
+                guild_id=1,
+                user_id=300,
+                discord_display_name="Screen Name",
+                preferred_name="Real Name",
+                birth_date="1990-01-01",
+                today=date(2026, 8, 6),
+                adult_memory_consent=False,
+                actor_user_id=300,
+            )
+        stored = member_profiles.get_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+        )
+
+    assert stored is None
+
+
+def test_underage_profile_does_not_change_registry_name(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        with pytest.raises(MemberIdentityError, match="at least 18"):
+            member_profiles.save_member_identity(
+                connection,
+                guild_id=1,
+                user_id=300,
+                discord_display_name="Changed Too Soon",
+                preferred_name="Member",
+                birth_date="2010-01-01",
+                today=date(2026, 8, 6),
+                adult_memory_consent=True,
+                actor_user_id=300,
+            )
+        entry = registry.get_entry(connection, guild_id=1, user_id=300)
+
+    assert entry is not None
+    assert entry.display_name == "Old Screen Name"
+
+
+def test_display_name_refresh_keeps_preferred_name_and_birth_date(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="First Screen Name",
+            preferred_name="Jessica",
+            birth_date="1991-10-31",
+            today=date(2026, 8, 6),
+            adult_memory_consent=True,
+            actor_user_id=300,
+        )
+        member_profiles.refresh_discord_display_name(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="Second Screen Name",
+            actor_user_id=101,
+        )
+        stored = member_profiles.get_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            required=True,
+        )
+
+    assert stored is not None
+    assert stored.discord_display_name == "Second Screen Name"
+    assert stored.preferred_name == "Jessica"
+    assert stored.birth_date == "1991-10-31"
+
+
+def test_identity_is_scoped_to_one_guild(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path, guild_id=1)
+    _bootstrap(path, guild_id=2)
+
+    with managed_connection(path) as connection:
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="Guild One",
+            preferred_name="Jessica",
+            birth_date="1991-10-31",
+            today=date(2026, 8, 6),
+            adult_memory_consent=True,
+            actor_user_id=300,
+        )
+        first = member_profiles.get_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+        )
+        second = member_profiles.get_member_identity(
+            connection,
+            guild_id=2,
+            user_id=300,
+        )
+
+    assert first is not None
+    assert second is None
+
+
+def test_identity_audit_omits_names_and_birth_date(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="Secret Screen Name",
+            preferred_name="Secret Preferred Name",
+            birth_date="1991-10-31",
+            today=date(2026, 8, 6),
+            adult_memory_consent=True,
+            actor_user_id=300,
+        )
+        events = audit_log.list_audit_events_for_target(connection, 1, 300, limit=10)
+
+    identity_event = next(event for event in events if event.action == "identity.save")
+    payload = f"{identity_event.before_json}{identity_event.after_json}"
+    assert "Secret Screen Name" not in payload
+    assert "Secret Preferred Name" not in payload
+    assert "1991-10-31" not in payload
+
+
+def test_identity_schema_version_and_table_are_created(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        member_profiles.initialize_member_identity_schema(connection)
+
+    connection = connect(path)
+    try:
+        table = connection.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'coven_member_identity_profiles'
+            """
+        ).fetchone()
+        versions = {
+            int(row["version"])
+            for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
+        }
+    finally:
+        connection.close()
+
+    assert table is not None
+    assert member_profiles.MEMBER_IDENTITY_SCHEMA_VERSION in versions


### PR DESCRIPTION
## Purpose

Build the private adult member-identity foundation on top of `openai-platform-foundation`.

## Implemented

- typed member identity domain model
- preserves current Discord display name and member-supplied preferred name separately
- stores full self-reported birth date as canonical identity data
- calculates current age locally from the configured guild timezone
- exposes both names, full birth date, and current age only through an explicit trusted chat-context object
- rejects malformed, future, and under-18 birth dates
- records explicit adult-memory consent before profile completion
- schema version 7 and private `coven_member_identity_profiles` persistence
- guild-scoped identity storage with Registry foreign-key cleanup
- Covenant Gate now opens the private identity modal for members who have not completed it
- existing completed profiles can accept later Covenant versions without re-entering identity data
- existing Registry acceptance bridge remains the single induction authority
- Discord display-name refresh listener preserves preferred name and birth date
- founder/admin-only ephemeral `/identity-admin show` view
- raw names and birth dates remain out of operational audit payloads
- persistence, reconnection, consent, age validation, guild isolation, display-name refresh, audit privacy, birthday rollover, and leap-day tests

## Validation

- CI run `31253015664` passed
- dependency install passed
- `ruff check .` passed
- `pytest` passed
- no live OpenAI request or runtime API key was used

## OpenAI direction applied

Trusted Python code decides whose profile is loaded and exactly which identity fields may enter model context. The model does not choose member identity, authorization, age calculation, or database mutations. Private identity values are excluded from operational logs. The existing OpenAI foundation remains asynchronous with response storage disabled by default.

## Deliberately not in this PR

The repository does not yet contain the actual designated Wilhelmina chat surface, so this PR provides the trusted identity-context API but does not pretend to wire it into a nonexistent chat handler. That integration belongs in the dedicated memory-aware chat tranche.

This PR intentionally targets `openai-platform-foundation` because the identity tranche depends on that foundation.