### PR TITLE
Build the OpenAI platform foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,11 +35,15 @@ ENABLE_BROADCASTS=false
 
 # AI support
 # Required only for AI-backed voice, /8ball, /fortune, help garnish, rules ceremony copy,
-# and generated daily broadcasts.
+# generated daily broadcasts, future Memory Ledger extraction, and designated chat.
+# Keep the real key in the deployment environment or secret manager, never in Git.
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 AI_TIMEOUT_SECONDS=8
 AI_MAX_RETRIES=1
+# Keep false for Wilhelmina's private-server content unless a future feature explicitly
+# requires OpenAI-hosted response state and receives a separate privacy review.
+OPENAI_STORE_RESPONSES=false
 
 # Broadcast sources
 # Comma-separated RSS/Atom feed URLs. No headlines are invented when these are empty.

--- a/services/ai.py
+++ b/services/ai.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 try:
-    from openai import OpenAI
+    import openai
+    from openai import AsyncOpenAI, OpenAI
 except ImportError:  # pragma: no cover - optional dependency guard
+    openai = None
+    AsyncOpenAI = None
     OpenAI = None
 
 logger = logging.getLogger("wilhelmina.ai")
@@ -15,22 +18,37 @@ logger = logging.getLogger("wilhelmina.ai")
 
 @dataclass(frozen=True)
 class AIConfig:
-    """Runtime configuration for AI-backed text generation."""
+    """Runtime configuration shared by Wilhelmina's OpenAI-backed features."""
 
     model: str = "gpt-4o-mini"
     timeout_seconds: float = 8.0
     max_retries: int = 1
+    store_responses: bool = False
 
     @classmethod
     def from_env(cls) -> "AIConfig":
         return cls(
             model=os.getenv("OPENAI_MODEL", "gpt-4o-mini").strip() or "gpt-4o-mini",
             timeout_seconds=_read_float("AI_TIMEOUT_SECONDS", default=8.0),
-            max_retries=_read_int("AI_MAX_RETRIES", default=1),
+            max_retries=max(0, _read_int("AI_MAX_RETRIES", default=1)),
+            store_responses=_read_bool("OPENAI_STORE_RESPONSES", default=False),
         )
 
 
-_client: OpenAI | None = None
+@dataclass(frozen=True)
+class AIResult:
+    """Safe metadata returned from one successful OpenAI response."""
+
+    text: str
+    model: str
+    request_id: str | None
+    input_tokens: int | None
+    output_tokens: int | None
+    total_tokens: int | None
+
+
+_sync_client: Any | None = None
+_async_client: Any | None = None
 
 
 def _read_float(name: str, *, default: float) -> float:
@@ -41,7 +59,7 @@ def _read_float(name: str, *, default: float) -> float:
     try:
         return float(raw)
     except ValueError:
-        logger.warning("invalid_float_setting name=%s value=%r default=%s", name, raw, default)
+        logger.warning("invalid_float_setting name=%s default=%s", name, default)
         return default
 
 
@@ -53,37 +71,231 @@ def _read_int(name: str, *, default: int) -> int:
     try:
         return int(raw)
     except ValueError:
-        logger.warning("invalid_int_setting name=%s value=%r default=%s", name, raw, default)
+        logger.warning("invalid_int_setting name=%s default=%s", name, default)
         return default
 
 
-def _get_openai_client() -> OpenAI | None:
-    """Return a cached OpenAI client, or None when AI generation is unavailable."""
+def _read_bool(name: str, *, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
 
-    global _client
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
 
-    if OpenAI is None:
-        return None
+    logger.warning("invalid_bool_setting name=%s default=%s", name, default)
+    return default
 
-    if not os.getenv("OPENAI_API_KEY"):
-        return None
 
-    if _client is not None:
-        return _client
-
-    try:
-        _client = OpenAI()
-    except Exception:
-        logger.exception("openai_client_initialization_failed")
-        return None
-
-    return _client
+def _has_api_key() -> bool:
+    return bool(os.getenv("OPENAI_API_KEY", "").strip())
 
 
 def ai_available() -> bool:
-    """Return whether AI generation can be attempted."""
+    """Return whether the OpenAI SDK and an API key are available."""
 
-    return _get_openai_client() is not None
+    return OpenAI is not None and AsyncOpenAI is not None and _has_api_key()
+
+
+def _get_sync_openai_client() -> Any | None:
+    global _sync_client
+
+    if not ai_available():
+        return None
+    if _sync_client is not None:
+        return _sync_client
+
+    try:
+        _sync_client = OpenAI()
+    except Exception as exc:  # pragma: no cover - SDK construction failure is environment-specific
+        _log_failure(exc, purpose="client_init", model=None)
+        return None
+    return _sync_client
+
+
+def _get_async_openai_client() -> Any | None:
+    global _async_client
+
+    if not ai_available():
+        return None
+    if _async_client is not None:
+        return _async_client
+
+    try:
+        _async_client = AsyncOpenAI()
+    except Exception as exc:  # pragma: no cover - SDK construction failure is environment-specific
+        _log_failure(exc, purpose="async_client_init", model=None)
+        return None
+    return _async_client
+
+
+def _reset_clients_for_tests() -> None:
+    """Clear cached SDK clients. Tests only; runtime code should not call this."""
+
+    global _sync_client, _async_client
+    _sync_client = None
+    _async_client = None
+
+
+def _normalize_text(value: str, *, preserve_newlines: bool) -> str:
+    text = value.strip()
+    if preserve_newlines:
+        return text
+    return text.replace("\n", " ")
+
+
+def _usage_value(usage: object | None, name: str) -> int | None:
+    if usage is None:
+        return None
+    value = getattr(usage, name, None)
+    return int(value) if value is not None else None
+
+
+def _result_from_response(
+    response: object,
+    *,
+    fallback_model: str,
+    preserve_newlines: bool,
+) -> AIResult:
+    text = _normalize_text(str(getattr(response, "output_text", "") or ""), preserve_newlines=preserve_newlines)
+    usage = getattr(response, "usage", None)
+    return AIResult(
+        text=text,
+        model=str(getattr(response, "model", None) or fallback_model),
+        request_id=getattr(response, "_request_id", None),
+        input_tokens=_usage_value(usage, "input_tokens"),
+        output_tokens=_usage_value(usage, "output_tokens"),
+        total_tokens=_usage_value(usage, "total_tokens"),
+    )
+
+
+def _error_category(exc: Exception) -> str:
+    if openai is None:
+        return "sdk_unavailable"
+
+    error_categories = (
+        ("authentication", getattr(openai, "AuthenticationError", None)),
+        ("permission", getattr(openai, "PermissionDeniedError", None)),
+        ("rate_limit", getattr(openai, "RateLimitError", None)),
+        ("timeout", getattr(openai, "APITimeoutError", None)),
+        ("connection", getattr(openai, "APIConnectionError", None)),
+        ("not_found", getattr(openai, "NotFoundError", None)),
+        ("bad_request", getattr(openai, "BadRequestError", None)),
+        ("api_status", getattr(openai, "APIStatusError", None)),
+    )
+    for category, error_type in error_categories:
+        if error_type is not None and isinstance(exc, error_type):
+            return category
+    return "unexpected"
+
+
+def _log_failure(exc: Exception, *, purpose: str, model: str | None) -> None:
+    """Log operational metadata without logging prompts, responses, or secrets."""
+
+    logger.warning(
+        "openai_request_failed purpose=%s category=%s exception=%s model=%s request_id=%s status=%s",
+        purpose,
+        _error_category(exc),
+        type(exc).__name__,
+        model,
+        getattr(exc, "request_id", None),
+        getattr(exc, "status_code", None),
+    )
+
+
+def _log_success(result: AIResult, *, purpose: str) -> None:
+    logger.info(
+        "openai_request_succeeded purpose=%s model=%s request_id=%s input_tokens=%s output_tokens=%s total_tokens=%s",
+        purpose,
+        result.model,
+        result.request_id,
+        result.input_tokens,
+        result.output_tokens,
+        result.total_tokens,
+    )
+
+
+def generate_result(
+    prompt: str,
+    *,
+    config: AIConfig | None = None,
+    preserve_newlines: bool = False,
+    purpose: str = "text",
+) -> AIResult | None:
+    """Generate text synchronously and return safe response metadata on success."""
+
+    if not prompt.strip():
+        return None
+
+    client = _get_sync_openai_client()
+    if client is None:
+        return None
+
+    config = config or AIConfig.from_env()
+    try:
+        response = client.with_options(
+            timeout=config.timeout_seconds,
+            max_retries=config.max_retries,
+        ).responses.create(
+            model=config.model,
+            input=prompt,
+            store=config.store_responses,
+        )
+        result = _result_from_response(
+            response,
+            fallback_model=config.model,
+            preserve_newlines=preserve_newlines,
+        )
+        if not result.text:
+            return None
+        _log_success(result, purpose=purpose)
+        return result
+    except Exception as exc:
+        _log_failure(exc, purpose=purpose, model=config.model)
+        return None
+
+
+async def generate_result_async(
+    prompt: str,
+    *,
+    config: AIConfig | None = None,
+    preserve_newlines: bool = False,
+    purpose: str = "text",
+) -> AIResult | None:
+    """Generate text with the native asynchronous OpenAI client."""
+
+    if not prompt.strip():
+        return None
+
+    client = _get_async_openai_client()
+    if client is None:
+        return None
+
+    config = config or AIConfig.from_env()
+    try:
+        response = await client.with_options(
+            timeout=config.timeout_seconds,
+            max_retries=config.max_retries,
+        ).responses.create(
+            model=config.model,
+            input=prompt,
+            store=config.store_responses,
+        )
+        result = _result_from_response(
+            response,
+            fallback_model=config.model,
+            preserve_newlines=preserve_newlines,
+        )
+        if not result.text:
+            return None
+        _log_success(result, purpose=purpose)
+        return result
+    except Exception as exc:
+        _log_failure(exc, purpose=purpose, model=config.model)
+        return None
 
 
 def generate_text(
@@ -91,50 +303,59 @@ def generate_text(
     *,
     config: AIConfig | None = None,
     preserve_newlines: bool = False,
+    purpose: str = "text",
 ) -> str:
     """Generate text synchronously, returning an empty string on failure."""
 
-    client = _get_openai_client()
-    if client is None:
-        return ""
-
-    config = config or AIConfig.from_env()
-
-    for attempt in range(config.max_retries + 1):
-        try:
-            response = client.responses.create(
-                model=config.model,
-                input=prompt,
-                timeout=config.timeout_seconds,
-            )
-            text = response.output_text.strip()
-            if preserve_newlines:
-                return text
-            return text.replace("\n", " ")
-        except Exception:
-            logger.exception(
-                "ai_generation_failed attempt=%s model=%s timeout=%s",
-                attempt + 1,
-                config.model,
-                config.timeout_seconds,
-            )
-
-    return ""
+    result = generate_result(
+        prompt,
+        config=config,
+        preserve_newlines=preserve_newlines,
+        purpose=purpose,
+    )
+    return result.text if result else ""
 
 
-def generate_markdown(prompt: str, *, config: AIConfig | None = None) -> str:
+def generate_markdown(
+    prompt: str,
+    *,
+    config: AIConfig | None = None,
+    purpose: str = "markdown",
+) -> str:
     """Generate Discord markdown while preserving line breaks."""
 
-    return generate_text(prompt, config=config, preserve_newlines=True)
+    return generate_text(
+        prompt,
+        config=config,
+        preserve_newlines=True,
+        purpose=purpose,
+    )
 
 
-async def generate_text_async(prompt: str, *, config: AIConfig | None = None) -> str:
-    """Run AI generation without blocking Discord's event loop."""
+async def generate_text_async(
+    prompt: str,
+    *,
+    config: AIConfig | None = None,
+    purpose: str = "text",
+) -> str:
+    """Generate text without blocking Discord's event loop."""
 
-    return await asyncio.to_thread(generate_text, prompt, config=config)
+    result = await generate_result_async(prompt, config=config, purpose=purpose)
+    return result.text if result else ""
 
 
-async def generate_markdown_async(prompt: str, *, config: AIConfig | None = None) -> str:
-    """Run markdown generation without blocking Discord's event loop."""
+async def generate_markdown_async(
+    prompt: str,
+    *,
+    config: AIConfig | None = None,
+    purpose: str = "markdown",
+) -> str:
+    """Generate Discord markdown without blocking Discord's event loop."""
 
-    return await asyncio.to_thread(generate_markdown, prompt, config=config)
+    result = await generate_result_async(
+        prompt,
+        config=config,
+        preserve_newlines=True,
+        purpose=purpose,
+    )
+    return result.text if result else ""

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from services import ai
+
+
+@dataclass
+class FakeUsage:
+    input_tokens: int = 12
+    output_tokens: int = 5
+    total_tokens: int = 17
+
+
+class FakeResponse:
+    output_text = "First line\nSecond line"
+    model = "test-model"
+    _request_id = "req_test_123"
+    usage = FakeUsage()
+
+
+class FakeSyncResponses:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return FakeResponse()
+
+
+class FakeAsyncResponses:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.error = error
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return FakeResponse()
+
+
+class FakeSyncClient:
+    def __init__(self) -> None:
+        self.responses = FakeSyncResponses()
+        self.options: dict[str, object] = {}
+
+    def with_options(self, **kwargs):
+        self.options = kwargs
+        return self
+
+
+class FakeAsyncClient:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.responses = FakeAsyncResponses(error=error)
+        self.options: dict[str, object] = {}
+
+    def with_options(self, **kwargs):
+        self.options = kwargs
+        return self
+
+
+def test_config_reads_privacy_timeout_and_retry_settings(monkeypatch):
+    monkeypatch.setenv("OPENAI_MODEL", "model-from-env")
+    monkeypatch.setenv("AI_TIMEOUT_SECONDS", "14.5")
+    monkeypatch.setenv("AI_MAX_RETRIES", "3")
+    monkeypatch.setenv("OPENAI_STORE_RESPONSES", "true")
+
+    config = ai.AIConfig.from_env()
+
+    assert config.model == "model-from-env"
+    assert config.timeout_seconds == 14.5
+    assert config.max_retries == 3
+    assert config.store_responses is True
+
+
+def test_config_rejects_negative_retries(monkeypatch):
+    monkeypatch.setenv("AI_MAX_RETRIES", "-5")
+
+    assert ai.AIConfig.from_env().max_retries == 0
+
+
+def test_ai_available_requires_sdk_and_key(monkeypatch):
+    monkeypatch.setattr(ai, "OpenAI", object())
+    monkeypatch.setattr(ai, "AsyncOpenAI", object())
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert ai.ai_available() is False
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    assert ai.ai_available() is True
+
+
+def test_generate_result_returns_safe_metadata(monkeypatch):
+    client = FakeSyncClient()
+    monkeypatch.setattr(ai, "_get_sync_openai_client", lambda: client)
+    config = ai.AIConfig(
+        model="requested-model",
+        timeout_seconds=4.0,
+        max_retries=2,
+        store_responses=False,
+    )
+
+    result = ai.generate_result("Say hello", config=config, purpose="unit_test")
+
+    assert result is not None
+    assert result.text == "First line Second line"
+    assert result.model == "test-model"
+    assert result.request_id == "req_test_123"
+    assert result.input_tokens == 12
+    assert result.output_tokens == 5
+    assert result.total_tokens == 17
+    assert client.options == {"timeout": 4.0, "max_retries": 2}
+    assert client.responses.calls == [
+        {
+            "model": "requested-model",
+            "input": "Say hello",
+            "store": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generate_result_async_uses_native_async_client(monkeypatch):
+    client = FakeAsyncClient()
+    monkeypatch.setattr(ai, "_get_async_openai_client", lambda: client)
+    config = ai.AIConfig(
+        model="requested-model",
+        timeout_seconds=6.0,
+        max_retries=1,
+        store_responses=False,
+    )
+
+    result = await ai.generate_result_async(
+        "Say hello",
+        config=config,
+        preserve_newlines=True,
+        purpose="unit_test",
+    )
+
+    assert result is not None
+    assert result.text == "First line\nSecond line"
+    assert client.options == {"timeout": 6.0, "max_retries": 1}
+    assert client.responses.calls[0]["store"] is False
+
+
+@pytest.mark.asyncio
+async def test_async_failure_returns_none_without_raising(monkeypatch):
+    client = FakeAsyncClient(error=RuntimeError("boom"))
+    monkeypatch.setattr(ai, "_get_async_openai_client", lambda: client)
+
+    result = await ai.generate_result_async("Say hello", purpose="unit_test")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_text_async_preserves_existing_string_contract(monkeypatch):
+    client = FakeAsyncClient()
+    monkeypatch.setattr(ai, "_get_async_openai_client", lambda: client)
+
+    text = await ai.generate_text_async("Say hello")
+    markdown = await ai.generate_markdown_async("Say hello")
+
+    assert text == "First line Second line"
+    assert markdown == "First line\nSecond line"


### PR DESCRIPTION
## Purpose

Establish the shared OpenAI runtime foundation that later Wilhelmina features depend on.

## Implemented

- Responses API as the primary OpenAI interface
- native `AsyncOpenAI` support so Discord event handling is not blocked
- `store=False` by default for response-state minimization
- configurable request timeout and retry policy
- request ID and token-usage telemetry without prompt/response logging
- classified SDK/API failure handling
- backwards-compatible synchronous and asynchronous text/markdown helpers
- mocked tests; no live API call or runtime key required
- `.env.example` coverage for AI runtime settings

## OpenAI guidance applied

The implementation follows the current official OpenAI Python SDK direction: Responses API first, native async client support, public request IDs for diagnostics, explicit timeout/retry configuration, and no private prompt/response content in operational logs.

This PR intentionally does not add memory extraction or Wilhelmina chat orchestration; it is the shared provider boundary those features will build on.