### PR TITLE
Phase 1: reconcile the memory-aware foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,12 +38,31 @@ ENABLE_BROADCASTS=false
 # generated daily broadcasts, future Memory Ledger extraction, and designated chat.
 # Keep the real key in the deployment environment or secret manager, never in Git.
 OPENAI_API_KEY=
-OPENAI_MODEL=gpt-4o-mini
+
+# Quality-first routing. Generic/chat defaults use GPT-5.6 Sol; structured memory work
+# defaults to GPT-5.6 Terra. These are independently overrideable after real evals.
+OPENAI_MODEL=gpt-5.6-sol
+OPENAI_CHAT_MODEL=gpt-5.6-sol
+OPENAI_MEMORY_MODEL=gpt-5.6-terra
 AI_TIMEOUT_SECONDS=8
 AI_MAX_RETRIES=1
-# Keep false for Wilhelmina's private-server content unless a future feature explicitly
-# requires OpenAI-hosted response state and receives a separate privacy review.
+
+# Provider-side retention posture. `standard` is safe for synthetic development only.
+# Private member-memory/chat calls fail closed unless this is `mam` or `zdr`.
+# The actual MAM/ZDR entitlement is configured in the OpenAI project, not by this string.
+OPENAI_RETENTION_MODE=standard
+
+# Private Wilhelmina calls always force this false even if a generic legacy feature overrides it.
 OPENAI_STORE_RESPONSES=false
+
+# Memory collection policy
+# - off: no automatic collection
+# - interaction: only eligible interactions involving Wilhelmina (DM/direct/reply/mention)
+# - ambient: future broad guild listening; requires ALL ambient gates below
+MEMORY_COLLECTION_MODE=off
+ENABLE_AMBIENT_MEMORY=false
+# Keep empty unless platform approval/clarification for broad ambient collection is documented.
+AMBIENT_MEMORY_APPROVAL_REFERENCE=
 
 # Broadcast sources
 # Comma-separated RSS/Atom feed URLs. No headlines are invented when these are empty.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Add or update tests with every behavior change.
 - Update README, `.env.example`, and ADR or feature documentation whenever architecture or runtime configuration changes.
 - Do not commit secrets, tokens, database files, or live Discord identifiers.
+- Preserve backward-compatible service helpers unless a migration plan explicitly removes them.
 
 ## Current authorized scope
 
@@ -19,14 +20,17 @@ SQLite persistence
 guild_config and audit_log storage
 Covenant Gate and Coven Registry
 scheduled broadcasts
-Memory Ledger persistence and admin controls
-OpenAI integration behind explicit feature flags
-automatic Memory Ledger collection after its extractor and Discord event layer are reviewed
-open-chat integration after the one-channel reveal boundary is enforced
+Memory Ledger persistence and private administration
+OpenAI integration behind explicit feature and privacy gates
+versioned adult memory consent
+interaction-scoped memory collection after extractor/event review
+memory-aware designated server chat
+memory-aware direct conversations with Wilhelmina
+cross-member ordinary social memory use inside approved memory-aware contexts
 tests and documentation
 ```
 
-Not allowed without a separate approved tranche:
+Not allowed without a separate approved tranche or required platform clearance:
 
 ```txt
 server takeover
@@ -35,18 +39,49 @@ server transformation
 automatic mass role/channel mutation
 new Oracle umbrella
 tarot/readings/ritual expansion outside their own approved feature work
-unreviewed public exposure of private Memory Ledger records
-committing or logging API keys, Discord tokens, or prohibited private data
+unreviewed public exposure of raw private Memory Ledger records
+ambient whole-server memory collection without every required runtime/platform gate
+committing or logging API keys, Discord tokens, prompts, responses, or prohibited private data
+letting model output directly authorize access or perform destructive database changes
 ```
 
 ## Memory Ledger rules
 
-- The founder/admin controls collection globally; there is no member-level memory opt-out in the approved design.
-- A legacy `memory_opt_out` database column may remain temporarily for compatibility, but it is inert and must not affect collection.
-- Prohibited information must be rejected or redacted before any external AI request.
-- Ordinary replacement permanently deletes the superseded memory and receipts.
-- Conflicting gossip remains separate, attributed, and linked through cascading contradiction records.
-- Admin-authored memories use an admin receipt rather than fabricated Discord message metadata.
+- SQLite is the canonical memory store. OpenAI never owns or authorizes memory state.
+- Automatic collection defaults off. The approved near-term collection mode is eligible human interaction involving Wilhelmina: direct conversation, DM, mention, reply, and later explicit remember actions.
+- Broad ambient guild listening is a dormant future capability. It must remain fail-closed unless `MEMORY_COLLECTION_MODE=ambient`, `ENABLE_AMBIENT_MEMORY=true`, and a documented platform approval/clarification reference is configured.
+- There is no history import or backfill.
+- Only human-authored text is eligible. Bots, webhooks, automated integrations, attachments, media, and external-link contents are excluded.
+- Prohibited information must be rejected locally before any external AI request or persistence.
+- The sensitive-data guard includes credentials/secrets, financial/payment data, exact private addresses, government/private identifiers, medical or mental-health diagnoses, and comparable dangerous secrets.
+- DMs directly involving Wilhelmina may be remembered after the current adult-memory disclosure is accepted. Third-party DMs Wilhelmina is not part of are never accessible or collectible.
+- The current adult-memory disclosure is versioned. Legacy consent must not be silently upgraded to the newer DM/cross-member memory behavior.
+- Ordinary social memories may be used across members in approved memory-aware server/DM contexts. Gossip must remain attributed and unverified. Admin-only/restricted material and prohibited secrets are never social ammunition.
+- The current interlocutor's full permitted active profile is core chat context. Later deterministic selection is for relevant cross-member memories, evidence, contradictions, and receipts; it is not a token-cost austerity mechanism.
+- The trusted identity context may include both names, the full canonical birth date, and locally calculated current age after authorization and current consent checks.
+- Ordinary same-topic corrections permanently replace the superseded memory and receipts. Exact duplicates merge receipts. Unrelated memories coexist. Contradictory gossip remains separate, attributed, and linked.
+- Admin-authored memories use an admin receipt rather than fabricated Discord metadata.
+- Model extraction returns typed proposals only. Python validates categories, permissions, duplicates, replacements, contradictions, and every database mutation.
+- Any member data access/correction/deletion controls required by current platform terms override older compatibility assumptions about the legacy `memory_opt_out` field; the legacy field itself remains inert unless explicitly migrated.
+
+## OpenAI rules
+
+- Use the Responses API through the shared provider boundary; Discord event paths must use native async calls.
+- Quality and character fidelity take priority over minimizing token/model spend.
+- Default routing is GPT-5.6 Sol for general/chat generation and GPT-5.6 Terra for structured memory work unless repository evals justify a better workload-specific choice.
+- Private member-memory/chat requests must use `store=false` and fail closed unless the deployment explicitly asserts an approved enhanced retention mode (`mam` or `zdr`).
+- Provider retention configuration lives in the OpenAI project; environment values are deployment assertions, not a substitute for actual MAM/ZDR approval/configuration.
+- Do not use OpenAI-hosted conversation state as Wilhelmina's permanent memory.
+- Operational logs may record model, request ID, token usage, latency/status, and content-free identifiers. They must not contain prompts, responses, memory summaries, receipts, preferred names, or birth dates.
+- Authorization, reveal scope, consent, age calculation, destructive actions, and database writes remain deterministic Python responsibilities.
+
+## Character contract
+
+- The server is adult-only and Wilhelmina is intentionally profane, sharp, confrontational, funny, and socially intrusive when useful.
+- Target voice: mean enough to delight the room, sharp enough to feel intelligent, and still useful.
+- Direct interactions receive a response. Ordinary designated-channel chatter may receive a spontaneous interjection only when Wilhelmina has something genuinely funny, useful, juicy, contradictory, or strongly relevant to add.
+- DMs are the same continuous character and same permitted Memory Ledger, but the room mode is more candid, intimate, and detailed rather than sanitized.
+- Adult character direction never converts passwords, financial data, exact addresses, restricted/admin data, or similar protected information into comedy material.
 
 ## Quality gates
 

--- a/cogs/member_identity.py
+++ b/cogs/member_identity.py
@@ -68,7 +68,7 @@ def _is_private_identity_admin(interaction: discord.Interaction, bot: commands.B
     return settings is not None and settings.founder_user_id == interaction.user.id
 
 
-class MemberInductionModal(discord.ui.Modal, title="Complete your induction"):
+class MemberInductionModal(discord.ui.Modal, title="Adult memory: DMs + callbacks"):
     preferred_name = discord.ui.TextInput(
         label="What should Wilhelmina call you?",
         placeholder="The name you actually want used",
@@ -83,8 +83,8 @@ class MemberInductionModal(discord.ui.Modal, title="Complete your induction"):
         max_length=10,
     )
     consent = discord.ui.TextInput(
-        label="Type I CONSENT to adult memory",
-        placeholder=CONSENT_PHRASE,
+        label="Type I CONSENT to memory + callbacks",
+        placeholder="DMs may be remembered; social memories may resurface with others",
         required=True,
         max_length=20,
     )
@@ -159,9 +159,16 @@ class MemberInductionModal(discord.ui.Modal, title="Complete your induction"):
             return
 
         if acceptance.already_accepted:
-            message = "Your identity profile is recorded, and that covenant was already accepted."
+            message = (
+                "Your profile and current memory consent are recorded; "
+                "that covenant was already accepted."
+            )
         else:
-            message = "Induction complete. I have the name you gave me, your screen name, and your birthday."
+            message = (
+                "Induction complete. I have both names and your full birthday. "
+                "Messages you send Wilhelmina, including DMs, may be remembered, "
+                "and ordinary social memories may resurface in her approved chats."
+            )
         await interaction.followup.send(message, ephemeral=True)
 
 
@@ -172,7 +179,7 @@ async def begin_covenant_acceptance(
     guild_id: int,
     rules_version_id: int,
 ) -> None:
-    """Accept directly for known adults; otherwise collect the private identity profile first."""
+    """Accept directly only when the current adult-memory disclosure is on file."""
 
     initialize_database(_database_path(bot))
     with managed_connection(_database_path(bot)) as connection:
@@ -186,7 +193,7 @@ async def begin_covenant_acceptance(
             user_id=interaction.user.id,
             required=False,
         )
-        if profile is not None:
+        if profile is not None and profile.has_current_memory_consent:
             result = rules_service.accept_rules_version(
                 connection,
                 guild_id=int(guild_id),
@@ -293,6 +300,7 @@ class MemberIdentityAdmin(commands.GroupCog, group_name="identity-admin"):
             f"birth_date   = {context.birth_date}\n"
             f"age          = {context.age}\n"
             f"consent_at   = {profile.adult_memory_consent_at}\n"
+            f"consent_ver  = {profile.memory_consent_version}\n"
             "```",
             ephemeral=True,
         )

--- a/docs/member_identity.md
+++ b/docs/member_identity.md
@@ -11,21 +11,53 @@ Neither name replaces the other. Approved memory-aware chat may use either name 
 
 Induction collects the member's full self-reported birth date in ISO `YYYY-MM-DD` format. The full date is the canonical source of truth. Age is never stored as a permanent number because it becomes stale; trusted local code recalculates it using the configured server date.
 
-The trusted identity context for the designated Wilhelmina channel and direct conversations in which she participates contains:
+After authorization and current-consent checks, the trusted identity context for approved Wilhelmina server chat and direct conversations with Wilhelmina contains:
 
 - current Discord display name;
 - preferred name;
 - full birth date;
 - current calculated age.
 
-This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her adult conversational persona.
+This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her adult conversational persona. The full birth date is not reduced to age-only context because the product requires Wilhelmina herself to know the canonical birthday inside approved trusted context.
 
-The same information must not be copied into general-purpose commands, operational logs, public Registry cards, error messages, or unrelated AI features. Local code decides whether the current channel or DM is approved before constructing the trusted identity context.
+The same information must not be copied into general-purpose commands, operational logs, public Registry cards, error messages, or unrelated AI features. Local code decides whether the member/context is authorized before constructing the trusted identity object.
 
 ## Adult gate
 
 A birth date that calculates to under eighteen blocks completion of the adult induction flow. Future dates and malformed dates are rejected. February 29 birthdays use February 28 as the anniversary in non-leap years for age calculation.
 
+## Versioned memory disclosure
+
+Adult-memory consent is versioned rather than treated as a permanent blank cheque.
+
+The current disclosure covers the intended next-phase behavior:
+
+- messages a member sends to Wilhelmina may be remembered;
+- this includes direct messages with Wilhelmina;
+- ordinary permitted social memories may later resurface in approved memory-aware conversation;
+- that may include Wilhelmina bringing one participating adult member's ordinary social memory into a relevant conversation with another participating adult member.
+
+A legacy identity profile is migrated with `legacy-adult-memory-v1`. That preserves the existing profile without pretending the older disclosure authorized the newer DM/cross-member behavior.
+
+The current disclosure version is `2026-08-interaction-dm-cross-reveal-v2`. A member with only legacy consent must complete the current disclosure before trusted memory-aware identity context is available.
+
+The existence of a profile and the validity of its current consent are deliberately separate concepts:
+
+- `profile_is_complete(...)` means the private identity row exists;
+- `profile_has_current_consent(...)` means that row has accepted the current disclosure.
+
+This preserves compatibility for administrative/profile code while giving chat/memory code an explicit consent gate.
+
 ## OpenAI boundary
 
-The model receives identity data only through an explicit allow-listed context assembled by trusted Python code. The model does not decide whose profile to load, whether the channel is authorised, or how age is calculated. OpenAI requests remain asynchronous, response storage remains disabled, and prompts or identity values must not enter operational logs.
+The model receives identity data only through an explicit allow-listed context assembled by trusted Python code. The model does not decide whose profile to load, whether a conversation is authorized, how age is calculated, or whether consent is current.
+
+Private member-memory/chat calls use the shared asynchronous Responses API boundary with response storage forced off. Live private calls are designed to fail closed unless the deployment explicitly asserts an approved enhanced OpenAI retention posture (`mam` or `zdr`). Provider-side MAM/ZDR configuration remains an OpenAI-project setting; the runtime value is an assertion, not a substitute for actual approval/configuration.
+
+Prompts, responses, preferred names, and birth dates must not enter operational logs. Safe telemetry may include request ID, model, token usage, latency/status, and content-free identifiers.
+
+## Schema migration
+
+The private member-identity schema uses version 8 for the versioned-consent migration.
+
+Fresh profiles store `memory_consent_version` directly. Existing version-7-style profiles gain the column with the legacy consent value. This migration is intentionally non-destructive: names and birth dates remain intact while richer memory-aware behavior stays blocked until current consent is recorded.

--- a/docs/memory_ledger.md
+++ b/docs/memory_ledger.md
@@ -1,35 +1,108 @@
 # Memory Ledger
 
-The Memory Ledger is Wilhelmina's private, persistent record of what human members say in the home Discord server. It extends the Coven Registry profile shell without making member profiles public.
+The Memory Ledger is Wilhelmina's private, persistent local memory for eligible human interactions. SQLite is the canonical source of truth. OpenAI may interpret or phrase approved context for a request, but OpenAI does not own the memory database and model output never directly authorizes access, deletion, replacement, or disclosure.
 
-This document is the implementation contract for the Memory Ledger. Manual Discord testing remains deferred until the project's final live-testing pass.
+This document is the implementation contract for the next memory-aware phases. PR #33 already implements the schema-v6 persistence foundation. Automatic extraction, local retrieval intelligence, and live Wilhelmina chat are later phases and must not be treated as already deployed.
 
-## Product rules
+## Product direction
 
-### Collection scope
+Wilhelmina is an adult social character, not a sanitized support bot. The intended experience is profane, sharp, funny, intrusive when useful, and capable of remembering callbacks, contradictions, preferences, embarrassing details, gossip, names, birthdays, projects, and other ordinary social context.
 
-- Collection begins only after the feature is enabled. There is no history import or backfill.
-- Wilhelmina may collect from any guild channel she can read.
-- Direct messages are excluded.
-- Only human-authored Discord messages are eligible.
-- Bot messages, webhook messages, and automated integrations are ignored.
-- Only message text is analyzed.
-- Images, audio, video, uploaded files, and external-link contents are not inspected.
-- Collection is silent.
-- Collection is controlled globally by the founder/admin. There is no member-level opt-out in the approved design.
-- The legacy `coven_profile_shells.memory_opt_out` column is inert compatibility data and must not alter collection.
+Target voice: **mean enough to delight the room, sharp enough to feel intelligent, and still useful.**
 
-### Ownership and visibility
+Quality and memory richness take priority over minimizing model or token cost. Privacy controls should minimize unnecessary retention and accidental disclosure without deliberately making Wilhelmina dumber.
 
-- Each memory belongs to the Coven Registry profile of the human member who supplied it.
-- Third-party gossip does not create a standalone profile for the person being discussed.
-- Raw records, receipts, searches, status output, and administration commands are visible only to the founder/admin.
-- Admin command responses must be ephemeral wherever Discord permits it.
-- Memories may feed later approved Wilhelmina features without making the raw ledger public.
+## Collection modes
 
-### Categories and labels
+Automatic collection is controlled by an explicit fail-closed runtime mode:
 
-Categories:
+- `off` — no automatic memory extraction;
+- `interaction` — eligible interactions involving Wilhelmina may be extracted;
+- `ambient` — future broad guild listening, subject to additional hard gates.
+
+The default is `off`.
+
+### Interaction collection
+
+The approved near-term target is `interaction` mode. Eligible sources may include:
+
+- a direct message sent to Wilhelmina;
+- a guild message that directly mentions Wilhelmina;
+- a reply to Wilhelmina;
+- an active direct conversation with Wilhelmina;
+- a later explicit remember action.
+
+A DM is eligible only when Wilhelmina is herself a participant. Wilhelmina cannot read or collect DMs between other people.
+
+Only human-authored text is eligible. Bot messages, webhook messages, automated integrations, images, audio, video, uploaded files, and external-link contents are excluded.
+
+There is no history import or backfill.
+
+### Future ambient collection
+
+The product vision keeps a future "ears everywhere" path so Wilhelmina may eventually learn from broader server conversation when platform rules and deployment approval make that appropriate.
+
+Ambient collection must remain fail-closed. It is considered ready only when all of the following are present:
+
+1. `MEMORY_COLLECTION_MODE=ambient`;
+2. `ENABLE_AMBIENT_MEMORY=true`;
+3. a non-empty `AMBIENT_MEMORY_APPROVAL_REFERENCE` documenting the required platform clarification/approval.
+
+One switch alone must never activate broad listening. The extraction/event phase must reject ambient messages before any OpenAI request when the full gate is not satisfied.
+
+## Consent and adult identity
+
+The memory experience is adult-only. Induction records a full self-reported birth date and rejects members under eighteen.
+
+The adult-memory disclosure is versioned. The current disclosure covers the intended richer behavior: messages sent to Wilhelmina, including DMs, may be remembered, and ordinary social memories may later resurface in approved conversations, including conversations with other participating adult members.
+
+Legacy consent is not silently upgraded. An older profile may remain stored, but trusted memory-aware context is blocked until the current disclosure is accepted.
+
+The private identity profile preserves two distinct names:
+
+- the member's current Discord display name;
+- the preferred name explicitly given to Wilhelmina.
+
+The full birth date remains the canonical source of truth. Python calculates current age locally. In an already-authorized trusted memory-aware request, Wilhelmina may receive both names, the full birth date, and calculated age so she can use birthday/age context naturally. These values do not belong in public Registry cards, generic logs, or unrelated AI features.
+
+## Visibility and social use
+
+Raw Memory Ledger records, receipts, searches, and administration surfaces remain private to authorized founder/admin tooling.
+
+Approved memory-aware conversational surfaces are different from raw Ledger administration. The target conversational surfaces are:
+
+- one designated Wilhelmina server channel;
+- direct conversations with Wilhelmina.
+
+Within those approved surfaces, ordinary permitted social memories may be used across members when contextually relevant. This is intentionally the "full menace" social behavior: Wilhelmina is allowed to remember one person's ordinary social statement and later bring it up while talking with somebody else.
+
+That permission does not override hard privacy classes. Credentials, financial data, exact private addresses, restricted/admin-only data, dangerous identifiers, diagnoses, and similar prohibited material are never comedy ammunition and must not enter ordinary chat context.
+
+Gossip remains gossip. It must stay attributed and unverified rather than being presented as established fact.
+
+## Server and DM behavior
+
+### Designated server channel
+
+Wilhelmina uses a selective social-predator participation style:
+
+- direct mentions, replies, and direct questions receive a response;
+- ordinary human conversation does not receive a mechanical response to every message;
+- she may spontaneously interject only when there is something genuinely funny, useful, juicy, contradictory, or strongly relevant to contribute.
+
+The later local selector/interjection gate should decide whether an ordinary message is worth considering before a chat-model call is made. The model may still return `NO_REPLY` for an optional interjection.
+
+### DMs
+
+DMs are a confessional-booth mode, not an amnesiac or sanitized version of the bot.
+
+A user-initiated DM may use the same permitted Memory Ledger as server chat, including relevant cross-member context. The behavioral difference is social framing: DM replies may be more candid, detailed, intimate, and analytical because there is no public audience.
+
+Wilhelmina does not proactively scrape third-party DMs and does not gain access to conversations she is not in.
+
+## Categories and epistemic labels
+
+Existing Memory Ledger categories remain schema-compatible:
 
 - `Identity`
 - `Preference`
@@ -44,37 +117,45 @@ Categories:
 - `Wilhelmina impression`
 - `Gossip`
 
-Epistemic labels:
+Existing labels remain schema-compatible:
 
 - `Fact`
 - `Inference`
 - `Impression`
 - `Gossip`
 
-Gossip is presented internally as `Unverified gossip`. Accusations are stored as attributed claims, never established facts.
+Automatic extraction must prefer explicit durable statements over speculative person-level inference. The later extraction/privacy phase will define which inference/impression records may be machine-created under current platform policy. Schema compatibility alone is not authorization to generate psychological dossiers.
 
-### Prohibited information
+Gossip is treated as an attributed unverified claim, never established fact.
 
-The Ledger must reject or redact the following before any external AI request and before persistence:
+## Prohibited information
 
-- passwords;
-- access tokens and API keys;
-- login credentials;
-- exact residential addresses;
-- banking or payment information;
-- government or identity-document numbers;
-- medical diagnoses;
-- mental-health diagnoses;
-- private-message content.
+The deterministic local validator runs before any external AI request and before persistence.
 
-The future event listener must call the deterministic pre-extraction validator before sending text to the OpenAI extractor. If the validator rejects a message, no external request is made and no memory is created.
+At minimum, reject or quarantine:
 
-## Memory records
+- passwords and authentication secrets;
+- API/access tokens and login credentials;
+- banking, card, payment, or account information;
+- government/private identity-document numbers;
+- exact home/private addresses and precise live location;
+- medical or mental-health diagnoses;
+- intimate non-consensual material;
+- information involving minors that is inappropriate for the adult-memory system;
+- comparable dangerous private secrets.
 
-A memory record stores:
+Do **not** blanket-reject DMs merely because they are private. A DM sent directly to Wilhelmina is an eligible source after consent and policy checks. Private messages that were not sent to Wilhelmina are outside her accessible collection scope.
+
+If local validation rejects a message, no external extraction request is made and no memory is created from that content.
+
+## Memory ownership, records, and receipts
+
+A stored memory is attached to the Coven Registry/profile shell of the participating member who supplied it. Third-party gossip does not automatically create a standalone outsider profile.
+
+The existing schema-v6 record stores:
 
 - guild ID;
-- owner user ID linked to a Coven Registry profile shell;
+- owner/subject user ID;
 - category;
 - epistemic label;
 - concise summary;
@@ -85,82 +166,95 @@ A memory record stores:
 - creator ID;
 - created, updated, and last-confirmed timestamps.
 
-Nothing expires automatically.
-
-## Receipts
+Nothing expires automatically under the existing persistence contract.
 
 Every memory has at least one receipt.
 
-### Discord receipt
+A Discord receipt stores source message ID, jump URL when available, author, channel, timestamp, original excerpt, latest edited excerpt, edit timestamp, and source-deletion timestamp. DM receipts will use the same evidence principle without pretending a guild jump URL exists when Discord does not provide one.
 
-A Discord-derived receipt stores:
+An admin-authored memory uses an admin receipt and never fabricates Discord message metadata.
 
-- source kind `discord`;
-- message ID;
-- jump URL;
-- author user ID;
-- channel ID;
-- original message timestamp;
-- original excerpt;
-- latest edited excerpt and edit timestamp when applicable;
-- source-deletion timestamp when applicable.
+If a captured Discord source is later deleted, the existing design keeps the stored receipt excerpt and marks the source deleted.
 
-### Admin receipt
+## Duplicate, replacement, and contradiction rules
 
-An admin-authored memory uses source kind `admin` and stores:
+These decisions remain deterministic Python/SQLite behavior.
 
-- administrator user ID;
-- the memory summary as the source excerpt;
-- creation timestamp;
-- no fabricated Discord message, channel, or jump URL.
+### Exact duplicate
 
-If Discord later deletes a source message, its stored receipt remains and is marked deleted.
+Keep one memory record, add the new receipt, retain every supporting source, and update confirmation timestamps.
 
-## Duplicate and contradiction behavior
+### Topic-scoped correction
 
-### Duplicate memories
+For ordinary non-gossip memory, a newer correction about the same specific topic replaces that memory. The superseded content and receipts are permanently deleted. A minimal content-free replacement audit may remain.
 
-A repeated memory keeps one record, adds another receipt, preserves every supporting link, and updates `last_confirmed_at`.
+Unrelated memories in the same category coexist.
 
-### Ordinary replacement
+### Contradictory gossip
 
-For non-gossip records, a newer statement in the same replacement category permanently deletes the superseded record and its receipts before creating the new record.
+Conflicting gossip remains as separate attributed claims. Related records are linked through contradiction rows. Deleting either memory removes the relevant contradiction relationship through cascading foreign keys.
 
-A minimal `memory.replaced` audit event may remain, but it stores no deleted memory content.
+The future chat layer may conversationally call out contradictions when both underlying memories are permitted in the current context.
 
-### Gossip contradictions
+## OpenAI boundary
 
-Conflicting gossip remains as separate attributed claims. Records sharing a topic key are linked in `memory_contradictions`.
+OpenAI receives only context approved by deterministic local code for the current operation.
 
-Both contradiction foreign keys use `ON DELETE CASCADE`, so permanently deleting either memory also removes the relationship row.
+Python owns:
 
-Future chat behavior:
+- guild/member authorization;
+- consent and collection eligibility;
+- prohibited-data filtering;
+- reveal scope;
+- identity/age calculation;
+- duplicate/replacement decisions;
+- contradiction links;
+- database writes and deletes;
+- context budgeting and local retrieval;
+- logging/privacy policy.
 
-- contradictions observed inside the designated Wilhelmina chat may be called out immediately;
-- contradictions observed elsewhere are stored silently and may be raised later in the designated chat;
-- dialogue should sound conversational and messy rather than judicial.
+OpenAI owns language tasks such as:
 
-## Collection controls
+- structured candidate extraction from already-approved text;
+- concise memory phrasing inside a strict schema;
+- conversational reasoning over supplied context;
+- Wilhelmina's prose and optional `NO_REPLY` judgement.
 
-The Ledger stores a persistent guild-level state:
+Model output is a proposal, never database authority.
 
-- active;
-- paused.
+Private memory/chat calls must use the shared asynchronous Responses API path with response storage disabled. Live private requests fail closed unless the deployment explicitly asserts an approved enhanced retention posture (`mam` or `zdr`). The provider-side MAM/ZDR setting is configured in the OpenAI project; an environment variable is only a runtime assertion and cannot grant the entitlement by itself.
 
-Admin controls will support pause, resume, status, and designated-chat-channel configuration. The state survives process restarts and Discord reconnections. Pausing does not delete existing memories.
+Quality-first default routing is:
 
-## Designated Wilhelmina chat channel
+- GPT-5.6 Sol for Wilhelmina chat/general generation;
+- GPT-5.6 Terra for structured memory work;
+- model choices remain independently configurable and should later be validated with Wilhelmina-specific evals.
 
-Exactly one guild channel may be configured as Wilhelmina's conversation channel.
+Operational logs may contain request IDs, model names, token counts, status/latency, and content-free internal identifiers. They must not contain raw prompts, model replies, memory summaries, receipts, preferred names, or birth dates.
 
-- Collection may occur in every readable guild channel.
-- Open use of memories is limited to the designated Wilhelmina chat channel.
-- Outside that channel, Wilhelmina may collect but must not reveal memories.
-- The full active profile is loaded for future Wilhelmina chat responses.
+## Full-profile and local retrieval contract
 
-## Administration surface
+The current interlocutor's full permitted active profile remains core context for memory-aware chat. The later retrieval engine is not designed to amputate that profile to save pennies.
 
-The planned founder/admin-only command group is `/memory-admin`:
+Local selection is primarily for:
+
+- relevant memories belonging to other members;
+- contradiction partners;
+- detailed historical evidence;
+- receipt snippets;
+- especially relevant callbacks among a large history.
+
+The planned selector will use deterministic local indexing/search and scoring. OpenAI is not asked to decide authorization or which private records it is allowed to retrieve.
+
+## Persistent collection controls
+
+The existing Memory Ledger stores persistent active/paused state and designated chat-channel configuration. Pause/resume survives process restarts and does not delete existing memories.
+
+The later controls phase will reconcile those database settings with the new runtime collection policy. Runtime `off` or an unsatisfied ambient gate always wins over a permissive database setting.
+
+## Administration
+
+The planned founder/admin surface remains private/ephemeral where Discord permits it:
 
 ```text
 /memory-admin status
@@ -175,31 +269,35 @@ The planned founder/admin-only command group is `/memory-admin`:
 /memory-admin receipt
 ```
 
-All responses are private/ephemeral where Discord permits it.
+Any additional member data access/correction/deletion controls required by current platform terms will be implemented in the controls phase. The legacy `coven_profile_shells.memory_opt_out` field remains inert compatibility data unless explicitly migrated; it is not silently repurposed by Phase 1.
 
-## SQLite schema version 6
+## Current schema status
 
-### `memory_ledger_settings`
+### Memory Ledger schema version 6 — implemented
 
-Stores guild collection state and the designated Wilhelmina channel.
+PR #33 implements:
 
-### `memory_records`
+- `memory_ledger_settings`;
+- `memory_records`;
+- `memory_receipts`;
+- `memory_contradictions`;
+- duplicate merging;
+- permanent ordinary replacement;
+- gossip contradiction links;
+- admin and Discord receipts;
+- permanent admin deletion with content-free audit;
+- local prohibited-content validation;
+- profile formatting and automated tests.
 
-Stores memory content and links `(guild_id, subject_user_id)` to `coven_profile_shells` with cascade deletion.
+### Member identity schema version 8 — current stacked foundation
 
-### `memory_receipts`
+The identity foundation stores preferred name, full birth date, adult-memory consent timestamp, and the version of the disclosure accepted. Existing schema-v7 identity data migrates to a legacy consent version rather than receiving the richer disclosure automatically.
 
-Stores either a `discord` source or an `admin` source. Receipts cascade when their memory is deleted.
+Because version 8 is now occupied by identity-consent migration, the next Memory Ledger schema expansion must use a later schema version.
 
-### `memory_contradictions`
+## Future extraction contract
 
-Stores normalized unordered gossip-memory pairs. Both memory references cascade on deletion.
-
-`initialize_memory_schema()` initializes its Coven Registry dependency first, applies all Memory Ledger tables and indexes idempotently, and records schema version 6.
-
-## Extraction contract
-
-Automatic extraction is a later tranche and will require strict structured output. One message may yield zero or more candidates:
+Automatic extraction is not yet implemented. When built, an eligible message may produce zero or more strict structured candidates such as:
 
 ```json
 {
@@ -212,74 +310,88 @@ Automatic extraction is a later tranche and will require strict structured outpu
 }
 ```
 
-Processing order is mandatory:
+Mandatory processing order:
 
-1. reject DMs, bots, webhooks, empty text, and paused guilds;
-2. confirm a Coven Registry profile shell exists;
-3. run deterministic prohibited-information validation locally;
-4. only then send allowed text and current profile context to the extractor;
-5. validate the returned structure;
-6. merge duplicates, permanently replace ordinary memories, or preserve/link gossip contradictions;
-7. create the appropriate receipt.
+1. classify the Discord source and interaction trigger;
+2. reject bots/webhooks/empty text and disallowed collection modes;
+3. verify current adult-memory consent and required local profile state;
+4. enforce the ambient multi-key gate when the source is ambient;
+5. run deterministic prohibited-information validation locally;
+6. only then send allowed text plus bounded existing-memory context to the structured extractor;
+7. validate the returned schema and local policy again;
+8. let Python merge duplicates, perform topic-scoped replacement, or preserve/link contradictory gossip;
+9. create the appropriate receipt transactionally.
 
-AI failure never blocks Discord event handling. Failed extraction creates no speculative memory.
+Timeouts, refusals, malformed structured output, or provider failures create no speculative memory and do not block Discord event handling.
 
 ## Message edits and deletions
 
-### Edited message
+Edited sources preserve the original excerpt, store the latest excerpt/edit timestamp, run local validation before any re-extraction, and reconcile only memories connected to that source.
 
-- preserve the original excerpt;
-- store the latest excerpt and edit timestamp;
-- validate the edited text before any future re-extraction;
-- reconcile only records connected to that source message.
+Deleted sources are marked deleted on matching receipts. The system does not reconstruct content it never captured.
 
-### Deleted message
+## Seven-phase implementation order
 
-- mark matching Discord receipts as source deleted;
-- keep stored excerpts and memories;
-- do not reconstruct content that was never captured.
+### Phase 1 — Foundation reconciliation
 
-## Build status and order
+- OpenAI Responses/async foundation made explicit and reviewable;
+- quality-first workload model routing;
+- private-call `store=false` enforcement and enhanced-retention fail-closed policy;
+- versioned adult-memory consent and legacy migration;
+- interaction/off/ambient runtime policy;
+- three-key ambient activation gate;
+- documentation/config/tests reconciled with DM and cross-member behavior.
 
-### Phase 1 — Persistence foundation
+### Phase 2 — Memory architecture upgrade
 
-Implemented in PR #33:
+- next Memory Ledger schema migration;
+- privacy/reveal metadata;
+- entity indexing and local full-text search;
+- deletion integrity and migration matrix;
+- durable local structures needed by retrieval/extraction.
 
-- schema version 6;
-- settings, records, receipts, and contradiction relationships;
-- duplicate merging;
-- permanent ordinary replacement;
-- gossip preservation and contradiction links;
-- admin and Discord receipt variants;
-- permanent deletion with content-free audit events;
-- pre-extraction prohibited-content validation;
-- profile rendering;
-- automated tests.
+### Phase 3 — Memory controls
 
-### Phase 2 — Admin controls
+- full founder/admin Memory Ledger controls;
+- required privacy/data-access/correction/deletion controls;
+- persistent status/pause/resume/channel configuration;
+- authorization and privacy tests.
 
-- feature flag;
-- ephemeral `/memory-admin` commands;
-- status, pause, resume, channel, profile, search, add, edit, delete, and receipt operations;
-- founder/admin authorization tests;
-- README and `.env.example` updates.
+### Phase 4 — Automatic memory extraction
 
-### Phase 3 — Automatic collection
+- Discord event eligibility for approved interaction sources and DMs;
+- local prohibited-data guard;
+- strict OpenAI structured extraction;
+- queue/backpressure/failure handling;
+- new/edit/delete reconciliation;
+- receipts, duplicate merging, replacement, and gossip contradiction handling.
 
-- Message Content Intent when enabled;
-- shared OpenAI client and strict extractor;
-- new, edit, and delete message listeners;
-- human/guild/text-only filters;
-- pre-AI prohibited-data filtering;
-- failure logging and rate controls.
+### Phase 5 — Memory intelligence and context
 
-### Phase 4 — Open-chat bridge
+- local FTS/index retrieval;
+- deterministic scoring and contradiction expansion;
+- full active speaker profile loading;
+- cross-member memory selection;
+- receipt/evidence budgeting;
+- deterministic context assembly tests.
 
-- full active-profile loading;
-- one-channel reveal boundary;
-- immediate and deferred contradiction behavior;
-- Wilhelmina's conversational response generation.
+### Phase 6 — Wilhelmina chat brain
 
-## Deferred live testing
+- designated server chat;
+- fully memory-aware DM confessional mode;
+- direct-response behavior;
+- selective spontaneous interjection gate;
+- cross-member social-memory use;
+- adult Wilhelmina persona and chat evals.
 
-The final Discord pass must verify Message Content Intent, collection from multiple channels, bot/webhook exclusion, private admin responses, pause persistence, edited/deleted receipts, duplicate merges, permanent replacement, gossip contradiction links, designated-channel reveal boundaries, and full-profile loading.
+### Phase 7 — Hardening and dormant ambient path
+
+- adversarial/privacy regression suite;
+- migration/reconnect/rate-limit testing;
+- observability and rollback controls;
+- production privacy assertions;
+- ambient event path completed but kept disabled until all deployment/platform gates are satisfied.
+
+## Final live testing
+
+The live Discord pass must eventually verify consent migration, DMs with Wilhelmina, direct server interactions, bot/webhook exclusion, pause persistence, edits/deletes, duplicate merges, topic-scoped replacement, gossip contradiction links, full-profile loading, cross-member context rules, selective interjections, DM/server mode differences, private admin surfaces, enhanced OpenAI retention configuration, and the fact that ambient collection stays off when any required gate is absent.

--- a/services/ai.py
+++ b/services/ai.py
@@ -15,12 +15,22 @@ except ImportError:  # pragma: no cover - optional dependency guard
 
 logger = logging.getLogger("wilhelmina.ai")
 
+DEFAULT_MODEL = "gpt-5.6-sol"
+DEFAULT_CHAT_MODEL = "gpt-5.6-sol"
+DEFAULT_MEMORY_MODEL = "gpt-5.6-terra"
+VALID_RETENTION_MODES = frozenset({"standard", "mam", "zdr"})
+VALID_WORKLOADS = frozenset({"default", "chat", "memory"})
+
+
+class AIPrivacyConfigurationError(RuntimeError):
+    """Raised when a private OpenAI call would violate Wilhelmina's privacy contract."""
+
 
 @dataclass(frozen=True)
 class AIConfig:
     """Runtime configuration shared by Wilhelmina's OpenAI-backed features."""
 
-    model: str = "gpt-4o-mini"
+    model: str = DEFAULT_MODEL
     timeout_seconds: float = 8.0
     max_retries: int = 1
     store_responses: bool = False
@@ -28,11 +38,59 @@ class AIConfig:
     @classmethod
     def from_env(cls) -> "AIConfig":
         return cls(
-            model=os.getenv("OPENAI_MODEL", "gpt-4o-mini").strip() or "gpt-4o-mini",
+            model=os.getenv("OPENAI_MODEL", DEFAULT_MODEL).strip() or DEFAULT_MODEL,
             timeout_seconds=_read_float("AI_TIMEOUT_SECONDS", default=8.0),
             max_retries=max(0, _read_int("AI_MAX_RETRIES", default=1)),
             store_responses=_read_bool("OPENAI_STORE_RESPONSES", default=False),
         )
+
+
+@dataclass(frozen=True)
+class AIPlatformPolicy:
+    """Model routing and provider-retention assertions for private Wilhelmina features."""
+
+    default_model: str = DEFAULT_MODEL
+    chat_model: str = DEFAULT_CHAT_MODEL
+    memory_model: str = DEFAULT_MEMORY_MODEL
+    retention_mode: str = "standard"
+
+    @classmethod
+    def from_env(cls) -> "AIPlatformPolicy":
+        base = os.getenv("OPENAI_MODEL", DEFAULT_MODEL).strip() or DEFAULT_MODEL
+        chat = os.getenv("OPENAI_CHAT_MODEL", DEFAULT_CHAT_MODEL).strip() or DEFAULT_CHAT_MODEL
+        memory = (
+            os.getenv("OPENAI_MEMORY_MODEL", DEFAULT_MEMORY_MODEL).strip()
+            or DEFAULT_MEMORY_MODEL
+        )
+        retention = (os.getenv("OPENAI_RETENTION_MODE", "standard").strip() or "standard").lower()
+        if retention not in VALID_RETENTION_MODES:
+            allowed = ", ".join(sorted(VALID_RETENTION_MODES))
+            raise AIPrivacyConfigurationError(
+                f"OPENAI_RETENTION_MODE must be one of: {allowed}"
+            )
+        return cls(
+            default_model=base,
+            chat_model=chat,
+            memory_model=memory,
+            retention_mode=retention,
+        )
+
+    @property
+    def enhanced_retention(self) -> bool:
+        """Return whether MAM or ZDR has been explicitly configured for the project."""
+
+        return self.retention_mode in {"mam", "zdr"}
+
+    def model_for(self, workload: str) -> str:
+        normalized = workload.strip().lower()
+        if normalized not in VALID_WORKLOADS:
+            allowed = ", ".join(sorted(VALID_WORKLOADS))
+            raise ValueError(f"Unknown AI workload {workload!r}; expected one of: {allowed}")
+        if normalized == "chat":
+            return self.chat_model
+        if normalized == "memory":
+            return self.memory_model
+        return self.default_model
 
 
 @dataclass(frozen=True)
@@ -88,6 +146,32 @@ def _read_bool(name: str, *, default: bool) -> bool:
 
     logger.warning("invalid_bool_setting name=%s default=%s", name, default)
     return default
+
+
+def private_ai_config(
+    *,
+    workload: str,
+    policy: AIPlatformPolicy | None = None,
+    require_enhanced_retention: bool = True,
+) -> AIConfig:
+    """Build a fail-closed config for memory-aware/private Discord content.
+
+    Provider-side MAM/ZDR is configured outside the request itself. This helper makes
+    that deployment assertion explicit and always forces Responses API storage off.
+    """
+
+    policy = policy or AIPlatformPolicy.from_env()
+    if require_enhanced_retention and not policy.enhanced_retention:
+        raise AIPrivacyConfigurationError(
+            "Private Wilhelmina OpenAI calls require OPENAI_RETENTION_MODE=mam or zdr"
+        )
+    base = AIConfig.from_env()
+    return AIConfig(
+        model=policy.model_for(workload),
+        timeout_seconds=base.timeout_seconds,
+        max_retries=base.max_retries,
+        store_responses=False,
+    )
 
 
 def _has_api_key() -> bool:
@@ -160,7 +244,10 @@ def _result_from_response(
     fallback_model: str,
     preserve_newlines: bool,
 ) -> AIResult:
-    text = _normalize_text(str(getattr(response, "output_text", "") or ""), preserve_newlines=preserve_newlines)
+    text = _normalize_text(
+        str(getattr(response, "output_text", "") or ""),
+        preserve_newlines=preserve_newlines,
+    )
     usage = getattr(response, "usage", None)
     return AIResult(
         text=text,
@@ -208,7 +295,8 @@ def _log_failure(exc: Exception, *, purpose: str, model: str | None) -> None:
 
 def _log_success(result: AIResult, *, purpose: str) -> None:
     logger.info(
-        "openai_request_succeeded purpose=%s model=%s request_id=%s input_tokens=%s output_tokens=%s total_tokens=%s",
+        "openai_request_succeeded purpose=%s model=%s request_id=%s input_tokens=%s "
+        "output_tokens=%s total_tokens=%s",
         purpose,
         result.model,
         result.request_id,
@@ -296,6 +384,30 @@ async def generate_result_async(
     except Exception as exc:
         _log_failure(exc, purpose=purpose, model=config.model)
         return None
+
+
+async def generate_private_result_async(
+    prompt: str,
+    *,
+    workload: str,
+    purpose: str,
+    policy: AIPlatformPolicy | None = None,
+    preserve_newlines: bool = False,
+    require_enhanced_retention: bool = True,
+) -> AIResult | None:
+    """Run an async private-content request through the fail-closed privacy policy."""
+
+    config = private_ai_config(
+        workload=workload,
+        policy=policy,
+        require_enhanced_retention=require_enhanced_retention,
+    )
+    return await generate_result_async(
+        prompt,
+        config=config,
+        preserve_newlines=preserve_newlines,
+        purpose=purpose,
+    )
 
 
 def generate_text(

--- a/services/member_profiles.py
+++ b/services/member_profiles.py
@@ -162,6 +162,25 @@ def get_member_identity(
     return _row_to_identity(row) if row is not None else None
 
 
+def profile_is_complete(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+) -> bool:
+    """Return whether the member has a persisted identity profile, regardless of consent version."""
+
+    return (
+        get_member_identity(
+            connection,
+            guild_id=guild_id,
+            user_id=user_id,
+            required=False,
+        )
+        is not None
+    )
+
+
 def profile_has_current_consent(
     connection: sqlite3.Connection,
     *,

--- a/services/member_profiles.py
+++ b/services/member_profiles.py
@@ -14,7 +14,9 @@ from services.member_identity import (
     normalize_discord_display_name,
 )
 
-MEMBER_IDENTITY_SCHEMA_VERSION = 7
+MEMBER_IDENTITY_SCHEMA_VERSION = 8
+LEGACY_MEMORY_CONSENT_VERSION = "legacy-adult-memory-v1"
+CURRENT_MEMORY_CONSENT_VERSION = "2026-08-interaction-dm-cross-reveal-v2"
 
 
 class MemberIdentityProfileNotFound(LookupError):
@@ -31,6 +33,7 @@ class StoredMemberIdentity:
     preferred_name: str
     birth_date: str
     adult_memory_consent_at: str
+    memory_consent_version: str
     created_at: str
     updated_at: str
 
@@ -47,6 +50,10 @@ class StoredMemberIdentity:
     def trusted_chat_context(self, *, on_date: date) -> TrustedIdentityContext:
         return self.to_domain(today=on_date).trusted_chat_context(on_date=on_date)
 
+    @property
+    def has_current_memory_consent(self) -> bool:
+        return self.memory_consent_version == CURRENT_MEMORY_CONSENT_VERSION
+
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
@@ -58,6 +65,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         ),
         birth_date TEXT NOT NULL CHECK (birth_date GLOB '????-??-??'),
         adult_memory_consent_at TEXT NOT NULL,
+        memory_consent_version TEXT NOT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         PRIMARY KEY (guild_id, user_id),
@@ -69,12 +77,33 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
 )
 
 
+def _column_names(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {
+        str(row["name"])
+        for row in connection.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+
+
+def _migrate_legacy_memory_consent(connection: sqlite3.Connection) -> None:
+    columns = _column_names(connection, "coven_member_identity_profiles")
+    if "memory_consent_version" in columns:
+        return
+    connection.execute(
+        """
+        ALTER TABLE coven_member_identity_profiles
+        ADD COLUMN memory_consent_version TEXT NOT NULL
+        DEFAULT 'legacy-adult-memory-v1'
+        """
+    )
+
+
 def initialize_member_identity_schema(connection: sqlite3.Connection) -> None:
-    """Create the private member-identity table idempotently."""
+    """Create and migrate the private member-identity table idempotently."""
 
     registry.initialize_registry_schema(connection)
     for statement in SCHEMA_STATEMENTS:
         connection.execute(statement)
+    _migrate_legacy_memory_consent(connection)
     connection.execute(
         """
         INSERT OR IGNORE INTO schema_migrations (version, applied_at)
@@ -92,6 +121,7 @@ def _row_to_identity(row: sqlite3.Row) -> StoredMemberIdentity:
         preferred_name=str(row["preferred_name"]),
         birth_date=str(row["birth_date"]),
         adult_memory_consent_at=str(row["adult_memory_consent_at"]),
+        memory_consent_version=str(row["memory_consent_version"]),
         created_at=str(row["created_at"]),
         updated_at=str(row["updated_at"]),
     )
@@ -116,6 +146,7 @@ def get_member_identity(
             profile.preferred_name,
             profile.birth_date,
             profile.adult_memory_consent_at,
+            profile.memory_consent_version,
             profile.created_at,
             profile.updated_at
         FROM coven_member_identity_profiles AS profile
@@ -131,6 +162,21 @@ def get_member_identity(
     return _row_to_identity(row) if row is not None else None
 
 
+def profile_has_current_consent(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+) -> bool:
+    profile = get_member_identity(
+        connection,
+        guild_id=guild_id,
+        user_id=user_id,
+        required=False,
+    )
+    return profile is not None and profile.has_current_memory_consent
+
+
 def save_member_identity(
     connection: sqlite3.Connection,
     *,
@@ -143,12 +189,17 @@ def save_member_identity(
     adult_memory_consent: bool,
     actor_user_id: int,
     consent_at: str | None = None,
+    consent_version: str = CURRENT_MEMORY_CONSENT_VERSION,
 ) -> StoredMemberIdentity:
-    """Validate and persist both names, full birth date, and adult-memory consent."""
+    """Validate and persist identity plus an explicit versioned adult-memory consent."""
 
     initialize_member_identity_schema(connection)
     if not adult_memory_consent:
         raise MemberIdentityError("adult memory consent is required to complete induction")
+
+    normalized_consent_version = consent_version.strip()
+    if not normalized_consent_version:
+        raise MemberIdentityError("consent_version cannot be empty")
 
     identity = MemberIdentity.create(
         discord_display_name=discord_display_name,
@@ -195,14 +246,16 @@ def save_member_identity(
             preferred_name,
             birth_date,
             adult_memory_consent_at,
+            memory_consent_version,
             created_at,
             updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (guild_id, user_id) DO UPDATE SET
             preferred_name = excluded.preferred_name,
             birth_date = excluded.birth_date,
             adult_memory_consent_at = excluded.adult_memory_consent_at,
+            memory_consent_version = excluded.memory_consent_version,
             updated_at = excluded.updated_at
         """,
         (
@@ -211,6 +264,7 @@ def save_member_identity(
             identity.preferred_name,
             identity.birth_date.isoformat(),
             consent_timestamp,
+            normalized_consent_version,
             timestamp,
             timestamp,
         ),
@@ -237,6 +291,7 @@ def save_member_identity(
             or before.preferred_name != after.preferred_name,
             "birth_date_changed": before is None or before.birth_date != after.birth_date,
             "adult_memory_consent_recorded": True,
+            "memory_consent_version": normalized_consent_version,
         },
     )
     return after
@@ -308,4 +363,6 @@ def get_trusted_identity_context(
         required=True,
     )
     assert stored is not None
+    if not stored.has_current_memory_consent:
+        raise MemberIdentityError("member must accept the current adult memory disclosure")
     return stored.trusted_chat_context(on_date=on_date)

--- a/services/memory_policy.py
+++ b/services/memory_policy.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+VALID_COLLECTION_MODES = frozenset({"off", "interaction", "ambient"})
+TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+class MemoryPolicyConfigurationError(RuntimeError):
+    """Raised when memory collection configuration is contradictory or invalid."""
+
+
+def _read_bool(name: str, *, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    normalized = raw.strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    raise MemoryPolicyConfigurationError(f"{name} must be a boolean")
+
+
+@dataclass(frozen=True)
+class MemoryRuntimePolicy:
+    """Fail-closed runtime switches for interaction and future ambient collection."""
+
+    collection_mode: str = "off"
+    ambient_enabled: bool = False
+    ambient_approval_reference: str | None = None
+
+    @classmethod
+    def from_env(cls) -> "MemoryRuntimePolicy":
+        mode = (os.getenv("MEMORY_COLLECTION_MODE", "off").strip() or "off").lower()
+        if mode not in VALID_COLLECTION_MODES:
+            allowed = ", ".join(sorted(VALID_COLLECTION_MODES))
+            raise MemoryPolicyConfigurationError(
+                f"MEMORY_COLLECTION_MODE must be one of: {allowed}"
+            )
+        approval = os.getenv("AMBIENT_MEMORY_APPROVAL_REFERENCE", "").strip() or None
+        return cls(
+            collection_mode=mode,
+            ambient_enabled=_read_bool("ENABLE_AMBIENT_MEMORY", default=False),
+            ambient_approval_reference=approval,
+        )
+
+    @property
+    def interaction_collection_enabled(self) -> bool:
+        """Whether direct/participating Wilhelmina interactions may enter extraction."""
+
+        return self.collection_mode in {"interaction", "ambient"}
+
+    @property
+    def ambient_collection_ready(self) -> bool:
+        """Require all three independent switches before ambient guild collection."""
+
+        return (
+            self.collection_mode == "ambient"
+            and self.ambient_enabled
+            and bool(self.ambient_approval_reference)
+        )
+
+    def require_ambient_collection_ready(self) -> None:
+        if not self.ambient_collection_ready:
+            raise MemoryPolicyConfigurationError(
+                "Ambient memory requires MEMORY_COLLECTION_MODE=ambient, "
+                "ENABLE_AMBIENT_MEMORY=true, and AMBIENT_MEMORY_APPROVAL_REFERENCE"
+            )

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -76,6 +76,82 @@ def test_config_reads_privacy_timeout_and_retry_settings(monkeypatch):
     assert config.store_responses is True
 
 
+def test_quality_first_defaults_use_sol_for_chat_and_terra_for_memory(monkeypatch):
+    for name in (
+        "OPENAI_MODEL",
+        "OPENAI_CHAT_MODEL",
+        "OPENAI_MEMORY_MODEL",
+        "OPENAI_RETENTION_MODE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    policy = ai.AIPlatformPolicy.from_env()
+
+    assert ai.AIConfig.from_env().model == "gpt-5.6-sol"
+    assert policy.model_for("default") == "gpt-5.6-sol"
+    assert policy.model_for("chat") == "gpt-5.6-sol"
+    assert policy.model_for("memory") == "gpt-5.6-terra"
+    assert policy.retention_mode == "standard"
+
+
+def test_platform_policy_allows_explicit_model_overrides(monkeypatch):
+    monkeypatch.setenv("OPENAI_MODEL", "default-model")
+    monkeypatch.setenv("OPENAI_CHAT_MODEL", "chat-model")
+    monkeypatch.setenv("OPENAI_MEMORY_MODEL", "memory-model")
+    monkeypatch.setenv("OPENAI_RETENTION_MODE", "mam")
+
+    policy = ai.AIPlatformPolicy.from_env()
+
+    assert policy.model_for("default") == "default-model"
+    assert policy.model_for("chat") == "chat-model"
+    assert policy.model_for("memory") == "memory-model"
+    assert policy.enhanced_retention is True
+
+
+def test_platform_policy_rejects_unknown_retention_mode(monkeypatch):
+    monkeypatch.setenv("OPENAI_RETENTION_MODE", "magic")
+
+    with pytest.raises(ai.AIPrivacyConfigurationError, match="OPENAI_RETENTION_MODE"):
+        ai.AIPlatformPolicy.from_env()
+
+
+def test_private_config_fails_closed_without_enhanced_retention(monkeypatch):
+    monkeypatch.setenv("OPENAI_RETENTION_MODE", "standard")
+
+    with pytest.raises(ai.AIPrivacyConfigurationError, match="mam or zdr"):
+        ai.private_ai_config(workload="chat")
+
+
+@pytest.mark.parametrize("retention_mode", ["mam", "zdr"])
+def test_private_config_forces_store_false_and_routes_workload(monkeypatch, retention_mode):
+    monkeypatch.setenv("OPENAI_RETENTION_MODE", retention_mode)
+    monkeypatch.setenv("OPENAI_STORE_RESPONSES", "true")
+    monkeypatch.setenv("OPENAI_CHAT_MODEL", "private-chat")
+    monkeypatch.setenv("OPENAI_MEMORY_MODEL", "private-memory")
+
+    chat = ai.private_ai_config(workload="chat")
+    memory = ai.private_ai_config(workload="memory")
+
+    assert chat.model == "private-chat"
+    assert memory.model == "private-memory"
+    assert chat.store_responses is False
+    assert memory.store_responses is False
+
+
+def test_private_config_can_be_exercised_with_standard_retention_in_synthetic_tests(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENAI_RETENTION_MODE", "standard")
+
+    config = ai.private_ai_config(
+        workload="memory",
+        require_enhanced_retention=False,
+    )
+
+    assert config.model == "gpt-5.6-terra"
+    assert config.store_responses is False
+
+
 def test_config_rejects_negative_retries(monkeypatch):
     monkeypatch.setenv("AI_MAX_RETRIES", "-5")
 
@@ -143,6 +219,34 @@ async def test_generate_result_async_uses_native_async_client(monkeypatch):
     assert result.text == "First line\nSecond line"
     assert client.options == {"timeout": 6.0, "max_retries": 1}
     assert client.responses.calls[0]["store"] is False
+
+
+@pytest.mark.asyncio
+async def test_private_async_call_uses_fail_closed_config(monkeypatch):
+    client = FakeAsyncClient()
+    monkeypatch.setattr(ai, "_get_async_openai_client", lambda: client)
+    policy = ai.AIPlatformPolicy(
+        default_model="default",
+        chat_model="chat-sol",
+        memory_model="memory-terra",
+        retention_mode="zdr",
+    )
+
+    result = await ai.generate_private_result_async(
+        "Private Discord context",
+        workload="chat",
+        purpose="private_test",
+        policy=policy,
+    )
+
+    assert result is not None
+    assert client.responses.calls == [
+        {
+            "model": "chat-sol",
+            "input": "Private Discord context",
+            "store": False,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_member_profiles.py
+++ b/tests/test_member_profiles.py
@@ -57,6 +57,8 @@ def test_identity_persists_both_names_full_birth_date_and_consent(tmp_path) -> N
     assert stored.preferred_name == "Jessica"
     assert stored.birth_date == "1991-10-31"
     assert stored.adult_memory_consent_at == "2026-08-06T20:00:00+00:00"
+    assert stored.memory_consent_version == member_profiles.CURRENT_MEMORY_CONSENT_VERSION
+    assert stored.has_current_memory_consent is True
     assert context.discord_display_name == "xXDarkSylveonXx"
     assert context.preferred_name == "Jessica"
     assert context.birth_date == "1991-10-31"
@@ -92,6 +94,7 @@ def test_identity_survives_a_new_database_connection(tmp_path) -> None:
     assert stored.discord_display_name == "Screen Name"
     assert stored.preferred_name == "Real Name"
     assert stored.birth_date == "1990-01-01"
+    assert stored.has_current_memory_consent is True
 
 
 def test_adult_memory_consent_is_required(tmp_path) -> None:
@@ -118,6 +121,26 @@ def test_adult_memory_consent_is_required(tmp_path) -> None:
         )
 
     assert stored is None
+
+
+def test_consent_version_cannot_be_empty(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        with pytest.raises(MemberIdentityError, match="consent_version"):
+            member_profiles.save_member_identity(
+                connection,
+                guild_id=1,
+                user_id=300,
+                discord_display_name="Screen Name",
+                preferred_name="Real Name",
+                birth_date="1990-01-01",
+                today=date(2026, 8, 6),
+                adult_memory_consent=True,
+                consent_version="   ",
+                actor_user_id=300,
+            )
 
 
 def test_underage_profile_does_not_change_registry_name(tmp_path) -> None:
@@ -234,6 +257,7 @@ def test_identity_audit_omits_names_and_birth_date(tmp_path) -> None:
     assert "Secret Screen Name" not in payload
     assert "Secret Preferred Name" not in payload
     assert "1991-10-31" not in payload
+    assert member_profiles.CURRENT_MEMORY_CONSENT_VERSION in payload
 
 
 def test_identity_schema_version_and_table_are_created(tmp_path) -> None:
@@ -252,6 +276,12 @@ def test_identity_schema_version_and_table_are_created(tmp_path) -> None:
             WHERE type = 'table' AND name = 'coven_member_identity_profiles'
             """
         ).fetchone()
+        columns = {
+            str(row["name"])
+            for row in connection.execute(
+                "PRAGMA table_info(coven_member_identity_profiles)"
+            ).fetchall()
+        }
         versions = {
             int(row["version"])
             for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
@@ -260,4 +290,57 @@ def test_identity_schema_version_and_table_are_created(tmp_path) -> None:
         connection.close()
 
     assert table is not None
+    assert "memory_consent_version" in columns
     assert member_profiles.MEMBER_IDENTITY_SCHEMA_VERSION in versions
+
+
+def test_legacy_identity_profile_migrates_without_granting_new_consent(tmp_path) -> None:
+    path = tmp_path / "identity.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE coven_member_identity_profiles (
+                guild_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                preferred_name TEXT NOT NULL,
+                birth_date TEXT NOT NULL,
+                adult_memory_consent_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (guild_id, user_id)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO coven_member_identity_profiles (
+                guild_id, user_id, preferred_name, birth_date,
+                adult_memory_consent_at, created_at, updated_at
+            )
+            VALUES (1, 300, 'Jessica', '1991-10-31', 'old-consent', 'created', 'updated')
+            """
+        )
+        connection.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (7, 'old')"
+        )
+
+        member_profiles.initialize_member_identity_schema(connection)
+        stored = member_profiles.get_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            required=True,
+        )
+
+        assert stored is not None
+        assert stored.memory_consent_version == member_profiles.LEGACY_MEMORY_CONSENT_VERSION
+        assert stored.has_current_memory_consent is False
+        with pytest.raises(MemberIdentityError, match="current adult memory disclosure"):
+            member_profiles.get_trusted_identity_context(
+                connection,
+                guild_id=1,
+                user_id=300,
+                on_date=date(2026, 8, 6),
+            )

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -1,0 +1,83 @@
+import pytest
+
+from services import memory_policy
+
+
+def test_memory_collection_defaults_fail_closed(monkeypatch) -> None:
+    for name in (
+        "MEMORY_COLLECTION_MODE",
+        "ENABLE_AMBIENT_MEMORY",
+        "AMBIENT_MEMORY_APPROVAL_REFERENCE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    policy = memory_policy.MemoryRuntimePolicy.from_env()
+
+    assert policy.collection_mode == "off"
+    assert policy.interaction_collection_enabled is False
+    assert policy.ambient_collection_ready is False
+
+
+def test_interaction_mode_enables_only_participating_interactions(monkeypatch) -> None:
+    monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
+    monkeypatch.setenv("ENABLE_AMBIENT_MEMORY", "true")
+    monkeypatch.setenv("AMBIENT_MEMORY_APPROVAL_REFERENCE", "approval-123")
+
+    policy = memory_policy.MemoryRuntimePolicy.from_env()
+
+    assert policy.interaction_collection_enabled is True
+    assert policy.ambient_collection_ready is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "enabled", "approval"),
+    [
+        ("ambient", "false", "approval-123"),
+        ("ambient", "true", ""),
+        ("interaction", "true", "approval-123"),
+    ],
+)
+def test_ambient_memory_requires_all_independent_gates(
+    monkeypatch,
+    mode,
+    enabled,
+    approval,
+) -> None:
+    monkeypatch.setenv("MEMORY_COLLECTION_MODE", mode)
+    monkeypatch.setenv("ENABLE_AMBIENT_MEMORY", enabled)
+    monkeypatch.setenv("AMBIENT_MEMORY_APPROVAL_REFERENCE", approval)
+
+    policy = memory_policy.MemoryRuntimePolicy.from_env()
+
+    assert policy.ambient_collection_ready is False
+    with pytest.raises(memory_policy.MemoryPolicyConfigurationError, match="Ambient memory"):
+        policy.require_ambient_collection_ready()
+
+
+def test_ambient_memory_is_ready_only_when_every_gate_is_present(monkeypatch) -> None:
+    monkeypatch.setenv("MEMORY_COLLECTION_MODE", "ambient")
+    monkeypatch.setenv("ENABLE_AMBIENT_MEMORY", "true")
+    monkeypatch.setenv("AMBIENT_MEMORY_APPROVAL_REFERENCE", "discord-review-approval")
+
+    policy = memory_policy.MemoryRuntimePolicy.from_env()
+
+    assert policy.interaction_collection_enabled is True
+    assert policy.ambient_collection_ready is True
+    policy.require_ambient_collection_ready()
+
+
+def test_invalid_collection_mode_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("MEMORY_COLLECTION_MODE", "everywhere-bitch")
+
+    with pytest.raises(
+        memory_policy.MemoryPolicyConfigurationError,
+        match="MEMORY_COLLECTION_MODE",
+    ):
+        memory_policy.MemoryRuntimePolicy.from_env()
+
+
+def test_invalid_ambient_boolean_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("ENABLE_AMBIENT_MEMORY", "maybe")
+
+    with pytest.raises(memory_policy.MemoryPolicyConfigurationError, match="boolean"):
+        memory_policy.MemoryRuntimePolicy.from_env()


### PR DESCRIPTION
## Purpose

Reconcile the OpenAI, member-identity, and Memory Ledger foundations with the locked next-phase product decisions before schema/extraction/chat work begins.

This is a stacked PR on top of `memory-profile-induction`.

## Implemented

- quality-first OpenAI routing: GPT-5.6 Sol for general/chat, GPT-5.6 Terra for structured memory work
- private OpenAI request helper that always forces `store=false`
- private memory/chat calls fail closed unless runtime asserts approved MAM or ZDR retention
- provider-retention mode validation without pretending an env var grants MAM/ZDR entitlement
- versioned adult-memory consent
- existing identity profiles migrate to legacy consent rather than silently gaining DM/cross-member permissions
- trusted identity context requires the current disclosure
- full DOB + locally calculated age remain available in approved trusted context
- induction copy now explicitly discloses DM memory and social callbacks across approved conversations
- compatibility `profile_is_complete()` helper retained separately from current-consent validity
- explicit memory runtime modes: `off`, `interaction`, `ambient`
- ambient whole-server memory requires three independent gates, including a documented platform approval/clarification reference
- `.env.example`, `AGENTS.md`, Member Identity docs, and Memory Ledger contract reconciled with the seven-phase build plan
- tests added for model routing, retention fail-closed behavior, consent migration, and ambient gates

## Architecture contract

SQLite remains the canonical memory store. Python owns authorization, consent, reveal scope, sensitive-data rejection, age calculation, reconciliation, and database mutations. OpenAI receives only locally approved context and returns language/structured proposals; it never becomes memory authority.

The current speaker's full permitted active profile remains core future chat context. Later local retrieval is for cross-member memories, contradictions, evidence, and receipts—not aggressive token-cost trimming.

## Deployment gates

- automatic memory collection still defaults off
- the intended next live collection mode is eligible interaction involving Wilhelmina
- ambient guild listening remains hard-disabled unless all runtime/platform gates are satisfied
- no live OpenAI key or provider request is required for this PR's tests

## Validation

- CI run `31417441105` passed
- dependency installation passed
- `ruff check .` passed
- `pytest` passed
- no live OpenAI key or provider request was used
- GitHub currently reports this stacked PR as mergeable

## Stack order

1. #35 `Build the OpenAI platform foundation` → `main`
2. #34 `Build the member identity foundation` → `openai-platform-foundation`
3. #36 `Phase 1: reconcile the memory-aware foundation` → `memory-profile-induction`

Keep #36 draft until the two lower dependency PRs are resolved; the code itself is green.