### PR TITLE
Phase 3 cleanup: remove memory consent gate

### DIFF
--- a/cogs/member_identity.py
+++ b/cogs/member_identity.py
@@ -17,7 +17,6 @@ from services.database import initialize_database, managed_connection
 from services.member_identity import MemberIdentityError
 
 logger = logging.getLogger("wilhelmina.identity")
-CONSENT_PHRASE = "I CONSENT"
 STALE_COVENANT = "This covenant is outdated. Use `/rules` for the current one."
 
 
@@ -68,7 +67,7 @@ def _is_private_identity_admin(interaction: discord.Interaction, bot: commands.B
     return settings is not None and settings.founder_user_id == interaction.user.id
 
 
-class MemberInductionModal(discord.ui.Modal, title="Adult memory: DMs + callbacks"):
+class MemberInductionModal(discord.ui.Modal, title="Private member identity"):
     preferred_name = discord.ui.TextInput(
         label="What should Wilhelmina call you?",
         placeholder="The name you actually want used",
@@ -81,12 +80,6 @@ class MemberInductionModal(discord.ui.Modal, title="Adult memory: DMs + callback
         required=True,
         min_length=10,
         max_length=10,
-    )
-    consent = discord.ui.TextInput(
-        label="Type I CONSENT to memory + callbacks",
-        placeholder="DMs may be remembered; social memories may resurface with others",
-        required=True,
-        max_length=20,
     )
 
     def __init__(self, *, bot: commands.Bot, guild_id: int, rules_version_id: int) -> None:
@@ -118,11 +111,6 @@ class MemberInductionModal(discord.ui.Modal, title="Adult memory: DMs + callback
                     await interaction.followup.send(STALE_COVENANT, ephemeral=True)
                     return
 
-                if str(self.consent.value).strip().upper() != CONSENT_PHRASE:
-                    raise MemberIdentityError(
-                        f"Type {CONSENT_PHRASE} exactly to confirm the adult memory experience."
-                    )
-
                 _ensure_registry_entry(connection, interaction.user)
                 member_profiles.save_member_identity(
                     connection,
@@ -132,7 +120,6 @@ class MemberInductionModal(discord.ui.Modal, title="Adult memory: DMs + callback
                     preferred_name=str(self.preferred_name.value),
                     birth_date=str(self.birth_date.value),
                     today=_guild_today(connection, self.guild_id),
-                    adult_memory_consent=True,
                     actor_user_id=interaction.user.id,
                 )
                 acceptance = rules_service.accept_rules_version(
@@ -159,16 +146,9 @@ class MemberInductionModal(discord.ui.Modal, title="Adult memory: DMs + callback
             return
 
         if acceptance.already_accepted:
-            message = (
-                "Your profile and current memory consent are recorded; "
-                "that covenant was already accepted."
-            )
+            message = "Your private identity profile is recorded; that covenant was already accepted."
         else:
-            message = (
-                "Induction complete. I have both names and your full birthday. "
-                "Messages you send Wilhelmina, including DMs, may be remembered, "
-                "and ordinary social memories may resurface in her approved chats."
-            )
+            message = "Induction complete. I have both names and your full birthday."
         await interaction.followup.send(message, ephemeral=True)
 
 
@@ -179,7 +159,7 @@ async def begin_covenant_acceptance(
     guild_id: int,
     rules_version_id: int,
 ) -> None:
-    """Accept directly only when the current adult-memory disclosure is on file."""
+    """Accept directly when the private identity profile already exists."""
 
     initialize_database(_database_path(bot))
     with managed_connection(_database_path(bot)) as connection:
@@ -193,7 +173,7 @@ async def begin_covenant_acceptance(
             user_id=interaction.user.id,
             required=False,
         )
-        if profile is not None and profile.has_current_memory_consent:
+        if profile is not None:
             result = rules_service.accept_rules_version(
                 connection,
                 guild_id=int(guild_id),
@@ -299,8 +279,6 @@ class MemberIdentityAdmin(commands.GroupCog, group_name="identity-admin"):
             f"preferred    = {context.preferred_name}\n"
             f"birth_date   = {context.birth_date}\n"
             f"age          = {context.age}\n"
-            f"consent_at   = {profile.adult_memory_consent_at}\n"
-            f"consent_ver  = {profile.memory_consent_version}\n"
             "```",
             ephemeral=True,
         )

--- a/docs/member_identity.md
+++ b/docs/member_identity.md
@@ -1,6 +1,6 @@
 # Member identity contract
 
-Wilhelmina keeps two distinct names for every inducted adult member:
+Wilhelmina keeps two distinct names for every inducted member:
 
 - the current Discord display name, refreshed when Discord changes it;
 - the preferred name the member gives Wilhelmina during induction.
@@ -11,53 +11,65 @@ Neither name replaces the other. Approved memory-aware chat may use either name 
 
 Induction collects the member's full self-reported birth date in ISO `YYYY-MM-DD` format. The full date is the canonical source of truth. Age is never stored as a permanent number because it becomes stale; trusted local code recalculates it using the configured server date.
 
-After authorization and current-consent checks, the trusted identity context for approved Wilhelmina server chat and direct conversations with Wilhelmina contains:
+For an already-authorized Wilhelmina interaction, the trusted identity context contains:
 
 - current Discord display name;
 - preferred name;
 - full birth date;
 - current calculated age.
 
-This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her adult conversational persona. The full birth date is not reduced to age-only context because the product requires Wilhelmina herself to know the canonical birthday inside approved trusted context.
+This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her conversational persona. The full birth date is not reduced to age-only context because the product requires Wilhelmina herself to know the canonical birthday inside approved trusted context.
 
-The same information must not be copied into general-purpose commands, operational logs, public Registry cards, error messages, or unrelated AI features. Local code decides whether the member/context is authorized before constructing the trusted identity object.
+The same information must not be copied into general-purpose commands, operational logs, public Registry cards, error messages, or unrelated AI features. Local code decides which member/profile and interaction are in scope before constructing the trusted identity object.
 
-## Adult gate
+## Current under-18 behavior — PRODUCT DECISION PENDING
 
-A birth date that calculates to under eighteen blocks completion of the adult induction flow. Future dates and malformed dates are rejected. February 29 birthdays use February 28 as the anniversary in non-leap years for age calculation.
+The existing runtime behavior remains unchanged in this tranche: a birth date that calculates to under eighteen blocks completion of the identity profile. Future dates and malformed dates are rejected. February 29 birthdays use February 28 as the anniversary in non-leap years for age calculation.
 
-## Versioned memory disclosure
+This behavior is intentionally preserved only to avoid changing an unresolved product decision while removing unrelated consent architecture.
 
-Adult-memory consent is versioned rather than treated as a permanent blank cheque.
+## Identity profile and memory eligibility
 
-The current disclosure covers the intended next-phase behavior:
+A completed private identity profile—not a separately versioned memory permission—is the identity prerequisite for approved interaction-scoped memory behavior.
 
-- messages a member sends to Wilhelmina may be remembered;
-- this includes direct messages with Wilhelmina;
-- ordinary permitted social memories may later resurface in approved memory-aware conversation;
-- that may include Wilhelmina bringing one participating adult member's ordinary social memory into a relevant conversation with another participating adult member.
+`profile_is_complete(...)` means the private identity row exists. `profile_is_memory_eligible(...)` currently delegates to that profile state. Memory extraction still separately enforces its real runtime boundaries, including:
 
-A legacy identity profile is migrated with `legacy-adult-memory-v1`. That preserves the existing profile without pretending the older disclosure authorized the newer DM/cross-member behavior.
+- configured home guild;
+- interaction collection mode;
+- persistent Memory Ledger pause/resume state;
+- approved direct-interaction source scope;
+- provider/privacy runtime readiness;
+- queue claim ownership and final mutation-time authorization.
 
-The current disclosure version is `2026-08-interaction-dm-cross-reveal-v2`. A member with only legacy consent must complete the current disclosure before trusted memory-aware identity context is available.
+Profile existence is not a substitute for those controls. It simply replaces the agent-created `adult_memory_consent` / exact `memory_consent_version` gate.
 
-The existence of a profile and the validity of its current consent are deliberately separate concepts:
+The old helper name `profile_has_current_consent(...)` remains temporarily as a compatibility alias for already-reviewed Phase-4 callers. It no longer checks a consent version and must not be treated as a permission API. The later cleanup/migration tranche should remove that compatibility name entirely.
 
-- `profile_is_complete(...)` means the private identity row exists;
-- `profile_has_current_consent(...)` means that row has accepted the current disclosure.
+## Legacy consent columns are non-authoritative
 
-This preserves compatibility for administrative/profile code while giving chat/memory code an explicit consent gate.
+Schema v8 still physically contains:
+
+- `adult_memory_consent_at`;
+- `memory_consent_version`.
+
+They remain only so this runtime correction does not destructively rebuild the identity table before the dedicated migration tranche. Existing values are preserved as historical compatibility data. New profiles receive a non-authoritative compatibility marker in the obsolete version column because the current table still requires a non-null value.
+
+Neither field grants, revokes, upgrades, or downgrades memory/chat authorization.
+
+The induction UI no longer asks a member to type `I CONSENT`, and identity completion no longer depends on a consent phrase or exact disclosure version.
 
 ## OpenAI boundary
 
-The model receives identity data only through an explicit allow-listed context assembled by trusted Python code. The model does not decide whose profile to load, whether a conversation is authorized, how age is calculated, or whether consent is current.
+The model receives identity data only through an explicit allow-listed context assembled by trusted Python code. The model does not decide whose profile to load, whether a conversation/source is authorized, or how age is calculated.
 
 Private member-memory/chat calls use the shared asynchronous Responses API boundary with response storage forced off. Live private calls are designed to fail closed unless the deployment explicitly asserts an approved enhanced OpenAI retention posture (`mam` or `zdr`). Provider-side MAM/ZDR configuration remains an OpenAI-project setting; the runtime value is an assertion, not a substitute for actual approval/configuration.
 
 Prompts, responses, preferred names, and birth dates must not enter operational logs. Safe telemetry may include request ID, model, token usage, latency/status, and content-free identifiers.
 
-## Schema migration
+## Schema migration status
 
-The private member-identity schema uses version 8 for the versioned-consent migration.
+The private member-identity schema remains version 8 during this tranche. No columns are dropped here.
 
-Fresh profiles store `memory_consent_version` directly. Existing version-7-style profiles gain the column with the legacy consent value. This migration is intentionally non-destructive: names and birth dates remain intact while richer memory-aware behavior stays blocked until current consent is recorded.
+Existing version-7-style profiles still gain `memory_consent_version` so old databases remain readable, but that migrated value is no longer an authorization gate. Names and full birth dates remain intact.
+
+The next dedicated migration tranche may rebuild the table and physically remove obsolete consent columns after this runtime/UI change has proven stable.

--- a/docs/memory_extraction.md
+++ b/docs/memory_extraction.md
@@ -25,7 +25,7 @@ Automatic extraction requires all of the following:
 1. `ENABLE_MEMORY_EXTRACTION=true` so `cogs.memory_extraction` is loaded.
 2. `MEMORY_COLLECTION_MODE=interaction` (or `ambient`, which still behaves interaction-only in Phase 4).
 3. The persistent Memory Ledger collection gate is resumed.
-4. The author has the current versioned adult-memory consent.
+4. The author has a completed private identity profile.
 5. A usable OpenAI API runtime exists.
 6. `OPENAI_RETENTION_MODE=mam` or `zdr` is asserted for the deployment and actually configured in the OpenAI project.
 
@@ -33,9 +33,9 @@ If any gate fails, private content does not enter OpenAI extraction.
 
 `ENABLE_MEMORY_EXTRACTION` defaults to `false`. Enabling it also requests Discord's Message Content gateway intent. Configure that intent in the Discord Developer Portal before enabling the feature in a deployment.
 
-Mutable authorization is checked more than once. The event path re-checks home guild, runtime mode, persistent pause/resume state, current consent, and interaction scope inside a SQLite `BEGIN IMMEDIATE` transaction immediately before queue persistence. A claimed job re-checks authorization immediately before the provider request and again inside a write transaction immediately before any Memory Ledger mutation.
+Mutable authorization is checked more than once. The event path re-checks home guild, runtime mode, persistent pause/resume state, member profile state, and interaction scope inside a SQLite `BEGIN IMMEDIATE` transaction immediately before queue persistence. A claimed job re-checks authorization immediately before the provider request and again inside a write transaction immediately before any Memory Ledger mutation.
 
-The exact-version consent dependency above is retained only as temporary Phase-4 compatibility with the currently merged identity schema. Repository doctrine marks that authorization architecture as technical debt for the separate post-Phase-4 migration; this tranche does not expand or re-legitimize it.
+The old `profile_has_current_consent(...)` helper name remains only as a compatibility alias for the already-reviewed Phase-4 worker. It now delegates to profile-state eligibility and does **not** inspect `adult_memory_consent_at` or `memory_consent_version`. Those schema-v8 columns are non-authoritative compatibility data pending the later physical migration.
 
 ## Eligible Discord text
 
@@ -46,7 +46,7 @@ Phase 4 collects only human-authored text in the dedicated home server context:
 - a guild message that mentions Wilhelmina;
 - a guild reply whose resolved referenced message was authored by Wilhelmina.
 
-Bots, webhooks, empty/non-text messages, other guilds, missing/legacy consent under the temporary compatibility gate, and paused/off collection are rejected locally.
+Bots, webhooks, empty/non-text messages, other guilds, missing identity profiles, and paused/off collection are rejected locally.
 
 Attachments, media, embeds, files, and external-link contents are not read by the extractor. Only the message's own text enters the pipeline.
 
@@ -73,12 +73,12 @@ For a known source message, one `BEGIN IMMEDIATE` transaction performs the edit 
 1. normalize and compare the Discord edit timestamp;
 2. ignore an older/equal edit if a newer edit version is already recorded;
 3. cancel outstanding queue work and advance the content-free edit version;
-4. re-check runtime/pause/home-guild/current-consent authorization;
+4. re-check runtime/pause/home-guild/profile-state authorization;
 5. only after authorization, inspect the new text with the dangerous-secret guard;
 6. update receipt edit text only when authorized;
 7. requeue the newest safe version only when current interaction scope and provider gates still pass.
 
-This ordering prevents a revoked-consent edit from writing new raw text into receipts and prevents two bot processes from letting a late older edit overwrite a newer queued version.
+This ordering prevents an unauthorized edit from writing new raw text into receipts and prevents two bot processes from letting a late older edit overwrite a newer queued version.
 
 If an authorized edit trips the dangerous-secret guard, the raw secret text is not queued or copied into the receipt. The receipt stores only:
 
@@ -209,14 +209,14 @@ Discord deletion events do not erase the receipt. They set `source_deleted_at`, 
 
 The feature fails closed:
 
-- missing current consent under the temporary compatibility architecture -> no queue;
+- missing completed identity profile -> no queue;
 - collection off/paused -> no queue;
 - private OpenAI retention gate unavailable -> no queue;
 - dangerous-secret source -> no queue;
-- revoked-consent edit -> outstanding job cancelled, edit version advanced, no new receipt text persisted;
+- unauthorized edit -> outstanding job cancelled, edit version advanced, no new receipt text persisted;
 - dangerous-secret authorized edit -> outstanding job cancelled, secret not persisted, receipt gets only the safe marker;
 - stale older raw edit -> ignored without overwriting newer queue/receipt state;
-- queued job loses consent/pause/runtime authorization before provider -> reject before provider;
+- queued job loses profile/pause/runtime authorization before provider -> reject before provider;
 - authorization changes while provider is running -> reject before mutation;
 - provider outage after enqueue -> retry;
 - expired lease below the attempt cap -> revoke claim token before retry/reclaim;
@@ -283,7 +283,7 @@ Regression coverage includes:
 - absolute raw-text retention for pending, retry, and in-flight processing rows;
 - full worker-path provider-return-after-TTL rejection with zero memory/receipt mutation;
 - uncached/raw dangerous-secret edit cancellation;
-- revoked-consent edit cancellation without receipt-text persistence;
+- unauthorized edit cancellation without receipt-text persistence;
 - out-of-order rapid edit versioning where the newest edit wins;
 - strict proposal validation including claim subject/attribution pairs;
 - deterministic third-party-claim coercion to Gossip;
@@ -292,7 +292,7 @@ Regression coverage includes:
 - deterministic memory/receipt/entity creation;
 - source deletion handling;
 - atomic mutable authorization re-check at enqueue and before mutation;
-- consent/runtime/pause/home-guild/interaction eligibility under the temporary compatibility architecture;
+- profile/runtime/pause/home-guild/interaction eligibility;
 - ambient-mode non-activation;
 - strict provider schema + `store=False` request shape;
 - least-privilege Message Content intent configuration.

--- a/services/member_profiles.py
+++ b/services/member_profiles.py
@@ -9,14 +9,16 @@ from services import coven_registry as registry
 from services.database import utc_now_iso
 from services.member_identity import (
     MemberIdentity,
-    MemberIdentityError,
     TrustedIdentityContext,
     normalize_discord_display_name,
 )
 
 MEMBER_IDENTITY_SCHEMA_VERSION = 8
+# Legacy schema values retained only until the dedicated destructive migration tranche.
+# They are historical/compatibility metadata and MUST NOT authorize memory or chat access.
 LEGACY_MEMORY_CONSENT_VERSION = "legacy-adult-memory-v1"
 CURRENT_MEMORY_CONSENT_VERSION = "2026-08-interaction-dm-cross-reveal-v2"
+NON_AUTHORITATIVE_MEMORY_MARKER = "deprecated-not-authority"
 
 
 class MemberIdentityProfileNotFound(LookupError):
@@ -32,6 +34,8 @@ class StoredMemberIdentity:
     discord_display_name: str
     preferred_name: str
     birth_date: str
+    # These two fields remain readable only because schema v8 still physically contains them.
+    # Runtime authorization must use profile existence/source scope, never these values.
     adult_memory_consent_at: str
     memory_consent_version: str
     created_at: str
@@ -52,6 +56,8 @@ class StoredMemberIdentity:
 
     @property
     def has_current_memory_consent(self) -> bool:
+        """Legacy metadata only; never use this property as an authorization gate."""
+
         return self.memory_consent_version == CURRENT_MEMORY_CONSENT_VERSION
 
 
@@ -85,6 +91,8 @@ def _column_names(connection: sqlite3.Connection, table: str) -> set[str]:
 
 
 def _migrate_legacy_memory_consent(connection: sqlite3.Connection) -> None:
+    """Keep legacy schema v7 readable until the later physical column-removal migration."""
+
     columns = _column_names(connection, "coven_member_identity_profiles")
     if "memory_consent_version" in columns:
         return
@@ -168,7 +176,7 @@ def profile_is_complete(
     guild_id: int,
     user_id: int,
 ) -> bool:
-    """Return whether the member has a persisted identity profile, regardless of consent version."""
+    """Return whether the member has a persisted identity profile."""
 
     return (
         get_member_identity(
@@ -181,19 +189,42 @@ def profile_is_complete(
     )
 
 
+def profile_is_memory_eligible(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+) -> bool:
+    """Return whether identity prerequisites exist for approved memory interactions.
+
+    This is intentionally profile-state based. Consent timestamps/versions left in schema v8
+    are non-authoritative compatibility data and do not grant or revoke runtime access.
+    """
+
+    return profile_is_complete(
+        connection,
+        guild_id=guild_id,
+        user_id=user_id,
+    )
+
+
 def profile_has_current_consent(
     connection: sqlite3.Connection,
     *,
     guild_id: int,
     user_id: int,
 ) -> bool:
-    profile = get_member_identity(
+    """Deprecated compatibility alias for old Phase-4 callers.
+
+    The old name survives temporarily so the reviewed extraction worker can remain mechanically
+    stable in this tranche. It no longer checks consent and delegates to profile eligibility.
+    """
+
+    return profile_is_memory_eligible(
         connection,
         guild_id=guild_id,
         user_id=user_id,
-        required=False,
     )
-    return profile is not None and profile.has_current_memory_consent
 
 
 def save_member_identity(
@@ -205,20 +236,20 @@ def save_member_identity(
     preferred_name: str,
     birth_date: str | date,
     today: date,
-    adult_memory_consent: bool,
     actor_user_id: int,
+    adult_memory_consent: bool | None = None,
     consent_at: str | None = None,
-    consent_version: str = CURRENT_MEMORY_CONSENT_VERSION,
+    consent_version: str | None = None,
 ) -> StoredMemberIdentity:
-    """Validate and persist identity plus an explicit versioned adult-memory consent."""
+    """Validate and persist the member's canonical private identity.
 
+    The consent arguments are accepted only as short-lived source-compatibility parameters while
+    schema v8 and older callers are being retired. Their values are ignored for authorization and
+    new profiles receive a non-authoritative marker in the obsolete NOT NULL columns.
+    """
+
+    del adult_memory_consent, consent_at, consent_version
     initialize_member_identity_schema(connection)
-    if not adult_memory_consent:
-        raise MemberIdentityError("adult memory consent is required to complete induction")
-
-    normalized_consent_version = consent_version.strip()
-    if not normalized_consent_version:
-        raise MemberIdentityError("consent_version cannot be empty")
 
     identity = MemberIdentity.create(
         discord_display_name=discord_display_name,
@@ -240,9 +271,6 @@ def save_member_identity(
         required=False,
     )
     timestamp = utc_now_iso()
-    consent_timestamp = (consent_at or timestamp).strip()
-    if not consent_timestamp:
-        raise MemberIdentityError("consent_at cannot be empty")
 
     connection.execute(
         """
@@ -273,8 +301,6 @@ def save_member_identity(
         ON CONFLICT (guild_id, user_id) DO UPDATE SET
             preferred_name = excluded.preferred_name,
             birth_date = excluded.birth_date,
-            adult_memory_consent_at = excluded.adult_memory_consent_at,
-            memory_consent_version = excluded.memory_consent_version,
             updated_at = excluded.updated_at
         """,
         (
@@ -282,8 +308,8 @@ def save_member_identity(
             int(user_id),
             identity.preferred_name,
             identity.birth_date.isoformat(),
-            consent_timestamp,
-            normalized_consent_version,
+            timestamp,
+            NON_AUTHORITATIVE_MEMORY_MARKER,
             timestamp,
             timestamp,
         ),
@@ -309,8 +335,6 @@ def save_member_identity(
             "preferred_name_changed": before is None
             or before.preferred_name != after.preferred_name,
             "birth_date_changed": before is None or before.birth_date != after.birth_date,
-            "adult_memory_consent_recorded": True,
-            "memory_consent_version": normalized_consent_version,
         },
     )
     return after
@@ -373,7 +397,7 @@ def get_trusted_identity_context(
     user_id: int,
     on_date: date,
 ) -> TrustedIdentityContext:
-    """Build the allow-listed identity context for an already-authorised chat request."""
+    """Build the allow-listed identity context for an already-authorized chat request."""
 
     stored = get_member_identity(
         connection,
@@ -382,6 +406,4 @@ def get_trusted_identity_context(
         required=True,
     )
     assert stored is not None
-    if not stored.has_current_memory_consent:
-        raise MemberIdentityError("member must accept the current adult memory disclosure")
     return stored.trusted_chat_context(on_date=on_date)

--- a/tests/test_member_profiles.py
+++ b/tests/test_member_profiles.py
@@ -29,7 +29,7 @@ def _bootstrap(path, *, guild_id: int = 1) -> None:
         )
 
 
-def test_identity_persists_both_names_full_birth_date_and_consent(tmp_path) -> None:
+def test_identity_persists_both_names_and_full_birth_date(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
@@ -42,8 +42,6 @@ def test_identity_persists_both_names_full_birth_date_and_consent(tmp_path) -> N
             preferred_name="  Jessica  ",
             birth_date="1991-10-31",
             today=date(2026, 8, 6),
-            adult_memory_consent=True,
-            consent_at="2026-08-06T20:00:00+00:00",
             actor_user_id=300,
         )
         context = member_profiles.get_trusted_identity_context(
@@ -56,9 +54,8 @@ def test_identity_persists_both_names_full_birth_date_and_consent(tmp_path) -> N
     assert stored.discord_display_name == "xXDarkSylveonXx"
     assert stored.preferred_name == "Jessica"
     assert stored.birth_date == "1991-10-31"
-    assert stored.adult_memory_consent_at == "2026-08-06T20:00:00+00:00"
-    assert stored.memory_consent_version == member_profiles.CURRENT_MEMORY_CONSENT_VERSION
-    assert stored.has_current_memory_consent is True
+    assert stored.memory_consent_version == member_profiles.NON_AUTHORITATIVE_MEMORY_MARKER
+    assert stored.has_current_memory_consent is False
     assert context.discord_display_name == "xXDarkSylveonXx"
     assert context.preferred_name == "Jessica"
     assert context.birth_date == "1991-10-31"
@@ -78,7 +75,6 @@ def test_identity_survives_a_new_database_connection(tmp_path) -> None:
             preferred_name="Real Name",
             birth_date="1990-01-01",
             today=date(2026, 8, 6),
-            adult_memory_consent=True,
             actor_user_id=300,
         )
 
@@ -89,58 +85,46 @@ def test_identity_survives_a_new_database_connection(tmp_path) -> None:
             user_id=300,
             required=True,
         )
-
-    assert stored is not None
-    assert stored.discord_display_name == "Screen Name"
-    assert stored.preferred_name == "Real Name"
-    assert stored.birth_date == "1990-01-01"
-    assert stored.has_current_memory_consent is True
-
-
-def test_adult_memory_consent_is_required(tmp_path) -> None:
-    path = tmp_path / "identity.sqlite3"
-    _bootstrap(path)
-
-    with managed_connection(path) as connection:
-        with pytest.raises(MemberIdentityError, match="consent"):
-            member_profiles.save_member_identity(
-                connection,
-                guild_id=1,
-                user_id=300,
-                discord_display_name="Screen Name",
-                preferred_name="Real Name",
-                birth_date="1990-01-01",
-                today=date(2026, 8, 6),
-                adult_memory_consent=False,
-                actor_user_id=300,
-            )
-        stored = member_profiles.get_member_identity(
+        eligible = member_profiles.profile_is_memory_eligible(
             connection,
             guild_id=1,
             user_id=300,
         )
 
-    assert stored is None
+    assert stored is not None
+    assert stored.discord_display_name == "Screen Name"
+    assert stored.preferred_name == "Real Name"
+    assert stored.birth_date == "1990-01-01"
+    assert eligible is True
 
 
-def test_consent_version_cannot_be_empty(tmp_path) -> None:
+def test_legacy_consent_arguments_do_not_gate_identity(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
     with managed_connection(path) as connection:
-        with pytest.raises(MemberIdentityError, match="consent_version"):
-            member_profiles.save_member_identity(
-                connection,
-                guild_id=1,
-                user_id=300,
-                discord_display_name="Screen Name",
-                preferred_name="Real Name",
-                birth_date="1990-01-01",
-                today=date(2026, 8, 6),
-                adult_memory_consent=True,
-                consent_version="   ",
-                actor_user_id=300,
-            )
+        stored = member_profiles.save_member_identity(
+            connection,
+            guild_id=1,
+            user_id=300,
+            discord_display_name="Screen Name",
+            preferred_name="Real Name",
+            birth_date="1990-01-01",
+            today=date(2026, 8, 6),
+            adult_memory_consent=False,
+            consent_at="",
+            consent_version="",
+            actor_user_id=300,
+        )
+        context = member_profiles.get_trusted_identity_context(
+            connection,
+            guild_id=1,
+            user_id=300,
+            on_date=date(2026, 8, 6),
+        )
+
+    assert stored.memory_consent_version == member_profiles.NON_AUTHORITATIVE_MEMORY_MARKER
+    assert context.preferred_name == "Real Name"
 
 
 def test_underage_profile_does_not_change_registry_name(tmp_path) -> None:
@@ -157,7 +141,6 @@ def test_underage_profile_does_not_change_registry_name(tmp_path) -> None:
                 preferred_name="Member",
                 birth_date="2010-01-01",
                 today=date(2026, 8, 6),
-                adult_memory_consent=True,
                 actor_user_id=300,
             )
         entry = registry.get_entry(connection, guild_id=1, user_id=300)
@@ -179,7 +162,6 @@ def test_display_name_refresh_keeps_preferred_name_and_birth_date(tmp_path) -> N
             preferred_name="Jessica",
             birth_date="1991-10-31",
             today=date(2026, 8, 6),
-            adult_memory_consent=True,
             actor_user_id=300,
         )
         member_profiles.refresh_discord_display_name(
@@ -216,7 +198,6 @@ def test_identity_is_scoped_to_one_guild(tmp_path) -> None:
             preferred_name="Jessica",
             birth_date="1991-10-31",
             today=date(2026, 8, 6),
-            adult_memory_consent=True,
             actor_user_id=300,
         )
         first = member_profiles.get_member_identity(
@@ -234,7 +215,7 @@ def test_identity_is_scoped_to_one_guild(tmp_path) -> None:
     assert second is None
 
 
-def test_identity_audit_omits_names_and_birth_date(tmp_path) -> None:
+def test_identity_audit_omits_names_birth_date_and_consent_metadata(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
@@ -247,7 +228,6 @@ def test_identity_audit_omits_names_and_birth_date(tmp_path) -> None:
             preferred_name="Secret Preferred Name",
             birth_date="1991-10-31",
             today=date(2026, 8, 6),
-            adult_memory_consent=True,
             actor_user_id=300,
         )
         events = audit_log.list_audit_events_for_target(connection, 1, 300, limit=10)
@@ -257,10 +237,10 @@ def test_identity_audit_omits_names_and_birth_date(tmp_path) -> None:
     assert "Secret Screen Name" not in payload
     assert "Secret Preferred Name" not in payload
     assert "1991-10-31" not in payload
-    assert member_profiles.CURRENT_MEMORY_CONSENT_VERSION in payload
+    assert "consent" not in payload.lower()
 
 
-def test_identity_schema_version_and_table_are_created(tmp_path) -> None:
+def test_identity_schema_version_and_legacy_columns_are_preserved_for_safe_migration(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
@@ -290,11 +270,12 @@ def test_identity_schema_version_and_table_are_created(tmp_path) -> None:
         connection.close()
 
     assert table is not None
+    assert "adult_memory_consent_at" in columns
     assert "memory_consent_version" in columns
     assert member_profiles.MEMBER_IDENTITY_SCHEMA_VERSION in versions
 
 
-def test_legacy_identity_profile_migrates_without_granting_new_consent(tmp_path) -> None:
+def test_legacy_identity_profile_migrates_without_remaining_an_authorization_gate(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
@@ -333,14 +314,24 @@ def test_legacy_identity_profile_migrates_without_granting_new_consent(tmp_path)
             user_id=300,
             required=True,
         )
+        context = member_profiles.get_trusted_identity_context(
+            connection,
+            guild_id=1,
+            user_id=300,
+            on_date=date(2026, 8, 6),
+        )
 
         assert stored is not None
         assert stored.memory_consent_version == member_profiles.LEGACY_MEMORY_CONSENT_VERSION
         assert stored.has_current_memory_consent is False
-        with pytest.raises(MemberIdentityError, match="current adult memory disclosure"):
-            member_profiles.get_trusted_identity_context(
-                connection,
-                guild_id=1,
-                user_id=300,
-                on_date=date(2026, 8, 6),
-            )
+        assert member_profiles.profile_is_memory_eligible(
+            connection,
+            guild_id=1,
+            user_id=300,
+        ) is True
+        assert member_profiles.profile_has_current_consent(
+            connection,
+            guild_id=1,
+            user_id=300,
+        ) is True
+        assert context.birth_date == "1991-10-31"

--- a/tests/test_memory_extraction_phase4_regressions.py
+++ b/tests/test_memory_extraction_phase4_regressions.py
@@ -35,7 +35,7 @@ def database_path(tmp_path):
     return path
 
 
-def _grant_consent(path):
+def _save_profile(path):
     with managed_connection(path) as connection:
         member_profiles.save_member_identity(
             connection,
@@ -45,7 +45,6 @@ def _grant_consent(path):
             preferred_name="Founder",
             birth_date="1990-01-01",
             today=date(2026, 8, 16),
-            adult_memory_consent=True,
             actor_user_id=2,
         )
 
@@ -288,13 +287,20 @@ def test_v10_processing_claim_is_invalidated_and_old_style_reclaim_is_blocked(tm
             )
 
 
-def test_revoked_consent_edit_cancels_without_persisting_new_receipt_text(
+def test_legacy_consent_version_does_not_revoke_profile_or_safe_edit(
     database_path,
     monkeypatch,
 ):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    monkeypatch.setattr(memory_extraction_provider, "provider_ready", lambda: True)
+    _save_profile(database_path)
     with managed_connection(database_path) as connection:
+        memory_ledger.set_wilhelmina_channel(
+            connection,
+            guild_id=100,
+            channel_id=10,
+            actor_user_id=2,
+        )
         memory = _add_receipt_memory(connection)
         queued = _enqueue(connection, content="I prefer tea")
         connection.execute(
@@ -323,12 +329,20 @@ def test_revoked_consent_edit_cancels_without_persisting_new_receipt_text(
     with managed_connection(database_path) as connection:
         current = memory_extraction.get_job(connection, queued.id)
         receipt = memory_ledger.list_receipts(connection, memory.id)[0]
+        profile = member_profiles.get_member_identity(
+            connection,
+            guild_id=100,
+            user_id=2,
+            required=True,
+        )
+    assert profile is not None
+    assert profile.has_current_memory_consent is False
     assert current is not None
-    assert current.status == "rejected"
-    assert current.content is None
+    assert current.status == "pending"
+    assert current.content == "Actually I prefer coffee"
     assert current.source_edited_at == "2026-08-16T10:05:00+00:00"
-    assert receipt.edited_excerpt is None
-    assert receipt.source_edited_at is None
+    assert receipt.edited_excerpt == "Actually I prefer coffee"
+    assert receipt.source_edited_at == "2026-08-16T10:05:00+00:00"
 
 
 @pytest.mark.asyncio
@@ -338,7 +352,7 @@ async def test_newer_raw_edit_wins_when_older_handler_arrives_late(
 ):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
     monkeypatch.setattr(memory_extraction_provider, "provider_ready", lambda: True)
-    _grant_consent(database_path)
+    _save_profile(database_path)
     with managed_connection(database_path) as connection:
         memory_ledger.set_wilhelmina_channel(
             connection,


### PR DESCRIPTION
## Purpose

Remove the agent-created `adult_memory_consent` / exact `memory_consent_version` runtime permission gate while preserving the existing private identity profile, full birth date, preferred name, Registry identity, and the current under-18 behavior.

This is intentionally a **stacked draft PR** on `phase-4-automatic-memory-extraction` / PR #39. It must not merge independently into `main` before Phase 4 lands.

## Implemented in this tranche

- induction no longer asks members to type `I CONSENT`;
- identity completion no longer depends on a consent phrase or exact disclosure version;
- trusted identity context no longer checks `memory_consent_version`;
- approved memory eligibility is based on a completed private identity profile plus the existing runtime/source/pause/provider authorization gates;
- the old `profile_has_current_consent(...)` function remains temporarily as a deprecated compatibility alias for profile-state eligibility so the already-reviewed Phase-4 worker does not need a mechanical rewrite in this tranche;
- new profiles write a non-authoritative compatibility marker into the obsolete schema-v8 consent columns because those columns are still `NOT NULL`;
- existing consent-column values are preserved as historical compatibility data but no longer grant/revoke/upgrade/downgrade authorization;
- identity admin output no longer presents consent timestamp/version as product state;
- tests prove legacy consent arguments do not gate identity, legacy-version profiles are memory-eligible, full DOB remains available in trusted context, and the current under-18 rejection is unchanged;
- the former revoked-consent raw-edit regression is inverted: changing the legacy consent-version column must not revoke a valid profile or suppress an otherwise authorized safe edit;
- `docs/member_identity.md` and `docs/memory_extraction.md` now describe profile-state eligibility rather than versioned consent.

## Deliberately deferred to the next cleanup/migration tranche

- physically dropping `adult_memory_consent_at` / `memory_consent_version` from SQLite;
- deleting the deprecated compatibility alias and obsolete constants once all stacked callers are rebased onto the migrated schema;
- broader Memory Admin/README/legacy-doc wording sweep that depends on the final physical migration shape;
- any change to the existing under-18 gate (`PRODUCT DECISION PENDING`).

## Safety boundaries retained

- Phase-4 queue/lease/claim-token/TTL/edit-ordering/authorization hardening is unchanged;
- dangerous-secret/private-ID/payment/address guards are unchanged;
- ambient whole-server listening remains dormant;
- SQLite remains authoritative;
- no merge authorization is implied by this stacked PR.

## Validation

Current exact head: `9b58d2d63b11f161ab8d08afbe2a587d2d9774a1`

- CI run `32579427448` / run #343 — **success**
- dependency installation — passed
- `ruff check .` — passed
- `pytest` — **235 passed**
- Phase-4 extraction/cog/final-hardening/lease/TTL/edit-ordering/provider/retention regressions all pass on the combined stack
- no live OpenAI key or provider request used

The preceding run #341 failed only because one historical regression still expected downgrading `memory_consent_version` to revoke safe edit handling. That test encoded the permission architecture this tranche intentionally removes. It was replaced with the inverse regression proving the legacy column is non-authoritative; no Phase-4 reliability mechanism was weakened to make the suite pass.
