### PR TITLE
Phase 2: upgrade Memory Ledger architecture

### DIFF
--- a/docs/memory_ledger.md
+++ b/docs/memory_ledger.md
@@ -1,108 +1,62 @@
 # Memory Ledger
 
-The Memory Ledger is Wilhelmina's private, persistent local memory for eligible human interactions. SQLite is the canonical source of truth. OpenAI may interpret or phrase approved context for a request, but OpenAI does not own the memory database and model output never directly authorizes access, deletion, replacement, or disclosure.
+The Memory Ledger is Wilhelmina's private, persistent local memory. SQLite is the canonical source of truth. OpenAI may interpret already-authorized text or reason over already-authorized context, but model output never authorizes access, disclosure, replacement, or deletion.
 
-This document is the implementation contract for the next memory-aware phases. PR #33 already implements the schema-v6 persistence foundation. Automatic extraction, local retrieval intelligence, and live Wilhelmina chat are later phases and must not be treated as already deployed.
+The product target remains an adult social character: sharp, vulgar, funny, intrusive when useful, and able to remember callbacks, contradictions, preferences, gossip, names, birthdays, projects, and other ordinary social context. Target voice: **mean enough to delight the room, sharp enough to feel intelligent, and still useful.**
 
-## Product direction
+Quality and memory richness take priority over minimizing model/token cost. Privacy controls exist to prevent dangerous retention or disclosure, not to make Wilhelmina artificially stupid.
 
-Wilhelmina is an adult social character, not a sanitized support bot. The intended experience is profane, sharp, funny, intrusive when useful, and capable of remembering callbacks, contradictions, preferences, embarrassing details, gossip, names, birthdays, projects, and other ordinary social context.
+## Current persistence status
 
-Target voice: **mean enough to delight the room, sharp enough to feel intelligent, and still useful.**
+### Member identity schema v8
 
-Quality and memory richness take priority over minimizing model or token cost. Privacy controls should minimize unnecessary retention and accidental disclosure without deliberately making Wilhelmina dumber.
+The private identity profile stores:
 
-## Collection modes
+- current Discord display name through the Registry;
+- member-provided preferred name;
+- full self-reported birth date;
+- adult-memory consent timestamp;
+- version of the memory disclosure accepted.
 
-Automatic collection is controlled by an explicit fail-closed runtime mode:
+The current disclosure covers interaction memory, DMs directly with Wilhelmina, and ordinary cross-member social callbacks. Legacy consent is not silently upgraded. Full birth date remains canonical and current age is calculated locally when trusted context is assembled.
 
-- `off` — no automatic memory extraction;
-- `interaction` — eligible interactions involving Wilhelmina may be extracted;
-- `ambient` — future broad guild listening, subject to additional hard gates.
+### Memory Ledger schema v9
 
-The default is `off`.
+Phase 2 upgrades the Memory Ledger from v6 to v9. Version 8 is already occupied by identity-consent migration, so v9 is the next persistence version.
 
-### Interaction collection
+Schema v9 contains:
 
-The approved near-term target is `interaction` mode. Eligible sources may include:
+- `memory_ledger_settings`;
+- `memory_records`;
+- `memory_receipts`;
+- `memory_contradictions`;
+- `memory_entities`;
+- `memory_search` (SQLite FTS5 virtual table and sync triggers).
 
-- a direct message sent to Wilhelmina;
-- a guild message that directly mentions Wilhelmina;
-- a reply to Wilhelmina;
-- an active direct conversation with Wilhelmina;
-- a later explicit remember action.
+Automatic Discord extraction and the live chat surface are **not** implemented by this schema phase. They remain later phases.
 
-A DM is eligible only when Wilhelmina is herself a participant. Wilhelmina cannot read or collect DMs between other people.
+## Memory record
 
-Only human-authored text is eligible. Bot messages, webhook messages, automated integrations, images, audio, video, uploaded files, and external-link contents are excluded.
+Every memory remains guild-scoped and attached to an existing Coven Registry/profile shell. No outsider profile is created merely because somebody gossips about a third party.
 
-There is no history import or backfill.
+A v9 memory stores:
 
-### Future ambient collection
+- guild ID;
+- subject/member ID;
+- category;
+- epistemic label;
+- concise summary;
+- normalized duplicate key;
+- normalized topic key;
+- gossip flag;
+- active flag;
+- privacy class;
+- reveal scope;
+- retrieval importance;
+- creator ID;
+- created, updated, and last-confirmed timestamps.
 
-The product vision keeps a future "ears everywhere" path so Wilhelmina may eventually learn from broader server conversation when platform rules and deployment approval make that appropriate.
-
-Ambient collection must remain fail-closed. It is considered ready only when all of the following are present:
-
-1. `MEMORY_COLLECTION_MODE=ambient`;
-2. `ENABLE_AMBIENT_MEMORY=true`;
-3. a non-empty `AMBIENT_MEMORY_APPROVAL_REFERENCE` documenting the required platform clarification/approval.
-
-One switch alone must never activate broad listening. The extraction/event phase must reject ambient messages before any OpenAI request when the full gate is not satisfied.
-
-## Consent and adult identity
-
-The memory experience is adult-only. Induction records a full self-reported birth date and rejects members under eighteen.
-
-The adult-memory disclosure is versioned. The current disclosure covers the intended richer behavior: messages sent to Wilhelmina, including DMs, may be remembered, and ordinary social memories may later resurface in approved conversations, including conversations with other participating adult members.
-
-Legacy consent is not silently upgraded. An older profile may remain stored, but trusted memory-aware context is blocked until the current disclosure is accepted.
-
-The private identity profile preserves two distinct names:
-
-- the member's current Discord display name;
-- the preferred name explicitly given to Wilhelmina.
-
-The full birth date remains the canonical source of truth. Python calculates current age locally. In an already-authorized trusted memory-aware request, Wilhelmina may receive both names, the full birth date, and calculated age so she can use birthday/age context naturally. These values do not belong in public Registry cards, generic logs, or unrelated AI features.
-
-## Visibility and social use
-
-Raw Memory Ledger records, receipts, searches, and administration surfaces remain private to authorized founder/admin tooling.
-
-Approved memory-aware conversational surfaces are different from raw Ledger administration. The target conversational surfaces are:
-
-- one designated Wilhelmina server channel;
-- direct conversations with Wilhelmina.
-
-Within those approved surfaces, ordinary permitted social memories may be used across members when contextually relevant. This is intentionally the "full menace" social behavior: Wilhelmina is allowed to remember one person's ordinary social statement and later bring it up while talking with somebody else.
-
-That permission does not override hard privacy classes. Credentials, financial data, exact private addresses, restricted/admin-only data, dangerous identifiers, diagnoses, and similar prohibited material are never comedy ammunition and must not enter ordinary chat context.
-
-Gossip remains gossip. It must stay attributed and unverified rather than being presented as established fact.
-
-## Server and DM behavior
-
-### Designated server channel
-
-Wilhelmina uses a selective social-predator participation style:
-
-- direct mentions, replies, and direct questions receive a response;
-- ordinary human conversation does not receive a mechanical response to every message;
-- she may spontaneously interject only when there is something genuinely funny, useful, juicy, contradictory, or strongly relevant to contribute.
-
-The later local selector/interjection gate should decide whether an ordinary message is worth considering before a chat-model call is made. The model may still return `NO_REPLY` for an optional interjection.
-
-### DMs
-
-DMs are a confessional-booth mode, not an amnesiac or sanitized version of the bot.
-
-A user-initiated DM may use the same permitted Memory Ledger as server chat, including relevant cross-member context. The behavioral difference is social framing: DM replies may be more candid, detailed, intimate, and analytical because there is no public audience.
-
-Wilhelmina does not proactively scrape third-party DMs and does not gain access to conversations she is not in.
-
-## Categories and epistemic labels
-
-Existing Memory Ledger categories remain schema-compatible:
+Categories remain:
 
 - `Identity`
 - `Preference`
@@ -117,281 +71,255 @@ Existing Memory Ledger categories remain schema-compatible:
 - `Wilhelmina impression`
 - `Gossip`
 
-Existing labels remain schema-compatible:
+Epistemic labels remain:
 
 - `Fact`
 - `Inference`
 - `Impression`
 - `Gossip`
 
-Automatic extraction must prefer explicit durable statements over speculative person-level inference. The later extraction/privacy phase will define which inference/impression records may be machine-created under current platform policy. Schema compatibility alone is not authorization to generate psychological dossiers.
+Gossip is always treated as attributed/unverified social information rather than established fact.
 
-Gossip is treated as an attributed unverified claim, never established fact.
+## Privacy and reveal metadata
 
-## Prohibited information
+Schema v9 separates **what a memory is** from **where it may be revealed**.
 
-The deterministic local validator runs before any external AI request and before persistence.
+### Privacy class
 
-At minimum, reject or quarantine:
+- `ordinary` — normal adult social memory eligible for approved conversational use.
+- `restricted` — material that requires a narrower reveal scope.
 
-- passwords and authentication secrets;
-- API/access tokens and login credentials;
-- banking, card, payment, or account information;
-- government/private identity-document numbers;
-- exact home/private addresses and precise live location;
-- medical or mental-health diagnoses;
-- intimate non-consensual material;
-- information involving minors that is inappropriate for the adult-memory system;
-- comparable dangerous private secrets.
+### Reveal scope
 
-Do **not** blanket-reject DMs merely because they are private. A DM sent directly to Wilhelmina is an eligible source after consent and policy checks. Private messages that were not sent to Wilhelmina are outside her accessible collection scope.
+- `cross_member` — may be used in approved memory-aware conversation even when the current interlocutor is somebody else. This is the default for ordinary social memories and implements the locked "full menace" direction.
+- `owner_only` — may be revealed only when the current interlocutor is the memory's subject.
+- `admin_only` — never enters ordinary member chat; reserved for founder/admin surfaces.
 
-If local validation rejects a message, no external extraction request is made and no memory is created from that content.
+`restricted + cross_member` is invalid. An `Admin note` is always forced to `restricted/admin_only` regardless of caller input.
 
-## Memory ownership, records, and receipts
+These fields are deterministic local authorization metadata. OpenAI never gets to override them.
 
-A stored memory is attached to the Coven Registry/profile shell of the participating member who supplied it. Third-party gossip does not automatically create a standalone outsider profile.
+### Importance
 
-The existing schema-v6 record stores:
+`importance` is an integer from 0 through 100, default 50. It is a local retrieval/ranking signal for later context assembly. It is not an authorization signal and does not override reveal scope.
 
-- guild ID;
-- owner/subject user ID;
-- category;
-- epistemic label;
-- concise summary;
-- normalized duplicate key;
-- normalized topic key;
-- gossip marker;
-- active status;
-- creator ID;
-- created, updated, and last-confirmed timestamps.
+## Receipts and source context
 
-Nothing expires automatically under the existing persistence contract.
+Every memory has evidence.
 
-Every memory has at least one receipt.
+Schema v9 adds `source_context` so a receipt can honestly represent where the evidence came from:
 
-A Discord receipt stores source message ID, jump URL when available, author, channel, timestamp, original excerpt, latest edited excerpt, edit timestamp, and source-deletion timestamp. DM receipts will use the same evidence principle without pretending a guild jump URL exists when Discord does not provide one.
+- `guild` — Discord guild message. Requires channel ID, message ID, and jump URL.
+- `dm` — direct message involving Wilhelmina. Requires message ID but **does not fabricate a guild jump URL**. A DM channel ID may be retained if the event layer has one, but it is not treated as a guild channel.
+- `admin` — founder/admin-authored memory. No Discord channel, message, or jump URL is fabricated.
 
-An admin-authored memory uses an admin receipt and never fabricates Discord message metadata.
+Discord receipts retain:
 
-If a captured Discord source is later deleted, the existing design keeps the stored receipt excerpt and marks the source deleted.
+- source author;
+- source context;
+- channel ID when applicable;
+- message ID;
+- jump URL when applicable;
+- original excerpt;
+- latest edited excerpt;
+- source creation timestamp;
+- edit timestamp;
+- source deletion timestamp.
 
-## Duplicate, replacement, and contradiction rules
+Deleting the original Discord message does not erase an already-captured receipt. It marks the source deleted. Permanently deleting the Memory Ledger record itself cascades its receipts.
 
-These decisions remain deterministic Python/SQLite behavior.
+## Duplicate, replacement, and contradiction behavior
+
+All destructive decisions remain Python/SQLite behavior.
 
 ### Exact duplicate
 
-Keep one memory record, add the new receipt, retain every supporting source, and update confirmation timestamps.
+An exact duplicate keeps one memory record, adds the new receipt, and updates confirmation timestamps.
 
 ### Topic-scoped correction
 
-For ordinary non-gossip memory, a newer correction about the same specific topic replaces that memory. The superseded content and receipts are permanently deleted. A minimal content-free replacement audit may remain.
+Ordinary replacement is **topic-scoped**, not category-wide.
 
-Unrelated memories in the same category coexist.
+A new ordinary memory replaces older active ordinary memories only when all of the following match:
 
-### Contradictory gossip
+- same guild;
+- same subject;
+- same normalized `topic_key`.
 
-Conflicting gossip remains as separate attributed claims. Related records are linked through contradiction rows. Deleting either memory removes the relevant contradiction relationship through cascading foreign keys.
+Unrelated memories in the same category coexist. For example, changing a coffee preference does not erase a movie preference merely because both are `Preference` memories.
 
-The future chat layer may conversationally call out contradictions when both underlying memories are permitted in the current context.
+Superseded ordinary records and their receipts are permanently deleted. A minimal content-free `memory.replaced` audit remains.
 
-## OpenAI boundary
+The legacy service parameter named `replace_normal_category` is temporarily preserved for compatibility; in v9 it controls topic-scoped replacement and no longer authorizes category-wide deletion.
 
-OpenAI receives only context approved by deterministic local code for the current operation.
+### Gossip contradiction
 
-Python owns:
+Multiple gossip claims about the same topic remain separate and are linked through `memory_contradictions`.
 
-- guild/member authorization;
-- consent and collection eligibility;
-- prohibited-data filtering;
+If a gossip record's topic/category changes, old contradiction links are cleared before valid links are regenerated. Deleting either memory cascades the relationship.
+
+## Entity index
+
+`memory_entities` provides deterministic local relationship/index data for later retrieval. Supported entity types are:
+
+- `subject` — automatically managed member who owns the memory;
+- `topic` — automatically managed normalized topic key;
+- `member` — additional participating/referenced Coven member IDs or member keys;
+- `term` — bounded normalized terms useful for deterministic lookup.
+
+`subject` and `topic` links are system-managed and cannot be overwritten through the public entity API. Custom entity replacement may change `member` and `term` links only.
+
+Deleting a memory cascades all entity links.
+
+## Local full-text search
+
+`memory_search` is an SQLite FTS5 external-content index over:
+
+- memory summary;
+- topic key.
+
+Insert/update/delete triggers keep it synchronized with `memory_records`.
+
+The service exposes local search with deterministic filters for:
+
+- guild;
 - reveal scope;
-- identity/age calculation;
-- duplicate/replacement decisions;
-- contradiction links;
-- database writes and deletes;
-- context budgeting and local retrieval;
-- logging/privacy policy.
+- optional subject IDs;
+- bounded result limit.
 
-OpenAI owns language tasks such as:
+Search defaults to `cross_member` records only. A later owner-context assembler may explicitly include `owner_only`. Admin-only records are never accidentally returned by the normal default.
 
-- structured candidate extraction from already-approved text;
-- concise memory phrasing inside a strict schema;
-- conversational reasoning over supplied context;
-- Wilhelmina's prose and optional `NO_REPLY` judgement.
+Entity lookup uses the same reveal-scope principle.
 
-Model output is a proposal, never database authority.
+This search layer is for local retrieval. OpenAI is **not** asked which private rows it is allowed to retrieve.
 
-Private memory/chat calls must use the shared asynchronous Responses API path with response storage disabled. Live private requests fail closed unless the deployment explicitly asserts an approved enhanced retention posture (`mam` or `zdr`). The provider-side MAM/ZDR setting is configured in the OpenAI project; an environment variable is only a runtime assertion and cannot grant the entitlement by itself.
+## Full-profile contract
 
-Quality-first default routing is:
+The current interlocutor's full permitted active profile remains core future chat context. FTS/entity retrieval is not a penny-saving excuse to amputate that profile.
 
-- GPT-5.6 Sol for Wilhelmina chat/general generation;
-- GPT-5.6 Terra for structured memory work;
-- model choices remain independently configurable and should later be validated with Wilhelmina-specific evals.
+Later retrieval uses these structures primarily for:
 
-Operational logs may contain request IDs, model names, token counts, status/latency, and content-free internal identifiers. They must not contain raw prompts, model replies, memory summaries, receipts, preferred names, or birth dates.
-
-## Full-profile and local retrieval contract
-
-The current interlocutor's full permitted active profile remains core context for memory-aware chat. The later retrieval engine is not designed to amputate that profile to save pennies.
-
-Local selection is primarily for:
-
-- relevant memories belonging to other members;
+- relevant cross-member memories;
+- named/referenced members;
 - contradiction partners;
-- detailed historical evidence;
-- receipt snippets;
-- especially relevant callbacks among a large history.
+- useful historical callbacks;
+- evidence/receipt budgeting.
 
-The planned selector will use deterministic local indexing/search and scoring. OpenAI is not asked to decide authorization or which private records it is allowed to retrieve.
+Authorization is applied before context is sent to the model.
 
-## Persistent collection controls
+## Audit privacy
 
-The existing Memory Ledger stores persistent active/paused state and designated chat-channel configuration. Pause/resume survives process restarts and does not delete existing memories.
+Operational audit rows must not serialize memory summaries or receipt excerpts.
 
-The later controls phase will reconcile those database settings with the new runtime collection policy. Runtime `off` or an unsatisfied ambient gate always wins over a permissive database setting.
+Schema-v9 service events keep only content-free metadata such as:
 
-## Administration
+- memory ID;
+- whether a record was created or merged;
+- whether fields changed;
+- privacy/reveal class;
+- receipt source context.
 
-The planned founder/admin surface remains private/ephemeral where Discord permits it:
+Permanent deletion/replacement audits remain content-free.
 
-```text
-/memory-admin status
-/memory-admin pause
-/memory-admin resume
-/memory-admin set-chat-channel
-/memory-admin profile
-/memory-admin search
-/memory-admin add
-/memory-admin edit
-/memory-admin delete
-/memory-admin receipt
-```
+Raw memories and receipts belong in the Memory Ledger, not generic audit logs.
 
-Any additional member data access/correction/deletion controls required by current platform terms will be implemented in the controls phase. The legacy `coven_profile_shells.memory_opt_out` field remains inert compatibility data unless explicitly migrated; it is not silently repurposed by Phase 1.
+## Prohibited information
 
-## Current schema status
+The deterministic local validator runs before external extraction and before persistence. At minimum it rejects material matching dangerous classes such as:
 
-### Memory Ledger schema version 6 — implemented
+- passwords and login credentials;
+- API/access tokens;
+- banking/payment/account information;
+- government/private identity-document numbers;
+- exact home/private addresses;
+- medical or mental-health diagnoses;
+- comparable dangerous private secrets.
 
-PR #33 implements:
+A DM sent directly to Wilhelmina is not rejected merely because it is private. Third-party DMs Wilhelmina is not part of remain outside accessible collection scope.
 
-- `memory_ledger_settings`;
-- `memory_records`;
-- `memory_receipts`;
-- `memory_contradictions`;
-- duplicate merging;
-- permanent ordinary replacement;
-- gossip contradiction links;
-- admin and Discord receipts;
-- permanent admin deletion with content-free audit;
-- local prohibited-content validation;
-- profile formatting and automated tests.
+Adult/social character direction never converts prohibited secrets or admin-only data into comedy ammunition.
 
-### Member identity schema version 8 — current stacked foundation
+## Collection policy
 
-The identity foundation stores preferred name, full birth date, adult-memory consent timestamp, and the version of the disclosure accepted. Existing schema-v7 identity data migrates to a legacy consent version rather than receiving the richer disclosure automatically.
+Automatic collection is still controlled separately by the Phase-1 runtime policy:
 
-Because version 8 is now occupied by identity-consent migration, the next Memory Ledger schema expansion must use a later schema version.
+- `off` — no automatic extraction;
+- `interaction` — eligible interaction involving Wilhelmina;
+- `ambient` — dormant future whole-server path requiring every platform/runtime gate.
 
-## Future extraction contract
+The default remains `off`.
 
-Automatic extraction is not yet implemented. When built, an eligible message may produce zero or more strict structured candidates such as:
+Phase 2 supplies durable local structures only; it does not activate automatic collection.
 
-```json
-{
-  "category": "Preference",
-  "epistemic_label": "Fact",
-  "summary": "Prefers iced coffee",
-  "topic_key": "drink.preference.coffee.temperature",
-  "relationship": "new|duplicate|replacement|contradictory_gossip",
-  "existing_memory_id": null
-}
-```
+## v6 → v9 migration matrix
 
-Mandatory processing order:
+Migration is idempotent and preserves existing content.
 
-1. classify the Discord source and interaction trigger;
-2. reject bots/webhooks/empty text and disallowed collection modes;
-3. verify current adult-memory consent and required local profile state;
-4. enforce the ambient multi-key gate when the source is ambient;
-5. run deterministic prohibited-information validation locally;
-6. only then send allowed text plus bounded existing-memory context to the structured extractor;
-7. validate the returned schema and local policy again;
-8. let Python merge duplicates, perform topic-scoped replacement, or preserve/link contradictory gossip;
-9. create the appropriate receipt transactionally.
+| Existing v6 data | v9 result |
+|---|---|
+| ordinary memory | preserved; `privacy_class=ordinary`, `reveal_scope=cross_member`, `importance=50` |
+| `Admin note` | preserved but tightened to `restricted/admin_only` |
+| guild Discord receipt | preserved and marked `source_context=guild` |
+| admin receipt | preserved and marked `source_context=admin` |
+| memory subject/topic | backfilled into system entity rows |
+| existing summary/topic | rebuilt into local FTS index |
+| receipts/contradictions | preserved subject to existing foreign-key integrity |
 
-Timeouts, refusals, malformed structured output, or provider failures create no speculative memory and do not block Discord event handling.
+The migration order is deliberate:
 
-## Message edits and deletions
+1. ensure base Registry/profile dependencies;
+2. ensure core memory tables exist;
+3. add new record columns to legacy tables;
+4. rebuild the receipt table into the v9 context-aware shape when required;
+5. create indexes that reference new columns;
+6. create/rebuild FTS and triggers;
+7. backfill subject/topic entity rows;
+8. record schema version 9.
 
-Edited sources preserve the original excerpt, store the latest excerpt/edit timestamp, run local validation before any re-extraction, and reconcile only memories connected to that source.
+Indexes never reference v9 columns before those columns exist.
 
-Deleted sources are marked deleted on matching receipts. The system does not reconstruct content it never captured.
+## Integrity checks
 
-## Seven-phase implementation order
+`check_memory_integrity()` provides a local Phase-2 diagnostic for:
 
-### Phase 1 — Foundation reconciliation
+- SQLite foreign-key violations;
+- orphan/mismatched entity rows;
+- invalid contradiction relationships;
+- missing system subject/topic entities;
+- presence of the FTS structure.
 
-- OpenAI Responses/async foundation made explicit and reviewable;
-- quality-first workload model routing;
-- private-call `store=false` enforcement and enhanced-retention fail-closed policy;
-- versioned adult-memory consent and legacy migration;
-- interaction/off/ambient runtime policy;
-- three-key ambient activation gate;
-- documentation/config/tests reconciled with DM and cross-member behavior.
+Tests also verify that deleting a memory removes dependent receipts, entity rows, contradiction links, and FTS searchability.
 
-### Phase 2 — Memory architecture upgrade
+## Rollback notes
 
-- next Memory Ledger schema migration;
-- privacy/reveal metadata;
-- entity indexing and local full-text search;
-- deletion integrity and migration matrix;
-- durable local structures needed by retrieval/extraction.
+Do not downgrade an already-migrated production database by merely running older code against it.
+
+Safe rollback for this phase is operational:
+
+1. stop Wilhelmina before changing database code;
+2. restore the pre-v9 SQLite backup/snapshot together with the previous application revision; or
+3. if no database rollback is needed, deploy a forward fix that continues understanding v9.
+
+The migration intentionally does not keep duplicated private-content backup tables after success. Old receipt rows are copied into the v9 table and the temporary legacy table is dropped in the same transaction managed by the caller.
+
+## Remaining implementation phases
 
 ### Phase 3 — Memory controls
 
-- full founder/admin Memory Ledger controls;
-- required privacy/data-access/correction/deletion controls;
-- persistent status/pause/resume/channel configuration;
-- authorization and privacy tests.
+Founder/admin commands, required member data controls, persistent pause/resume/channel controls, authorization and privacy tests.
 
 ### Phase 4 — Automatic memory extraction
 
-- Discord event eligibility for approved interaction sources and DMs;
-- local prohibited-data guard;
-- strict OpenAI structured extraction;
-- queue/backpressure/failure handling;
-- new/edit/delete reconciliation;
-- receipts, duplicate merging, replacement, and gossip contradiction handling.
+Discord interaction/DM event eligibility, local prohibited-data guard, strict structured OpenAI extraction, queue/backpressure, receipt/edit/delete reconciliation.
 
-### Phase 5 — Memory intelligence and context
+### Phase 5 — Memory intelligence/context
 
-- local FTS/index retrieval;
-- deterministic scoring and contradiction expansion;
-- full active speaker profile loading;
-- cross-member memory selection;
-- receipt/evidence budgeting;
-- deterministic context assembly tests.
+Deterministic scoring, FTS/entity retrieval, full active speaker profile loading, cross-member selection, contradiction expansion, evidence budgeting.
 
 ### Phase 6 — Wilhelmina chat brain
 
-- designated server chat;
-- fully memory-aware DM confessional mode;
-- direct-response behavior;
-- selective spontaneous interjection gate;
-- cross-member social-memory use;
-- adult Wilhelmina persona and chat evals.
+Designated server chat, fully memory-aware DM confessional mode, direct responses, selective spontaneous interjections, adult persona/evals.
 
 ### Phase 7 — Hardening and dormant ambient path
 
-- adversarial/privacy regression suite;
-- migration/reconnect/rate-limit testing;
-- observability and rollback controls;
-- production privacy assertions;
-- ambient event path completed but kept disabled until all deployment/platform gates are satisfied.
-
-## Final live testing
-
-The live Discord pass must eventually verify consent migration, DMs with Wilhelmina, direct server interactions, bot/webhook exclusion, pause persistence, edits/deletes, duplicate merges, topic-scoped replacement, gossip contradiction links, full-profile loading, cross-member context rules, selective interjections, DM/server mode differences, private admin surfaces, enhanced OpenAI retention configuration, and the fact that ambient collection stays off when any required gate is absent.
+Adversarial/privacy regressions, reconnect/rate-limit testing, observability/rollback controls, and the ambient whole-server path kept disabled until every required gate is satisfied.

--- a/services/memory_ledger.py
+++ b/services/memory_ledger.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import hashlib
 import re
 import sqlite3
-from dataclasses import asdict, dataclass
-from typing import Iterable
+from dataclasses import dataclass
+from typing import Iterable, Sequence
 
 from services import audit_log
 from services.database import utc_now_iso
 
-MEMORY_SCHEMA_VERSION = 6
+MEMORY_SCHEMA_VERSION = 9
 
 VALID_CATEGORIES = (
     "Identity",
@@ -26,6 +26,11 @@ VALID_CATEGORIES = (
     "Gossip",
 )
 VALID_LABELS = ("Fact", "Inference", "Impression", "Gossip")
+VALID_PRIVACY_CLASSES = ("ordinary", "restricted")
+VALID_REVEAL_SCOPES = ("cross_member", "owner_only", "admin_only")
+VALID_ENTITY_TYPES = ("subject", "member", "topic", "term")
+RESERVED_ENTITY_TYPES = frozenset({"subject", "topic"})
+
 BLOCKED_PATTERNS = (
     re.compile(r"\bpassword\b", re.IGNORECASE),
     re.compile(
@@ -78,6 +83,9 @@ class MemoryRecord:
     topic_key: str
     is_gossip: bool
     active: bool
+    privacy_class: str
+    reveal_scope: str
+    importance: int
     created_by: int
     created_at: str
     updated_at: str
@@ -90,6 +98,7 @@ class MemoryReceipt:
     memory_id: int
     guild_id: int
     source_kind: str
+    source_context: str
     author_user_id: int
     channel_id: int | None
     message_id: int | None
@@ -113,6 +122,40 @@ class MemoryContradiction:
 
 
 @dataclass(frozen=True)
+class MemoryEntity:
+    memory_id: int
+    guild_id: int
+    entity_type: str
+    entity_key: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class MemorySearchHit:
+    memory: MemoryRecord
+    rank: float
+
+
+@dataclass(frozen=True)
+class MemoryIntegrityReport:
+    foreign_key_violations: int
+    orphan_entities: int
+    bad_contradictions: int
+    missing_system_entities: int
+    fts_available: bool
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.foreign_key_violations == 0
+            and self.orphan_entities == 0
+            and self.bad_contradictions == 0
+            and self.missing_system_entities == 0
+            and self.fts_available
+        )
+
+
+@dataclass(frozen=True)
 class UpsertResult:
     memory: MemoryRecord
     created: bool
@@ -120,6 +163,51 @@ class UpsertResult:
     replaced_memory_ids: tuple[int, ...]
     receipt: MemoryReceipt
 
+
+CREATE_RECEIPTS_TABLE = """
+CREATE TABLE IF NOT EXISTS memory_receipts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    memory_id INTEGER NOT NULL,
+    guild_id INTEGER NOT NULL,
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('discord', 'admin')),
+    source_context TEXT NOT NULL CHECK (source_context IN ('guild', 'dm', 'admin')),
+    author_user_id INTEGER NOT NULL,
+    channel_id INTEGER,
+    message_id INTEGER,
+    jump_url TEXT,
+    original_excerpt TEXT NOT NULL,
+    edited_excerpt TEXT,
+    source_created_at TEXT NOT NULL,
+    source_edited_at TEXT,
+    source_deleted_at TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE,
+    CHECK (
+        (
+            source_kind = 'admin'
+            AND source_context = 'admin'
+            AND channel_id IS NULL
+            AND message_id IS NULL
+            AND jump_url IS NULL
+        )
+        OR
+        (
+            source_kind = 'discord'
+            AND source_context = 'guild'
+            AND channel_id IS NOT NULL
+            AND message_id IS NOT NULL
+            AND jump_url IS NOT NULL
+        )
+        OR
+        (
+            source_kind = 'discord'
+            AND source_context = 'dm'
+            AND message_id IS NOT NULL
+            AND jump_url IS NULL
+        )
+    )
+)
+"""
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
@@ -143,6 +231,11 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         topic_key TEXT NOT NULL,
         is_gossip INTEGER NOT NULL DEFAULT 0 CHECK (is_gossip IN (0, 1)),
         active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+        privacy_class TEXT NOT NULL DEFAULT 'ordinary'
+            CHECK (privacy_class IN ('ordinary', 'restricted')),
+        reveal_scope TEXT NOT NULL DEFAULT 'cross_member'
+            CHECK (reveal_scope IN ('cross_member', 'owner_only', 'admin_only')),
+        importance INTEGER NOT NULL DEFAULT 50 CHECK (importance BETWEEN 0 AND 100),
         created_by INTEGER NOT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
@@ -152,52 +245,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
             ON DELETE CASCADE
     )
     """,
-    """
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_active_non_gossip_key
-    ON memory_records (guild_id, subject_user_id, normalized_key)
-    WHERE active = 1 AND is_gossip = 0
-    """,
-    """
-    CREATE INDEX IF NOT EXISTS idx_memory_profile
-    ON memory_records (guild_id, subject_user_id, active, category, updated_at DESC)
-    """,
-    """
-    CREATE INDEX IF NOT EXISTS idx_memory_gossip_topic
-    ON memory_records (guild_id, subject_user_id, topic_key, is_gossip, active)
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS memory_receipts (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        memory_id INTEGER NOT NULL,
-        guild_id INTEGER NOT NULL,
-        source_kind TEXT NOT NULL CHECK (source_kind IN ('discord', 'admin')),
-        author_user_id INTEGER NOT NULL,
-        channel_id INTEGER,
-        message_id INTEGER,
-        jump_url TEXT,
-        original_excerpt TEXT NOT NULL,
-        edited_excerpt TEXT,
-        source_created_at TEXT NOT NULL,
-        source_edited_at TEXT,
-        source_deleted_at TEXT,
-        created_at TEXT NOT NULL,
-        FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE,
-        CHECK (
-            (source_kind = 'admin' AND channel_id IS NULL AND message_id IS NULL AND jump_url IS NULL)
-            OR
-            (source_kind = 'discord' AND channel_id IS NOT NULL AND message_id IS NOT NULL AND jump_url IS NOT NULL)
-        )
-    )
-    """,
-    """
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_receipts_discord_message
-    ON memory_receipts (memory_id, message_id)
-    WHERE message_id IS NOT NULL
-    """,
-    """
-    CREATE INDEX IF NOT EXISTS idx_memory_receipts_message
-    ON memory_receipts (guild_id, message_id)
-    """,
+    CREATE_RECEIPTS_TABLE,
     """
     CREATE TABLE IF NOT EXISTS memory_contradictions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -212,17 +260,206 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         UNIQUE (left_memory_id, right_memory_id)
     )
     """,
+    """
+    CREATE TABLE IF NOT EXISTS memory_entities (
+        memory_id INTEGER NOT NULL,
+        guild_id INTEGER NOT NULL,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('subject', 'member', 'topic', 'term')),
+        entity_key TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (memory_id, entity_type, entity_key),
+        FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE
+    )
+    """,
 )
 
 
+def _column_names(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {
+        str(row["name"])
+        for row in connection.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+
+
+def _migration_applied(connection: sqlite3.Connection, version: int) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM schema_migrations WHERE version = ?",
+        (int(version),),
+    ).fetchone()
+    return row is not None
+
+
+def _migrate_memory_records_v9(connection: sqlite3.Connection) -> None:
+    columns = _column_names(connection, "memory_records")
+    if "privacy_class" not in columns:
+        connection.execute(
+            "ALTER TABLE memory_records ADD COLUMN privacy_class TEXT NOT NULL DEFAULT 'ordinary'"
+        )
+    if "reveal_scope" not in columns:
+        connection.execute(
+            "ALTER TABLE memory_records ADD COLUMN reveal_scope TEXT NOT NULL DEFAULT 'cross_member'"
+        )
+    if "importance" not in columns:
+        connection.execute(
+            "ALTER TABLE memory_records ADD COLUMN importance INTEGER NOT NULL DEFAULT 50"
+        )
+
+    connection.execute(
+        """
+        UPDATE memory_records
+        SET privacy_class = 'restricted', reveal_scope = 'admin_only'
+        WHERE category = 'Admin note'
+        """
+    )
+
+
+def _migrate_receipts_v9(connection: sqlite3.Connection) -> None:
+    columns = _column_names(connection, "memory_receipts")
+    if "source_context" in columns:
+        return
+
+    connection.execute("DROP INDEX IF EXISTS idx_memory_receipts_discord_message")
+    connection.execute("DROP INDEX IF EXISTS idx_memory_receipts_message")
+    connection.execute("ALTER TABLE memory_receipts RENAME TO memory_receipts_v6")
+    connection.execute(CREATE_RECEIPTS_TABLE)
+    connection.execute(
+        """
+        INSERT INTO memory_receipts (
+            id, memory_id, guild_id, source_kind, source_context, author_user_id,
+            channel_id, message_id, jump_url, original_excerpt, edited_excerpt,
+            source_created_at, source_edited_at, source_deleted_at, created_at
+        )
+        SELECT
+            id, memory_id, guild_id, source_kind,
+            CASE WHEN source_kind = 'admin' THEN 'admin' ELSE 'guild' END,
+            author_user_id, channel_id, message_id, jump_url, original_excerpt,
+            edited_excerpt, source_created_at, source_edited_at, source_deleted_at,
+            created_at
+        FROM memory_receipts_v6
+        """
+    )
+    connection.execute("DROP TABLE memory_receipts_v6")
+
+
+def _ensure_record_indexes(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_active_non_gossip_key
+        ON memory_records (guild_id, subject_user_id, normalized_key)
+        WHERE active = 1 AND is_gossip = 0
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_profile
+        ON memory_records (guild_id, subject_user_id, active, category, updated_at DESC)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_gossip_topic
+        ON memory_records (guild_id, subject_user_id, topic_key, is_gossip, active)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_reveal
+        ON memory_records (guild_id, reveal_scope, active, importance DESC, updated_at DESC)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_entities_lookup
+        ON memory_entities (guild_id, entity_type, entity_key, memory_id)
+        """
+    )
+
+
+def _ensure_receipt_indexes(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_receipts_discord_message
+        ON memory_receipts (memory_id, message_id)
+        WHERE message_id IS NOT NULL
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_receipts_message
+        ON memory_receipts (guild_id, message_id)
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_receipts_context
+        ON memory_receipts (guild_id, source_context, source_created_at DESC)
+        """
+    )
+
+
+def _ensure_memory_search(connection: sqlite3.Connection, *, rebuild: bool) -> None:
+    connection.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS memory_search USING fts5(
+            summary,
+            topic_key,
+            content='memory_records',
+            content_rowid='id',
+            tokenize='unicode61 remove_diacritics 2'
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS memory_records_search_ai
+        AFTER INSERT ON memory_records BEGIN
+            INSERT INTO memory_search(rowid, summary, topic_key)
+            VALUES (new.id, new.summary, new.topic_key);
+        END
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS memory_records_search_ad
+        AFTER DELETE ON memory_records BEGIN
+            INSERT INTO memory_search(memory_search, rowid, summary, topic_key)
+            VALUES ('delete', old.id, old.summary, old.topic_key);
+        END
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS memory_records_search_au
+        AFTER UPDATE OF summary, topic_key ON memory_records BEGIN
+            INSERT INTO memory_search(memory_search, rowid, summary, topic_key)
+            VALUES ('delete', old.id, old.summary, old.topic_key);
+            INSERT INTO memory_search(rowid, summary, topic_key)
+            VALUES (new.id, new.summary, new.topic_key);
+        END
+        """
+    )
+    if rebuild:
+        connection.execute("INSERT INTO memory_search(memory_search) VALUES ('rebuild')")
+
+
 def initialize_memory_schema(connection: sqlite3.Connection) -> None:
-    """Create the Registry dependency and Memory Ledger schema idempotently."""
+    """Create and migrate the Memory Ledger schema idempotently."""
 
     from services import coven_registry
 
     coven_registry.initialize_registry_schema(connection)
+    already_v9 = _migration_applied(connection, MEMORY_SCHEMA_VERSION)
     for statement in SCHEMA_STATEMENTS:
         connection.execute(statement)
+
+    # Existing v6 tables must gain v9 columns before indexes reference them.
+    _migrate_memory_records_v9(connection)
+    _migrate_receipts_v9(connection)
+    _ensure_record_indexes(connection)
+    _ensure_receipt_indexes(connection)
+    _ensure_memory_search(connection, rebuild=not already_v9)
+    if not already_v9:
+        _backfill_system_entities(connection)
     connection.execute(
         "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
         (MEMORY_SCHEMA_VERSION, utc_now_iso()),
@@ -255,6 +492,9 @@ def _row_to_memory(row: sqlite3.Row) -> MemoryRecord:
         topic_key=str(row["topic_key"]),
         is_gossip=bool(row["is_gossip"]),
         active=bool(row["active"]),
+        privacy_class=str(row["privacy_class"]),
+        reveal_scope=str(row["reveal_scope"]),
+        importance=int(row["importance"]),
         created_by=int(row["created_by"]),
         created_at=str(row["created_at"]),
         updated_at=str(row["updated_at"]),
@@ -268,6 +508,7 @@ def _row_to_receipt(row: sqlite3.Row) -> MemoryReceipt:
         memory_id=int(row["memory_id"]),
         guild_id=int(row["guild_id"]),
         source_kind=str(row["source_kind"]),
+        source_context=str(row["source_context"]),
         author_user_id=int(row["author_user_id"]),
         channel_id=_optional_int(row["channel_id"]),
         message_id=_optional_int(row["message_id"]),
@@ -288,6 +529,16 @@ def _row_to_contradiction(row: sqlite3.Row) -> MemoryContradiction:
         left_memory_id=int(row["left_memory_id"]),
         right_memory_id=int(row["right_memory_id"]),
         topic_key=str(row["topic_key"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def _row_to_entity(row: sqlite3.Row) -> MemoryEntity:
+    return MemoryEntity(
+        memory_id=int(row["memory_id"]),
+        guild_id=int(row["guild_id"]),
+        entity_type=str(row["entity_type"]),
+        entity_key=str(row["entity_key"]),
         created_at=str(row["created_at"]),
     )
 
@@ -326,6 +577,48 @@ def normalize_topic_key(value: str) -> str:
     if not normalized:
         raise MemoryLedgerError("topic_key cannot be empty")
     return normalized[:255]
+
+
+def normalize_entity_key(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9._:-]+", ".", value.lower()).strip(".")
+    if not normalized:
+        raise MemoryLedgerError("entity_key cannot be empty")
+    return normalized[:255]
+
+
+def _validate_entity_type(entity_type: str) -> str:
+    normalized = entity_type.strip().lower()
+    if normalized not in VALID_ENTITY_TYPES:
+        allowed = ", ".join(VALID_ENTITY_TYPES)
+        raise MemoryLedgerError(f"entity_type must be one of: {allowed}")
+    return normalized
+
+
+def _resolve_privacy(
+    *,
+    category: str,
+    privacy_class: str | None,
+    reveal_scope: str | None,
+) -> tuple[str, str]:
+    if category == "Admin note":
+        return "restricted", "admin_only"
+
+    resolved_privacy = (privacy_class or "ordinary").strip().lower()
+    resolved_scope = (reveal_scope or "cross_member").strip().lower()
+    if resolved_privacy not in VALID_PRIVACY_CLASSES:
+        raise MemoryLedgerError("Invalid privacy_class")
+    if resolved_scope not in VALID_REVEAL_SCOPES:
+        raise MemoryLedgerError("Invalid reveal_scope")
+    if resolved_privacy == "restricted" and resolved_scope == "cross_member":
+        raise MemoryLedgerError("Restricted memories cannot use cross_member reveal scope")
+    return resolved_privacy, resolved_scope
+
+
+def _validate_importance(value: int) -> int:
+    importance = int(value)
+    if not 0 <= importance <= 100:
+        raise MemoryLedgerError("importance must be between 0 and 100")
+    return importance
 
 
 def get_or_create_settings(connection: sqlite3.Connection, guild_id: int) -> LedgerSettings:
@@ -414,33 +707,146 @@ def get_memory(
     return _row_to_memory(row) if row else None
 
 
+def _insert_entity(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int,
+    guild_id: int,
+    entity_type: str,
+    entity_key: str,
+) -> None:
+    connection.execute(
+        """
+        INSERT OR IGNORE INTO memory_entities (
+            memory_id, guild_id, entity_type, entity_key, created_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            int(memory_id),
+            int(guild_id),
+            _validate_entity_type(entity_type),
+            normalize_entity_key(entity_key),
+            utc_now_iso(),
+        ),
+    )
+
+
+def _sync_system_entities(connection: sqlite3.Connection, memory: MemoryRecord) -> None:
+    connection.execute(
+        "DELETE FROM memory_entities WHERE memory_id = ? AND entity_type IN ('subject', 'topic')",
+        (int(memory.id),),
+    )
+    _insert_entity(
+        connection,
+        memory_id=memory.id,
+        guild_id=memory.guild_id,
+        entity_type="subject",
+        entity_key=str(memory.subject_user_id),
+    )
+    _insert_entity(
+        connection,
+        memory_id=memory.id,
+        guild_id=memory.guild_id,
+        entity_type="topic",
+        entity_key=memory.topic_key,
+    )
+
+
+def _backfill_system_entities(connection: sqlite3.Connection) -> None:
+    rows = connection.execute("SELECT * FROM memory_records ORDER BY id ASC").fetchall()
+    for row in rows:
+        _sync_system_entities(connection, _row_to_memory(row))
+
+
+def set_memory_entities(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int,
+    entities: Iterable[tuple[str, str]],
+) -> list[MemoryEntity]:
+    """Replace non-system entity links while preserving subject/topic indexes."""
+
+    memory = get_memory(connection, memory_id)
+    if memory is None:
+        raise MemoryNotFound("No Memory Ledger record exists with that ID")
+    normalized_entities: list[tuple[str, str]] = []
+    for entity_type, entity_key in entities:
+        normalized_type = _validate_entity_type(entity_type)
+        if normalized_type in RESERVED_ENTITY_TYPES:
+            raise MemoryLedgerError("subject/topic entity links are managed by the Memory Ledger")
+        normalized_entities.append((normalized_type, normalize_entity_key(entity_key)))
+
+    connection.execute(
+        "DELETE FROM memory_entities WHERE memory_id = ? AND entity_type NOT IN ('subject', 'topic')",
+        (int(memory_id),),
+    )
+    for entity_type, entity_key in normalized_entities:
+        _insert_entity(
+            connection,
+            memory_id=memory.id,
+            guild_id=memory.guild_id,
+            entity_type=entity_type,
+            entity_key=entity_key,
+        )
+    _sync_system_entities(connection, memory)
+    return list_memory_entities(connection, memory_id=memory.id)
+
+
+def list_memory_entities(
+    connection: sqlite3.Connection,
+    *,
+    memory_id: int,
+) -> list[MemoryEntity]:
+    initialize_memory_schema(connection)
+    rows = connection.execute(
+        """
+        SELECT * FROM memory_entities
+        WHERE memory_id = ?
+        ORDER BY entity_type ASC, entity_key ASC
+        """,
+        (int(memory_id),),
+    ).fetchall()
+    return [_row_to_entity(row) for row in rows]
+
+
 def _insert_discord_receipt(
     connection: sqlite3.Connection,
     *,
     memory_id: int,
     guild_id: int,
+    source_context: str,
     author_user_id: int,
-    channel_id: int,
+    channel_id: int | None,
     message_id: int,
-    jump_url: str,
+    jump_url: str | None,
     excerpt: str,
     source_created_at: str,
 ) -> MemoryReceipt:
+    resolved_context = source_context.strip().lower()
+    if resolved_context not in {"guild", "dm"}:
+        raise MemoryLedgerError("Discord source_context must be guild or dm")
+    if resolved_context == "guild" and (channel_id is None or not jump_url):
+        raise MemoryLedgerError("Guild Discord receipts require channel_id and jump_url")
+    if resolved_context == "dm" and jump_url is not None:
+        raise MemoryLedgerError("DM receipts must not fabricate a guild jump_url")
+
     timestamp = utc_now_iso()
     connection.execute(
         """
         INSERT OR IGNORE INTO memory_receipts (
-            memory_id, guild_id, source_kind, author_user_id, channel_id, message_id,
-            jump_url, original_excerpt, source_created_at, created_at
-        ) VALUES (?, ?, 'discord', ?, ?, ?, ?, ?, ?, ?)
+            memory_id, guild_id, source_kind, source_context, author_user_id,
+            channel_id, message_id, jump_url, original_excerpt,
+            source_created_at, created_at
+        ) VALUES (?, ?, 'discord', ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             int(memory_id),
             int(guild_id),
+            resolved_context,
             int(author_user_id),
-            int(channel_id),
+            _optional_int(channel_id),
             int(message_id),
-            jump_url.strip(),
+            jump_url.strip() if jump_url else None,
             excerpt.strip(),
             source_created_at,
             timestamp,
@@ -467,9 +873,9 @@ def _insert_admin_receipt(
     cursor = connection.execute(
         """
         INSERT INTO memory_receipts (
-            memory_id, guild_id, source_kind, author_user_id,
+            memory_id, guild_id, source_kind, source_context, author_user_id,
             original_excerpt, source_created_at, created_at
-        ) VALUES (?, ?, 'admin', ?, ?, ?, ?)
+        ) VALUES (?, ?, 'admin', 'admin', ?, ?, ?, ?)
         """,
         (int(memory_id), int(guild_id), int(actor_user_id), excerpt.strip(), timestamp, timestamp),
     )
@@ -521,9 +927,17 @@ def add_memory(
     jump_url: str | None = None,
     excerpt: str | None = None,
     source_created_at: str | None = None,
+    source_context: str | None = None,
+    privacy_class: str | None = None,
+    reveal_scope: str | None = None,
+    importance: int = 50,
     replace_normal_category: bool = True,
 ) -> UpsertResult:
-    """Create or merge a memory and permanently replace superseded ordinary records."""
+    """Create/merge a memory and replace only superseded ordinary same-topic records.
+
+    `replace_normal_category` is retained for backward compatibility. In schema v9 the
+    flag controls topic-scoped replacement rather than category-wide deletion.
+    """
 
     initialize_memory_schema(connection)
     category = _clean_text(category, field="category", limit=100)
@@ -540,6 +954,12 @@ def add_memory(
         epistemic_label = "Gossip"
     _validate_content(summary, excerpt or "")
 
+    resolved_privacy, resolved_scope = _resolve_privacy(
+        category=category,
+        privacy_class=privacy_class,
+        reveal_scope=reveal_scope,
+    )
+    resolved_importance = _validate_importance(importance)
     timestamp = utc_now_iso()
     duplicate_key = normalize_memory_key(category, summary)
     resolved_topic_key = normalize_topic_key(topic_key or summary)
@@ -567,10 +987,10 @@ def add_memory(
             rows = connection.execute(
                 """
                 SELECT id FROM memory_records
-                WHERE guild_id = ? AND subject_user_id = ? AND category = ?
+                WHERE guild_id = ? AND subject_user_id = ? AND topic_key = ?
                   AND active = 1 AND is_gossip = 0
                 """,
-                (int(guild_id), int(subject_user_id), category),
+                (int(guild_id), int(subject_user_id), resolved_topic_key),
             ).fetchall()
             replaced_ids = [int(row["id"]) for row in rows]
             for replaced_id in replaced_ids:
@@ -589,9 +1009,10 @@ def add_memory(
             """
             INSERT INTO memory_records (
                 guild_id, subject_user_id, category, epistemic_label, summary,
-                normalized_key, topic_key, is_gossip, active, created_by,
-                created_at, updated_at, last_confirmed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+                normalized_key, topic_key, is_gossip, active, privacy_class,
+                reveal_scope, importance, created_by, created_at, updated_at,
+                last_confirmed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 int(guild_id),
@@ -602,6 +1023,9 @@ def add_memory(
                 duplicate_key,
                 resolved_topic_key,
                 1 if is_gossip else 0,
+                resolved_privacy,
+                resolved_scope,
+                resolved_importance,
                 int(actor_user_id),
                 timestamp,
                 timestamp,
@@ -611,6 +1035,7 @@ def add_memory(
         memory = get_memory(connection, int(cursor.lastrowid))
         if memory is None:
             raise RuntimeError("Failed to create memory")
+        _sync_system_entities(connection, memory)
         if memory.is_gossip:
             _record_contradictions_for_gossip(connection, memory)
 
@@ -618,22 +1043,31 @@ def add_memory(
     if memory is None:
         raise RuntimeError("Failed to load memory")
 
-    discord_fields = (author_user_id, channel_id, message_id, jump_url, excerpt, source_created_at)
-    if any(value is not None for value in discord_fields):
-        if not all(value is not None for value in discord_fields):
-            raise MemoryLedgerError("All Discord receipt fields are required together")
+    discord_requested = any(
+        value is not None
+        for value in (author_user_id, channel_id, message_id, jump_url, excerpt, source_created_at)
+    ) or source_context in {"guild", "dm"}
+    if discord_requested:
+        if author_user_id is None or message_id is None or excerpt is None or source_created_at is None:
+            raise MemoryLedgerError(
+                "Discord receipts require author_user_id, message_id, excerpt, and source_created_at"
+            )
+        resolved_context = (source_context or "guild").strip().lower()
         receipt = _insert_discord_receipt(
             connection,
             memory_id=memory.id,
             guild_id=guild_id,
+            source_context=resolved_context,
             author_user_id=int(author_user_id),
-            channel_id=int(channel_id),
+            channel_id=_optional_int(channel_id),
             message_id=int(message_id),
-            jump_url=str(jump_url),
+            jump_url=jump_url,
             excerpt=str(excerpt),
             source_created_at=str(source_created_at),
         )
     else:
+        if source_context not in {None, "admin"}:
+            raise MemoryLedgerError("Admin memories may only use source_context='admin'")
         receipt = _insert_admin_receipt(
             connection,
             memory_id=memory.id,
@@ -649,7 +1083,14 @@ def add_memory(
         action="memory.created" if created else "memory.confirmed",
         target=f"memory:{memory.id}",
         before=None,
-        after=asdict(memory),
+        after={
+            "memory_id": memory.id,
+            "created": created,
+            "merged": merged,
+            "privacy_class": memory.privacy_class,
+            "reveal_scope": memory.reveal_scope,
+            "source_context": receipt.source_context,
+        },
     )
     return UpsertResult(memory, created, merged, tuple(replaced_ids), receipt)
 
@@ -663,6 +1104,9 @@ def update_memory(
     category: str | None = None,
     epistemic_label: str | None = None,
     topic_key: str | None = None,
+    privacy_class: str | None = None,
+    reveal_scope: str | None = None,
+    importance: int | None = None,
 ) -> MemoryRecord:
     before = get_memory(connection, memory_id)
     if before is None:
@@ -681,12 +1125,24 @@ def update_memory(
     is_gossip = new_category == "Gossip" or new_label == "Gossip"
     if is_gossip:
         new_category = new_label = "Gossip"
+    new_privacy, new_scope = _resolve_privacy(
+        category=new_category,
+        privacy_class=before.privacy_class if privacy_class is None else privacy_class,
+        reveal_scope=before.reveal_scope if reveal_scope is None else reveal_scope,
+    )
+    new_importance = before.importance if importance is None else _validate_importance(importance)
+
+    connection.execute(
+        "DELETE FROM memory_contradictions WHERE left_memory_id = ? OR right_memory_id = ?",
+        (int(memory_id), int(memory_id)),
+    )
     timestamp = utc_now_iso()
     connection.execute(
         """
         UPDATE memory_records
         SET category = ?, epistemic_label = ?, summary = ?, normalized_key = ?,
-            topic_key = ?, is_gossip = ?, updated_at = ?, last_confirmed_at = ?
+            topic_key = ?, is_gossip = ?, privacy_class = ?, reveal_scope = ?,
+            importance = ?, updated_at = ?, last_confirmed_at = ?
         WHERE id = ?
         """,
         (
@@ -696,6 +1152,9 @@ def update_memory(
             normalize_memory_key(new_category, new_summary),
             new_topic,
             1 if is_gossip else 0,
+            new_privacy,
+            new_scope,
+            new_importance,
             timestamp,
             timestamp,
             int(memory_id),
@@ -704,6 +1163,7 @@ def update_memory(
     after = get_memory(connection, memory_id)
     if after is None:
         raise RuntimeError("Failed to update memory")
+    _sync_system_entities(connection, after)
     if after.is_gossip:
         _record_contradictions_for_gossip(connection, after)
     audit_log.record_audit_event(
@@ -712,14 +1172,23 @@ def update_memory(
         actor_user_id=actor_user_id,
         action="memory.updated",
         target=f"memory:{after.id}",
-        before=before,
-        after=after,
+        before=None,
+        after={
+            "memory_id": after.id,
+            "summary_changed": before.summary != after.summary,
+            "category_changed": before.category != after.category,
+            "label_changed": before.epistemic_label != after.epistemic_label,
+            "topic_changed": before.topic_key != after.topic_key,
+            "privacy_changed": before.privacy_class != after.privacy_class,
+            "reveal_scope_changed": before.reveal_scope != after.reveal_scope,
+            "importance_changed": before.importance != after.importance,
+        },
     )
     return after
 
 
 def delete_memory(connection: sqlite3.Connection, *, memory_id: int, actor_user_id: int) -> None:
-    """Permanently delete a memory; receipts and contradiction links cascade."""
+    """Permanently delete a memory and every dependent row."""
 
     memory = get_memory(connection, memory_id)
     if memory is None:
@@ -749,11 +1218,47 @@ def list_profile(
         f"""
         SELECT * FROM memory_records
         WHERE guild_id = ? AND subject_user_id = ? {active_clause}
-        ORDER BY category ASC, updated_at DESC, id DESC
+        ORDER BY category ASC, importance DESC, updated_at DESC, id DESC
         """,
         (int(guild_id), int(subject_user_id)),
     ).fetchall()
     return [_row_to_memory(row) for row in rows]
+
+
+def memory_is_revealable(
+    memory: MemoryRecord,
+    *,
+    interlocutor_user_id: int,
+    allow_admin: bool = False,
+) -> bool:
+    if memory.reveal_scope == "admin_only":
+        return allow_admin
+    if memory.reveal_scope == "owner_only":
+        return memory.subject_user_id == int(interlocutor_user_id)
+    return memory.reveal_scope == "cross_member"
+
+
+def list_revealable_profile(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    subject_user_id: int,
+    interlocutor_user_id: int,
+    allow_admin: bool = False,
+) -> list[MemoryRecord]:
+    return [
+        memory
+        for memory in list_profile(
+            connection,
+            guild_id=guild_id,
+            subject_user_id=subject_user_id,
+        )
+        if memory_is_revealable(
+            memory,
+            interlocutor_user_id=interlocutor_user_id,
+            allow_admin=allow_admin,
+        )
+    ]
 
 
 def list_receipts(connection: sqlite3.Connection, memory_id: int) -> list[MemoryReceipt]:
@@ -785,6 +1290,101 @@ def list_contradictions(
             (int(memory_id), int(memory_id)),
         ).fetchall()
     return [_row_to_contradiction(row) for row in rows]
+
+
+def _normalize_search_query(query: str) -> str:
+    cleaned = _clean_text(query, field="search query", limit=500)
+    tokens = re.findall(r"[a-z0-9]+", cleaned.lower())[:12]
+    if not tokens:
+        raise MemoryLedgerError("search query contains no searchable terms")
+    return " AND ".join(f'"{token}"' for token in tokens)
+
+
+def _validate_reveal_scopes(reveal_scopes: Sequence[str]) -> tuple[str, ...]:
+    normalized = tuple(scope.strip().lower() for scope in reveal_scopes)
+    if not normalized:
+        raise MemoryLedgerError("At least one reveal scope is required")
+    if any(scope not in VALID_REVEAL_SCOPES for scope in normalized):
+        raise MemoryLedgerError("Invalid reveal scope filter")
+    return normalized
+
+
+def search_memories(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    query: str,
+    reveal_scopes: Sequence[str] = ("cross_member",),
+    subject_user_ids: Sequence[int] | None = None,
+    limit: int = 20,
+) -> list[MemorySearchHit]:
+    """Search active memories locally with FTS5 and deterministic scope filters."""
+
+    initialize_memory_schema(connection)
+    resolved_scopes = _validate_reveal_scopes(reveal_scopes)
+    resolved_limit = max(1, min(int(limit), 100))
+    query_sql = _normalize_search_query(query)
+    scope_placeholders = ", ".join("?" for _ in resolved_scopes)
+    subject_clause = ""
+    params: list[object] = [query_sql, int(guild_id), *resolved_scopes]
+    if subject_user_ids:
+        subject_ids = tuple(int(value) for value in subject_user_ids)
+        subject_placeholders = ", ".join("?" for _ in subject_ids)
+        subject_clause = f"AND records.subject_user_id IN ({subject_placeholders})"
+        params.extend(subject_ids)
+    params.append(resolved_limit)
+    rows = connection.execute(
+        f"""
+        SELECT records.*, bm25(memory_search) AS search_rank
+        FROM memory_search
+        JOIN memory_records AS records ON records.id = memory_search.rowid
+        WHERE memory_search MATCH ?
+          AND records.guild_id = ?
+          AND records.active = 1
+          AND records.reveal_scope IN ({scope_placeholders})
+          {subject_clause}
+        ORDER BY search_rank ASC, records.importance DESC, records.updated_at DESC
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+    return [
+        MemorySearchHit(memory=_row_to_memory(row), rank=float(row["search_rank"]))
+        for row in rows
+    ]
+
+
+def find_memories_by_entity(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    entity_type: str,
+    entity_key: str,
+    reveal_scopes: Sequence[str] = ("cross_member",),
+    limit: int = 50,
+) -> list[MemoryRecord]:
+    initialize_memory_schema(connection)
+    resolved_type = _validate_entity_type(entity_type)
+    resolved_key = normalize_entity_key(entity_key)
+    resolved_scopes = _validate_reveal_scopes(reveal_scopes)
+    resolved_limit = max(1, min(int(limit), 100))
+    placeholders = ", ".join("?" for _ in resolved_scopes)
+    rows = connection.execute(
+        f"""
+        SELECT records.*
+        FROM memory_entities AS entities
+        JOIN memory_records AS records ON records.id = entities.memory_id
+        WHERE entities.guild_id = ?
+          AND entities.entity_type = ?
+          AND entities.entity_key = ?
+          AND records.active = 1
+          AND records.reveal_scope IN ({placeholders})
+        ORDER BY records.importance DESC, records.updated_at DESC, records.id DESC
+        LIMIT ?
+        """,
+        (int(guild_id), resolved_type, resolved_key, *resolved_scopes, resolved_limit),
+    ).fetchall()
+    return [_row_to_memory(row) for row in rows]
 
 
 def mark_message_edited(
@@ -823,6 +1423,69 @@ def mark_message_deleted(
         (deleted_at or utc_now_iso(), int(guild_id), int(message_id)),
     )
     return int(cursor.rowcount)
+
+
+def check_memory_integrity(connection: sqlite3.Connection) -> MemoryIntegrityReport:
+    initialize_memory_schema(connection)
+    foreign_key_violations = len(connection.execute("PRAGMA foreign_key_check").fetchall())
+    orphan_entities = int(
+        connection.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM memory_entities AS entities
+            LEFT JOIN memory_records AS records ON records.id = entities.memory_id
+            WHERE records.id IS NULL OR records.guild_id != entities.guild_id
+            """
+        ).fetchone()["count"]
+    )
+    bad_contradictions = int(
+        connection.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM memory_contradictions AS links
+            LEFT JOIN memory_records AS left_record ON left_record.id = links.left_memory_id
+            LEFT JOIN memory_records AS right_record ON right_record.id = links.right_memory_id
+            WHERE left_record.id IS NULL
+               OR right_record.id IS NULL
+               OR left_record.guild_id != links.guild_id
+               OR right_record.guild_id != links.guild_id
+               OR left_record.topic_key != links.topic_key
+               OR right_record.topic_key != links.topic_key
+               OR left_record.is_gossip != 1
+               OR right_record.is_gossip != 1
+            """
+        ).fetchone()["count"]
+    )
+    missing_system_entities = int(
+        connection.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM memory_records AS records
+            WHERE NOT EXISTS (
+                SELECT 1 FROM memory_entities AS subject_entity
+                WHERE subject_entity.memory_id = records.id
+                  AND subject_entity.entity_type = 'subject'
+                  AND subject_entity.entity_key = CAST(records.subject_user_id AS TEXT)
+            )
+            OR NOT EXISTS (
+                SELECT 1 FROM memory_entities AS topic_entity
+                WHERE topic_entity.memory_id = records.id
+                  AND topic_entity.entity_type = 'topic'
+                  AND topic_entity.entity_key = records.topic_key
+            )
+            """
+        ).fetchone()["count"]
+    )
+    fts_available = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'memory_search'"
+    ).fetchone() is not None
+    return MemoryIntegrityReport(
+        foreign_key_violations=foreign_key_violations,
+        orphan_entities=orphan_entities,
+        bad_contradictions=bad_contradictions,
+        missing_system_entities=missing_system_entities,
+        fts_available=fts_available,
+    )
 
 
 def render_profile_for_prompt(memories: Iterable[MemoryRecord]) -> str:

--- a/services/memory_ledger.py
+++ b/services/memory_ledger.py
@@ -301,7 +301,7 @@ def _migrate_memory_records_v9(connection: sqlite3.Connection) -> None:
         )
     if "importance" not in columns:
         connection.execute(
-            "ALTER TABLE memory_records ADD COLUMN importance INTEGER NOT NULL DEFAULT 50"
+            "ALTER TABLE memory_records ADD COLUMN importance INTEGER NOT NULL DEFAULT 50 CHECK (importance BETWEEN 0 AND 100)"
         )
 
     connection.execute(
@@ -983,14 +983,15 @@ def add_memory(
             (timestamp, timestamp, memory.id),
         )
     else:
-        if not is_gossip and replace_normal_category:
+        if not is_gossip and resolved_privacy == "ordinary" and replace_normal_category:
             rows = connection.execute(
                 """
                 SELECT id FROM memory_records
                 WHERE guild_id = ? AND subject_user_id = ? AND topic_key = ?
                   AND active = 1 AND is_gossip = 0
+                  AND privacy_class = 'ordinary' AND reveal_scope = ?
                 """,
-                (int(guild_id), int(subject_user_id), resolved_topic_key),
+                (int(guild_id), int(subject_user_id), resolved_topic_key, resolved_scope),
             ).fetchall()
             replaced_ids = [int(row["id"]) for row in rows]
             for replaced_id in replaced_ids:

--- a/tests/test_memory_ledger.py
+++ b/tests/test_memory_ledger.py
@@ -25,7 +25,29 @@ def database_path(tmp_path):
     return path
 
 
-def test_schema_initializes_idempotently(database_path):
+def _add(
+    connection,
+    *,
+    summary: str,
+    topic: str,
+    category: str = "Interest",
+    label: str = "Fact",
+    **kwargs,
+):
+    return memory_ledger.add_memory(
+        connection,
+        guild_id=100,
+        subject_user_id=2,
+        category=category,
+        epistemic_label=label,
+        summary=summary,
+        topic_key=topic,
+        actor_user_id=2,
+        **kwargs,
+    )
+
+
+def test_schema_v9_initializes_idempotently(database_path):
     with managed_connection(database_path) as connection:
         memory_ledger.initialize_memory_schema(connection)
         memory_ledger.initialize_memory_schema(connection)
@@ -35,58 +57,48 @@ def test_schema_initializes_idempotently(database_path):
                 "SELECT name FROM sqlite_master WHERE type = 'table'"
             ).fetchall()
         }
-        versions = connection.execute(
-            "SELECT version FROM schema_migrations ORDER BY version"
-        ).fetchall()
+        record_columns = {
+            row["name"]
+            for row in connection.execute("PRAGMA table_info(memory_records)").fetchall()
+        }
+        receipt_columns = {
+            row["name"]
+            for row in connection.execute("PRAGMA table_info(memory_receipts)").fetchall()
+        }
+        versions = {
+            int(row["version"])
+            for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
+        }
 
-    assert {
-        "memory_ledger_settings",
-        "memory_records",
-        "memory_receipts",
-        "memory_contradictions",
-    }.issubset(tables)
-    assert memory_ledger.MEMORY_SCHEMA_VERSION in [int(row["version"]) for row in versions]
+    assert {"memory_records", "memory_receipts", "memory_entities", "memory_search"} <= tables
+    assert {"privacy_class", "reveal_scope", "importance"} <= record_columns
+    assert "source_context" in receipt_columns
+    assert memory_ledger.MEMORY_SCHEMA_VERSION in versions
 
 
-def test_settings_default_active_and_persist_pause(database_path):
+def test_settings_and_designated_channel_persist(database_path):
     with managed_connection(database_path) as connection:
-        settings = memory_ledger.get_or_create_settings(connection, 100)
-        assert settings.collection_enabled is True
-
-        paused = memory_ledger.set_collection_enabled(
+        assert memory_ledger.get_or_create_settings(connection, 100).collection_enabled is True
+        memory_ledger.set_collection_enabled(
             connection, guild_id=100, enabled=False, actor_user_id=2
         )
-        assert paused.collection_enabled is False
-
-    with managed_connection(database_path) as connection:
-        persisted = memory_ledger.get_or_create_settings(connection, 100)
-        assert persisted.collection_enabled is False
-
-
-def test_designated_channel_persists(database_path):
-    with managed_connection(database_path) as connection:
-        settings = memory_ledger.set_wilhelmina_channel(
+        memory_ledger.set_wilhelmina_channel(
             connection, guild_id=100, channel_id=555, actor_user_id=2
         )
+
+    with managed_connection(database_path) as connection:
+        settings = memory_ledger.get_or_create_settings(connection, 100)
+        assert settings.collection_enabled is False
         assert settings.wilhelmina_channel_id == 555
 
-    with managed_connection(database_path) as connection:
-        assert memory_ledger.get_or_create_settings(connection, 100).wilhelmina_channel_id == 555
 
-
-def test_duplicate_memory_merges_discord_receipts(database_path):
-    kwargs = dict(
-        guild_id=100,
-        subject_user_id=2,
-        category="Preference",
-        epistemic_label="Fact",
-        summary="Prefers black coffee",
-        actor_user_id=2,
-    )
+def test_duplicate_memory_merges_guild_receipts(database_path):
     with managed_connection(database_path) as connection:
-        first = memory_ledger.add_memory(
+        first = _add(
             connection,
-            **kwargs,
+            summary="Prefers black coffee",
+            topic="drink.coffee.preference",
+            category="Preference",
             author_user_id=2,
             channel_id=10,
             message_id=1000,
@@ -94,9 +106,11 @@ def test_duplicate_memory_merges_discord_receipts(database_path):
             excerpt="I prefer black coffee.",
             source_created_at="2026-07-27T00:00:00+00:00",
         )
-        second = memory_ledger.add_memory(
+        second = _add(
             connection,
-            **kwargs,
+            summary="Prefers black coffee",
+            topic="drink.coffee.preference",
+            category="Preference",
             author_user_id=2,
             channel_id=11,
             message_id=1001,
@@ -104,178 +118,196 @@ def test_duplicate_memory_merges_discord_receipts(database_path):
             excerpt="Black coffee, obviously.",
             source_created_at="2026-07-27T01:00:00+00:00",
         )
-
-        assert first.created is True
-        assert second.created is False
-        assert second.merged is True
-        assert second.memory.id == first.memory.id
         receipts = memory_ledger.list_receipts(connection, first.memory.id)
-        assert len(receipts) == 2
-        assert all(receipt.source_kind == "discord" for receipt in receipts)
+
+    assert first.created is True
+    assert second.created is False and second.merged is True
+    assert second.memory.id == first.memory.id
+    assert len(receipts) == 2
+    assert {receipt.source_context for receipt in receipts} == {"guild"}
 
 
-def test_admin_memory_gets_admin_receipt(database_path):
+def test_dm_receipt_keeps_evidence_without_fake_jump_url(database_path):
     with managed_connection(database_path) as connection:
-        created = memory_ledger.add_memory(
+        created = _add(
             connection,
-            guild_id=100,
-            subject_user_id=2,
-            category="Admin note",
-            epistemic_label="Fact",
+            summary="Is thinking about texting Alex again",
+            topic="relationship.alex.recontact",
+            category="Relationship context",
+            author_user_id=2,
+            message_id=5000,
+            excerpt="I might text Alex again.",
+            source_created_at="2026-08-11T12:00:00+00:00",
+            source_context="dm",
+        )
+        receipt = memory_ledger.list_receipts(connection, created.memory.id)[0]
+
+    assert receipt.source_kind == "discord"
+    assert receipt.source_context == "dm"
+    assert receipt.message_id == 5000
+    assert receipt.channel_id is None
+    assert receipt.jump_url is None
+
+
+def test_admin_notes_are_restricted_and_admin_only(database_path):
+    with managed_connection(database_path) as connection:
+        created = _add(
+            connection,
             summary="Founder-added note",
-            actor_user_id=2,
+            topic="admin.founder.note",
+            category="Admin note",
         )
-        receipts = memory_ledger.list_receipts(connection, created.memory.id)
+        receipt = memory_ledger.list_receipts(connection, created.memory.id)[0]
 
-    assert len(receipts) == 1
-    assert receipts[0].source_kind == "admin"
-    assert receipts[0].message_id is None
-    assert receipts[0].channel_id is None
-    assert receipts[0].jump_url is None
+    assert created.memory.privacy_class == "restricted"
+    assert created.memory.reveal_scope == "admin_only"
+    assert receipt.source_kind == "admin"
+    assert receipt.source_context == "admin"
 
 
-def test_new_normal_memory_permanently_replaces_old_same_category(database_path):
+def test_topic_scoped_replacement_preserves_unrelated_same_category(database_path):
     with managed_connection(database_path) as connection:
-        old = memory_ledger.add_memory(
+        old = _add(
             connection,
-            guild_id=100,
-            subject_user_id=2,
-            category="Preference",
-            epistemic_label="Fact",
             summary="Prefers tea",
-            actor_user_id=2,
-        )
-        new = memory_ledger.add_memory(
-            connection,
-            guild_id=100,
-            subject_user_id=2,
+            topic="drink.hot.preference",
             category="Preference",
-            epistemic_label="Fact",
+        )
+        unrelated = _add(
+            connection,
+            summary="Prefers horror movies",
+            topic="movie.genre.preference",
+            category="Preference",
+        )
+        new = _add(
+            connection,
             summary="Prefers coffee",
-            actor_user_id=2,
+            topic="drink.hot.preference",
+            category="Preference",
         )
-
-        assert new.replaced_memory_ids == (old.memory.id,)
-        assert memory_ledger.get_memory(connection, old.memory.id, required=False) is None
-        assert memory_ledger.list_receipts(connection, old.memory.id) == []
-        active = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
-        assert [record.summary for record in active] == ["Prefers coffee"]
-
-        events = audit_log.list_audit_events_for_target(
-            connection, 100, f"memory:{old.memory.id}"
-        )
-        replacement = next(event for event in events if event.action == "memory.replaced")
-        assert replacement.before_json is None
-        assert replacement.after_json is None
-
-
-def test_conflicting_gossip_is_preserved_and_linked(database_path):
-    with managed_connection(database_path) as connection:
-        first = memory_ledger.add_memory(
-            connection,
-            guild_id=100,
-            subject_user_id=2,
-            category="Gossip",
-            epistemic_label="Gossip",
-            summary="Sam says Alex quit the project",
-            topic_key="alex.project.departure",
-            actor_user_id=2,
-        )
-        second = memory_ledger.add_memory(
-            connection,
-            guild_id=100,
-            subject_user_id=2,
-            category="Gossip",
-            epistemic_label="Gossip",
-            summary="Jordan says Alex was removed from the project",
-            topic_key="alex.project.departure",
-            actor_user_id=2,
-        )
-
         profile = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
-        links = memory_ledger.list_contradictions(connection)
 
-    assert first.memory.id != second.memory.id
-    assert len(profile) == 2
-    assert all(record.is_gossip for record in profile)
-    assert len(links) == 1
-    assert {links[0].left_memory_id, links[0].right_memory_id} == {
-        first.memory.id,
-        second.memory.id,
-    }
+    assert new.replaced_memory_ids == (old.memory.id,)
+    assert {memory.summary for memory in profile} == {"Prefers coffee", "Prefers horror movies"}
+    assert unrelated.memory.id in {memory.id for memory in profile}
 
 
-def test_deleting_gossip_cascades_contradiction_link(database_path):
+def test_gossip_links_rebuild_when_topic_changes(database_path):
     with managed_connection(database_path) as connection:
-        first = memory_ledger.add_memory(
+        first = _add(
             connection,
-            guild_id=100,
-            subject_user_id=2,
+            summary="Sam says Alex quit",
+            topic="alex.project.departure",
             category="Gossip",
-            epistemic_label="Gossip",
-            summary="First claim",
-            topic_key="shared.topic",
-            actor_user_id=2,
+            label="Gossip",
         )
-        memory_ledger.add_memory(
+        second = _add(
             connection,
-            guild_id=100,
-            subject_user_id=2,
+            summary="Jordan says Alex was removed",
+            topic="alex.project.departure",
             category="Gossip",
-            epistemic_label="Gossip",
-            summary="Second claim",
-            topic_key="shared.topic",
-            actor_user_id=2,
+            label="Gossip",
         )
-        assert len(memory_ledger.list_contradictions(connection)) == 1
+        links = memory_ledger.list_contradictions(connection)
+        assert len(links) == 1
+        assert {links[0].left_memory_id, links[0].right_memory_id} == {
+            first.memory.id,
+            second.memory.id,
+        }
 
-        memory_ledger.delete_memory(
-            connection, memory_id=first.memory.id, actor_user_id=2
+        memory_ledger.update_memory(
+            connection,
+            memory_id=second.memory.id,
+            actor_user_id=2,
+            topic_key="alex.project.removal",
         )
         assert memory_ledger.list_contradictions(connection) == []
 
 
-def test_delete_is_permanent_and_audit_contains_no_content(database_path):
+def test_delete_cascades_receipts_entities_fts_and_contradictions(database_path):
     with managed_connection(database_path) as connection:
-        created = memory_ledger.add_memory(
+        first = _add(
+            connection,
+            summary="First telescope claim",
+            topic="astronomy.telescope.claim",
+            category="Gossip",
+            label="Gossip",
+        )
+        _add(
+            connection,
+            summary="Second telescope claim",
+            topic="astronomy.telescope.claim",
+            category="Gossip",
+            label="Gossip",
+        )
+        memory_ledger.set_memory_entities(
+            connection,
+            memory_id=first.memory.id,
+            entities=(("term", "telescope"),),
+        )
+        assert memory_ledger.search_memories(
+            connection, guild_id=100, query="telescope"
+        )
+        assert memory_ledger.find_memories_by_entity(
             connection,
             guild_id=100,
-            subject_user_id=2,
-            category="Boundary",
-            epistemic_label="Fact",
-            summary="Do not mention spiders",
-            actor_user_id=2,
-            author_user_id=2,
-            channel_id=10,
-            message_id=1000,
-            jump_url="https://discord.com/channels/100/10/1000",
-            excerpt="Do not mention spiders.",
-            source_created_at="2026-07-27T00:00:00+00:00",
+            entity_type="term",
+            entity_key="telescope",
         )
+        assert memory_ledger.list_contradictions(connection)
+
         memory_ledger.delete_memory(
-            connection, memory_id=created.memory.id, actor_user_id=2
+            connection, memory_id=first.memory.id, actor_user_id=2
         )
 
-        assert memory_ledger.get_memory(connection, created.memory.id, required=False) is None
-        assert memory_ledger.list_receipts(connection, created.memory.id) == []
+        assert memory_ledger.list_receipts(connection, first.memory.id) == []
+        assert memory_ledger.list_memory_entities(connection, memory_id=first.memory.id) == []
+        assert all(
+            link.left_memory_id != first.memory.id and link.right_memory_id != first.memory.id
+            for link in memory_ledger.list_contradictions(connection)
+        )
+        assert memory_ledger.find_memories_by_entity(
+            connection,
+            guild_id=100,
+            entity_type="term",
+            entity_key="telescope",
+        ) == []
+        assert memory_ledger.check_memory_integrity(connection).ok is True
+
+
+def test_memory_audits_never_serialize_memory_content(database_path):
+    phrase = "collects haunted porcelain clowns"
+    with managed_connection(database_path) as connection:
+        created = _add(
+            connection,
+            summary=phrase,
+            topic="hobby.clowns",
+        )
+        memory_ledger.update_memory(
+            connection,
+            memory_id=created.memory.id,
+            actor_user_id=2,
+            summary="collects haunted dolls",
+        )
         events = audit_log.list_audit_events_for_target(
             connection, 100, f"memory:{created.memory.id}"
         )
-        deletion = next(event for event in events if event.action == "memory.deleted")
-        assert deletion.before_json is None
-        assert deletion.after_json is None
+
+    serialized = "\n".join(
+        value or ""
+        for event in events
+        for value in (event.before_json, event.after_json)
+    )
+    assert phrase not in serialized
+    assert "haunted dolls" not in serialized
 
 
-def test_receipt_tracks_edit_and_delete_without_erasing_excerpt(database_path):
+def test_receipt_tracks_edit_and_source_delete(database_path):
     with managed_connection(database_path) as connection:
-        created = memory_ledger.add_memory(
+        created = _add(
             connection,
-            guild_id=100,
-            subject_user_id=2,
-            category="Interest",
-            epistemic_label="Fact",
             summary="Interested in astronomy",
-            actor_user_id=2,
+            topic="interest.astronomy",
             author_user_id=2,
             channel_id=10,
             message_id=1000,
@@ -296,45 +328,37 @@ def test_receipt_tracks_edit_and_delete_without_erasing_excerpt(database_path):
             message_id=1000,
             deleted_at="2026-07-27T00:10:00+00:00",
         ) == 1
-
         receipt = memory_ledger.list_receipts(connection, created.memory.id)[0]
-        assert receipt.original_excerpt == "I like astronomy."
-        assert receipt.edited_excerpt == "I love astronomy."
-        assert receipt.source_deleted_at == "2026-07-27T00:10:00+00:00"
+
+    assert receipt.original_excerpt == "I like astronomy."
+    assert receipt.edited_excerpt == "I love astronomy."
+    assert receipt.source_deleted_at == "2026-07-27T00:10:00+00:00"
 
 
-def test_prohibited_content_is_rejected_before_extraction(database_path):
+def test_prohibited_content_is_rejected_before_memory_or_extraction(database_path):
     with pytest.raises(memory_ledger.BlockedMemoryContent):
         memory_ledger.validate_extractable_text("My password is hunter2")
 
     with managed_connection(database_path) as connection:
         with pytest.raises(memory_ledger.BlockedMemoryContent):
-            memory_ledger.add_memory(
+            _add(
                 connection,
-                guild_id=100,
-                subject_user_id=2,
-                category="Admin note",
-                epistemic_label="Fact",
                 summary="Their password is hunter2",
-                actor_user_id=2,
+                topic="admin.secret",
+                category="Admin note",
             )
 
 
-def test_legacy_member_opt_out_is_inert(database_path):
+def test_legacy_member_opt_out_remains_inert(database_path):
     with managed_connection(database_path) as connection:
         connection.execute(
             "UPDATE coven_profile_shells SET memory_opt_out = 1 WHERE guild_id = 100 AND user_id = 2"
         )
-        created = memory_ledger.add_memory(
+        created = _add(
             connection,
-            guild_id=100,
-            subject_user_id=2,
-            category="Interest",
-            epistemic_label="Fact",
             summary="Likes old horror films",
-            actor_user_id=2,
+            topic="movie.horror",
         )
-
     assert created.created is True
 
 
@@ -352,19 +376,184 @@ def test_profile_foreign_key_requires_registry_shell(database_path):
             )
 
 
-def test_prompt_renderer_labels_gossip(database_path):
+def test_search_and_entity_lookup_respect_reveal_scope(database_path):
     with managed_connection(database_path) as connection:
-        memory_ledger.add_memory(
+        social = _add(
+            connection,
+            summary="Obsessed with lunar eclipses",
+            topic="astronomy.lunar.eclipse",
+        )
+        owner_only = _add(
+            connection,
+            summary="Keeps a private eclipse journal",
+            topic="astronomy.eclipse.journal",
+            reveal_scope="owner_only",
+        )
+        memory_ledger.set_memory_entities(
+            connection,
+            memory_id=social.memory.id,
+            entities=(("term", "eclipse"),),
+        )
+        memory_ledger.set_memory_entities(
+            connection,
+            memory_id=owner_only.memory.id,
+            entities=(("term", "eclipse"),),
+        )
+
+        default_hits = memory_ledger.search_memories(
+            connection, guild_id=100, query="eclipse"
+        )
+        owner_hits = memory_ledger.search_memories(
             connection,
             guild_id=100,
-            subject_user_id=2,
-            category="Gossip",
-            epistemic_label="Gossip",
-            summary="Sam claims Alex stole the charger",
+            query="eclipse",
+            reveal_scopes=("cross_member", "owner_only"),
+        )
+        entity_hits = memory_ledger.find_memories_by_entity(
+            connection,
+            guild_id=100,
+            entity_type="term",
+            entity_key="eclipse",
+        )
+
+    assert [hit.memory.id for hit in default_hits] == [social.memory.id]
+    assert {hit.memory.id for hit in owner_hits} == {social.memory.id, owner_only.memory.id}
+    assert [memory.id for memory in entity_hits] == [social.memory.id]
+    assert memory_ledger.memory_is_revealable(owner_only.memory, interlocutor_user_id=2)
+    assert not memory_ledger.memory_is_revealable(owner_only.memory, interlocutor_user_id=3)
+
+
+def test_fts_tracks_memory_updates(database_path):
+    with managed_connection(database_path) as connection:
+        created = _add(
+            connection,
+            summary="Collects vinyl records",
+            topic="music.vinyl",
+        )
+        assert memory_ledger.search_memories(connection, guild_id=100, query="vinyl")
+        memory_ledger.update_memory(
+            connection,
+            memory_id=created.memory.id,
             actor_user_id=2,
+            summary="Collects cassette tapes",
+            topic_key="music.cassettes",
+        )
+        assert memory_ledger.search_memories(connection, guild_id=100, query="vinyl") == []
+        hits = memory_ledger.search_memories(connection, guild_id=100, query="cassettes")
+        assert [hit.memory.id for hit in hits] == [created.memory.id]
+
+
+def test_prompt_renderer_preserves_gossip_label(database_path):
+    with managed_connection(database_path) as connection:
+        _add(
+            connection,
+            summary="Sam claims Alex stole the charger",
+            topic="alex.charger",
+            category="Gossip",
+            label="Gossip",
         )
         profile = memory_ledger.list_profile(connection, guild_id=100, subject_user_id=2)
-
     rendered = memory_ledger.render_profile_for_prompt(profile)
     assert "Unverified gossip" in rendered
     assert "Sam claims Alex stole the charger" in rendered
+
+
+def test_v6_schema_migrates_forward_without_losing_existing_memory(tmp_path):
+    path = tmp_path / "legacy.sqlite3"
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        connection.execute(
+            """
+            CREATE TABLE memory_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                subject_user_id INTEGER NOT NULL,
+                category TEXT NOT NULL,
+                epistemic_label TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                normalized_key TEXT NOT NULL,
+                topic_key TEXT NOT NULL,
+                is_gossip INTEGER NOT NULL DEFAULT 0,
+                active INTEGER NOT NULL DEFAULT 1,
+                created_by INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_confirmed_at TEXT NOT NULL,
+                FOREIGN KEY (guild_id, subject_user_id)
+                    REFERENCES coven_profile_shells (guild_id, user_id)
+                    ON DELETE CASCADE
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE memory_receipts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                memory_id INTEGER NOT NULL,
+                guild_id INTEGER NOT NULL,
+                source_kind TEXT NOT NULL,
+                author_user_id INTEGER NOT NULL,
+                channel_id INTEGER,
+                message_id INTEGER,
+                jump_url TEXT,
+                original_excerpt TEXT NOT NULL,
+                edited_excerpt TEXT,
+                source_created_at TEXT NOT NULL,
+                source_edited_at TEXT,
+                source_deleted_at TEXT,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO memory_records (
+                guild_id, subject_user_id, category, epistemic_label, summary,
+                normalized_key, topic_key, is_gossip, active, created_by,
+                created_at, updated_at, last_confirmed_at
+            ) VALUES (
+                100, 2, 'Interest', 'Fact', 'Likes astronomy', 'legacy-key',
+                'interest.astronomy', 0, 1, 2,
+                '2026-07-01T00:00:00+00:00',
+                '2026-07-01T00:00:00+00:00',
+                '2026-07-01T00:00:00+00:00'
+            )
+            """
+        )
+        memory_id = int(connection.execute("SELECT id FROM memory_records").fetchone()["id"])
+        connection.execute(
+            """
+            INSERT INTO memory_receipts (
+                memory_id, guild_id, source_kind, author_user_id, channel_id,
+                message_id, jump_url, original_excerpt, source_created_at, created_at
+            ) VALUES (?, 100, 'discord', 2, 10, 1000,
+                'https://discord.com/channels/100/10/1000', 'I like astronomy.',
+                '2026-07-01T00:00:00+00:00', '2026-07-01T00:00:00+00:00')
+            """,
+            (memory_id,),
+        )
+
+        memory_ledger.initialize_memory_schema(connection)
+        migrated = memory_ledger.get_memory(connection, memory_id)
+        receipt = memory_ledger.list_receipts(connection, memory_id)[0]
+        entities = memory_ledger.list_memory_entities(connection, memory_id=memory_id)
+        hits = memory_ledger.search_memories(connection, guild_id=100, query="astronomy")
+        integrity = memory_ledger.check_memory_integrity(connection)
+
+    assert migrated is not None and migrated.summary == "Likes astronomy"
+    assert migrated.privacy_class == "ordinary"
+    assert migrated.reveal_scope == "cross_member"
+    assert migrated.importance == 50
+    assert receipt.source_context == "guild"
+    assert {entity.entity_type for entity in entities} == {"subject", "topic"}
+    assert [hit.memory.id for hit in hits] == [memory_id]
+    assert integrity.ok is True

--- a/tests/test_memory_ledger_phase2_regressions.py
+++ b/tests/test_memory_ledger_phase2_regressions.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from services import coven_registry, memory_ledger
+from services.database import initialize_database, managed_connection
+
+
+def _bootstrap(path) -> None:
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        memory_ledger.initialize_memory_schema(connection)
+
+
+def test_ordinary_same_topic_never_replaces_restricted_admin_memory(tmp_path):
+    path = tmp_path / "privacy-regression.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        admin = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Admin note",
+            epistemic_label="Fact",
+            summary="Founder-only context",
+            topic_key="shared.topic",
+            actor_user_id=2,
+        )
+        admin_receipts_before = memory_ledger.list_receipts(connection, admin.memory.id)
+        assert len(admin_receipts_before) == 1
+
+        ordinary = memory_ledger.add_memory(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+            category="Interest",
+            epistemic_label="Fact",
+            summary="Publicly usable context",
+            topic_key="shared.topic",
+            actor_user_id=2,
+        )
+
+        preserved_admin = memory_ledger.get_memory(connection, admin.memory.id)
+        admin_receipts_after = memory_ledger.list_receipts(connection, admin.memory.id)
+        profile = memory_ledger.list_profile(
+            connection,
+            guild_id=100,
+            subject_user_id=2,
+        )
+
+    assert ordinary.replaced_memory_ids == ()
+    assert preserved_admin is not None
+    assert preserved_admin.privacy_class == "restricted"
+    assert preserved_admin.reveal_scope == "admin_only"
+    assert [receipt.id for receipt in admin_receipts_after] == [
+        receipt.id for receipt in admin_receipts_before
+    ]
+    assert {memory.id for memory in profile} == {admin.memory.id, ordinary.memory.id}
+
+
+def test_v6_migration_enforces_importance_database_constraint(tmp_path):
+    path = tmp_path / "importance-regression.sqlite3"
+    initialize_database(path)
+
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        connection.execute(
+            """
+            CREATE TABLE memory_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                subject_user_id INTEGER NOT NULL,
+                category TEXT NOT NULL,
+                epistemic_label TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                normalized_key TEXT NOT NULL,
+                topic_key TEXT NOT NULL,
+                is_gossip INTEGER NOT NULL DEFAULT 0,
+                active INTEGER NOT NULL DEFAULT 1,
+                created_by INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_confirmed_at TEXT NOT NULL,
+                FOREIGN KEY (guild_id, subject_user_id)
+                    REFERENCES coven_profile_shells (guild_id, user_id)
+                    ON DELETE CASCADE
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE memory_receipts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                memory_id INTEGER NOT NULL,
+                guild_id INTEGER NOT NULL,
+                source_kind TEXT NOT NULL,
+                author_user_id INTEGER NOT NULL,
+                channel_id INTEGER,
+                message_id INTEGER,
+                jump_url TEXT,
+                original_excerpt TEXT NOT NULL,
+                edited_excerpt TEXT,
+                source_created_at TEXT NOT NULL,
+                source_edited_at TEXT,
+                source_deleted_at TEXT,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (memory_id) REFERENCES memory_records (id) ON DELETE CASCADE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO memory_records (
+                guild_id, subject_user_id, category, epistemic_label, summary,
+                normalized_key, topic_key, is_gossip, active, created_by,
+                created_at, updated_at, last_confirmed_at
+            ) VALUES (
+                100, 2, 'Interest', 'Fact', 'Likes astronomy', 'legacy-key',
+                'interest.astronomy', 0, 1, 2,
+                '2026-07-01T00:00:00+00:00',
+                '2026-07-01T00:00:00+00:00',
+                '2026-07-01T00:00:00+00:00'
+            )
+            """
+        )
+        memory_id = int(
+            connection.execute("SELECT id FROM memory_records").fetchone()["id"]
+        )
+
+        memory_ledger.initialize_memory_schema(connection)
+        migrated = memory_ledger.get_memory(connection, memory_id)
+        assert migrated is not None and migrated.importance == 50
+
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "UPDATE memory_records SET importance = 101 WHERE id = ?",
+                (memory_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "UPDATE memory_records SET importance = -1 WHERE id = ?",
+                (memory_id,),
+            )
+
+        still_valid = memory_ledger.get_memory(connection, memory_id)
+
+    assert still_valid is not None
+    assert still_valid.importance == 50


### PR DESCRIPTION
## Purpose

Upgrade the Memory Ledger persistence layer from schema v6 to v9 so the later control, extraction, retrieval, and chat phases have a safe deterministic local architecture to build on.

## Implemented

- schema v9 after the existing member-identity v8 migration
- idempotent v6 → v9 migration preserving existing memories and receipts
- `privacy_class`, `reveal_scope`, and bounded `importance` metadata
- ordinary memories default to `cross_member`; `Admin note` is forced `restricted/admin_only`
- DM-safe receipt contexts (`guild`, `dm`, `admin`) without fabricated guild jump URLs
- local `memory_entities` index with protected system subject/topic links
- SQLite FTS5 `memory_search` index with insert/update/delete synchronization triggers
- deterministic FTS and entity lookup APIs filtered by reveal scope
- revealability helpers for `cross_member`, `owner_only`, and `admin_only`
- topic-scoped ordinary replacement; unrelated same-category memories now coexist
- exact duplicates still merge receipts
- gossip contradictions remain separate/linked, with stale links rebuilt after edits
- permanent deletion cascades receipts, entities, contradiction links, and FTS visibility
- content-free create/update/delete/replacement audit metadata; memory summaries no longer serialize into generic audit logs
- integrity diagnostic covering foreign keys, entity links, contradictions, system entities, and FTS presence
- migration matrix, rollback notes, privacy semantics, and later-phase boundaries documented

## Explicit bug fixes from the live foundation

1. Ordinary replacement previously deleted every active memory in the same category. It now replaces only the same normalized topic.
2. Create/update audits previously serialized memory summaries. They are now content-free.
3. Discord receipts previously required a guild channel and jump URL, making honest DM evidence impossible. v9 adds source context.
4. Editing gossip could leave stale contradiction links. Links are now cleared/rebuilt deterministically.

## Deliberately not in Phase 2

- founder/admin command surface — Phase 3
- automatic Discord extraction/listeners/queue — Phase 4
- full context scoring/assembly — Phase 5
- live Wilhelmina server/DM chat brain — Phase 6
- ambient whole-server ears activation — Phase 7

## Validation

- CI run `31516635848` passed
- dependency installation passed
- `ruff check .` passed
- `pytest` passed, including simulated legacy v6 → v9 migration coverage
- GitHub reports this PR mergeable against `main`
- no live OpenAI key or provider request was used

The implementation is green; the PR remains unmerged until the founder explicitly advances it.