### PR TITLE
Phase 4 cleanup: migrate identity schema and explicit privacy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ memory_extraction_jobs
 schema_migrations
 ```
 
+Private identity schema v12 stores preferred name, full canonical birth date, and timestamps; current Discord display name remains in the Coven Registry. The obsolete adult-memory-consent timestamp/version columns are physically removed. The existing under-18 profile-completion behavior remains unchanged and is a separate product decision.
+
 The stored guild configuration is the source of truth for server role/channel IDs after Phase 2. Environment variables for role/channel IDs are not used by the new config layer.
 
 ## Living Command Grimoire
@@ -210,11 +212,11 @@ Core commands:
 /memory-admin delete-member-id
 ```
 
-The persistent pause/resume switch is separate from `MEMORY_COLLECTION_MODE`. Resuming the local gate does not activate automatic extraction by itself. Search and inspection are local SQLite operations; Phase 3 does not call OpenAI and does not need an API key.
+The persistent pause/resume switch is separate from `MEMORY_COLLECTION_MODE`. Resuming the local gate does not activate automatic extraction by itself. Search and inspection are local SQLite operations and do not need an API key.
 
-Exact duplicate admin writes still merge receipts. Their privacy metadata may tighten but never loosen: a later restricted/admin-only confirmation can narrow an existing ordinary record, while a broader duplicate cannot reopen a record that is already narrower. The command reports the actual stored privacy/reveal scope and importance.
+Exact duplicate admin writes merge receipts/evidence only. They do **not** silently change privacy, reveal scope, or importance. Metadata changes require `/memory-admin edit`, which may explicitly tighten or loosen a valid privacy/reveal pair.
 
-Single-memory deletion requires the exact confirmation text `DELETE`. Member-wide Memory Ledger deletion requires `DELETE MEMBER`. The member-wide purge removes the member's own Memory Ledger records **and** receipts they authored on other members' memories. Any memory left with zero evidence is also deleted; memories that still have another receipt survive. The purge deliberately does **not** silently delete Coven Registry or private identity/consent rows.
+Single-memory deletion requires the exact confirmation text `DELETE`. Member-wide Memory Ledger deletion requires `DELETE MEMBER`. The member-wide purge removes the member's own Memory Ledger records **and** receipts they authored on other members' memories. Any memory left with zero evidence is also deleted; memories that still have another receipt survive. The purge deliberately does **not** silently delete Coven Registry or private identity rows.
 
 `member-data-id` and `delete-member-id` provide the same private controls for departed/archived users who are no longer selectable as `discord.Member`.
 
@@ -236,9 +238,9 @@ OPENAI_RETENTION_MODE=mam
 
 `zdr` may be used instead of `mam` when that approved project configuration is available. The environment value is only a deployment assertion; the corresponding retention control must actually be configured for the OpenAI project. Private extraction requests use `store=false`.
 
-Enabling extraction requests Discord's Message Content intent, which must also be enabled in the Discord Developer Portal. The persistent Memory Ledger collection gate must be resumed. The current exact-version adult-memory consent check remains only as temporary compatibility with the merged identity schema and is scheduled for removal in the separate post-Phase-4 identity/profile cleanup; it is not the long-term product contract.
+Enabling extraction requests Discord's Message Content intent, which must also be enabled in the Discord Developer Portal. The persistent Memory Ledger collection gate must be resumed, and the speaking member must have a completed private identity profile. There is no separate adult-memory-consent/version permission gate.
 
-Phase 4 uses schema v11 queue ownership with per-claim tokens, absolute raw-text TTL cleanup, atomic authorization before queue persistence, uncached/raw edit handling, and deterministic dangerous-secret rejection both before OpenAI and after structured model output. Medical, mental-health, adult relationship/sexual, political, religious, identity, substance-use, embarrassing, gossip, and other socially sensitive material is not blocked merely because of its subject category. SQLite/Python remain authoritative; the model cannot authorize access or mutate memory directly.
+Phase 4 uses schema-v11 queue ownership with per-claim tokens, absolute raw-text TTL cleanup, atomic authorization before queue persistence, uncached/raw edit handling, and deterministic dangerous-secret rejection both before OpenAI and after structured model output. Medical, mental-health, adult relationship/sexual, political, religious, identity, substance-use, embarrassing, gossip, and other socially sensitive material is not blocked merely because of its subject category. SQLite/Python remain authoritative; the model cannot authorize access or mutate memory directly.
 
 For upgrades from the earlier v10 extraction draft, stop/drain old workers before enabling v11. v11 invalidates leftover tokenless processing rows and installs database enforcement that prevents old-style tokenless claims from entering `processing`.
 
@@ -302,7 +304,7 @@ broadcast_morning    The Vanguard Frequency generation
 broadcast_evening    W.W.N. Broadcast generation
 ```
 
-This keeps Wilhelmina recognizable while allowing each feature to apply the right functional limits. The old umbrella oracle/persona architecture remains removed.
+This keeps Wilhelmina recognizable while allowing each feature to apply the right functional limits. Protected/identity traits may be mentioned factually when relevant; the persona boundary is against using the trait itself as the basis for dehumanizing or comparable targeted abuse.
 
 ## AI-backed features
 

--- a/cogs/memory_admin.py
+++ b/cogs/memory_admin.py
@@ -66,11 +66,7 @@ def _parse_user_id(value: str) -> int:
 
 
 def _identity_state(identity) -> str:
-    if identity is None:
-        return "none"
-    if identity.has_current_memory_consent:
-        return "current consent"
-    return f"legacy consent ({identity.memory_consent_version})"
+    return "complete" if identity is not None else "none"
 
 
 def _memory_line(memory: memory_ledger.MemoryRecord) -> str:
@@ -323,7 +319,7 @@ class MemoryAdmin(commands.GroupCog, group_name="memory-admin"):
             "on other members' memories, and "
             f"**{result.evidence_orphan_memory_count_deleted}** additional memory record(s) "
             "deleted because no evidence remained. "
-            "Coven Registry and private identity/consent records were not changed.",
+            "Coven Registry and private identity records were not changed.",
             ephemeral=True,
         )
 
@@ -377,8 +373,8 @@ class MemoryAdmin(commands.GroupCog, group_name="memory-admin"):
             f"contradiction_errors= {integrity.bad_contradictions}\n"
             f"fts                 = {'ok' if integrity.fts_available else 'missing'}\n```\n"
             f"Designated Wilhelmina channel: {channel}\n"
-            "Automatic extraction itself remains a later phase; these controls are the "
-            "persistent local gate.",
+            "Automatic extraction is controlled independently by the runtime feature/policy "
+            "gates above; this command manages the persistent local gate.",
             ephemeral=True,
         )
 
@@ -509,15 +505,9 @@ class MemoryAdmin(commands.GroupCog, group_name="memory-admin"):
         embed.add_field(name="Discord user ID", value=f"`{user.id}`", inline=False)
         if identity is not None:
             trusted = identity.trusted_chat_context(on_date=date.today())
-            consent = (
-                "current"
-                if identity.has_current_memory_consent
-                else f"legacy: {identity.memory_consent_version}"
-            )
             embed.add_field(name="Preferred name", value=trusted.preferred_name, inline=True)
             embed.add_field(name="Birth date", value=trusted.birth_date, inline=True)
             embed.add_field(name="Age", value=str(trusted.age), inline=True)
-            embed.add_field(name="Memory consent", value=consent, inline=False)
         embed.set_footer(
             text=(
                 f"Page {current}/{pages} · {len(memories)} active memories · "
@@ -704,8 +694,8 @@ class MemoryAdmin(commands.GroupCog, group_name="memory-admin"):
             else ""
         )
         duplicate_note = (
-            " Duplicate confirmation merged its receipt; privacy/reveal metadata may tighten "
-            "but never loosens."
+            " Duplicate confirmation merged its receipt; existing privacy/reveal/importance "
+            "metadata was not changed. Use `/memory-admin edit` to change metadata explicitly."
             if not result.created
             else ""
         )

--- a/cogs/memory_extraction.py
+++ b/cogs/memory_extraction.py
@@ -86,7 +86,7 @@ class MemoryExtraction(commands.Cog):
         settings = memory_ledger.get_or_create_settings(connection, int(home_guild_id))
         if not settings.collection_enabled:
             return None
-        if not member_profiles.profile_has_current_consent(
+        if not member_profiles.profile_is_memory_eligible(
             connection,
             guild_id=int(home_guild_id),
             user_id=int(user_id),
@@ -139,12 +139,12 @@ class MemoryExtraction(commands.Cog):
             settings = memory_ledger.get_or_create_settings(connection, home_guild_id)
             if not settings.collection_enabled:
                 return Eligibility(False, reason="persistent_pause")
-            if not member_profiles.profile_has_current_consent(
+            if not member_profiles.profile_is_memory_eligible(
                 connection,
                 guild_id=home_guild_id,
                 user_id=message.author.id,
             ):
-                return Eligibility(False, reason="consent_missing")
+                return Eligibility(False, reason="profile_missing")
 
         if is_dm:
             return Eligibility(True, home_guild_id, "dm", "dm")

--- a/docs/member_identity.md
+++ b/docs/member_identity.md
@@ -18,21 +18,21 @@ For an already-authorized Wilhelmina interaction, the trusted identity context c
 - full birth date;
 - current calculated age.
 
-This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her conversational persona. The full birth date is not reduced to age-only context because the product requires Wilhelmina herself to know the canonical birthday inside approved trusted context.
+This deliberately gives Wilhelmina enough context to use age, birthday timing, and the contrast between both names in her conversational persona. The full birth date is not reduced to age-only context because Wilhelmina herself needs the canonical birthday inside approved trusted context.
 
 The same information must not be copied into general-purpose commands, operational logs, public Registry cards, error messages, or unrelated AI features. Local code decides which member/profile and interaction are in scope before constructing the trusted identity object.
 
 ## Current under-18 behavior — PRODUCT DECISION PENDING
 
-The existing runtime behavior remains unchanged in this tranche: a birth date that calculates to under eighteen blocks completion of the identity profile. Future dates and malformed dates are rejected. February 29 birthdays use February 28 as the anniversary in non-leap years for age calculation.
+The existing runtime behavior remains unchanged: a birth date that calculates to under eighteen blocks completion of the identity profile. Future dates and malformed dates are rejected. February 29 birthdays use February 28 as the anniversary in non-leap years for age calculation.
 
-This behavior is intentionally preserved only to avoid changing an unresolved product decision while removing unrelated consent architecture.
+This is preserved only because the age rule is a separate unresolved product decision. The consent cleanup does not expand, remove, or reinterpret it.
 
 ## Identity profile and memory eligibility
 
-A completed private identity profile—not a separately versioned memory permission—is the identity prerequisite for approved interaction-scoped memory behavior.
+A completed private identity profile is the identity prerequisite for approved interaction-scoped memory behavior.
 
-`profile_is_complete(...)` means the private identity row exists. `profile_is_memory_eligible(...)` currently delegates to that profile state. Memory extraction still separately enforces its real runtime boundaries, including:
+`profile_is_complete(...)` means the private identity row exists. `profile_is_memory_eligible(...)` currently delegates to that profile state. Memory extraction separately enforces its actual runtime boundaries, including:
 
 - configured home guild;
 - interaction collection mode;
@@ -41,35 +41,40 @@ A completed private identity profile—not a separately versioned memory permiss
 - provider/privacy runtime readiness;
 - queue claim ownership and final mutation-time authorization.
 
-Profile existence is not a substitute for those controls. It simply replaces the agent-created `adult_memory_consent` / exact `memory_consent_version` gate.
+Profile existence is not a substitute for those controls. There is no separate adult-memory-consent permission, consent phrase, or exact disclosure-version gate.
 
-The old helper name `profile_has_current_consent(...)` remains temporarily as a compatibility alias for already-reviewed Phase-4 callers. It no longer checks a consent version and must not be treated as a permission API. The later cleanup/migration tranche should remove that compatibility name entirely.
+## Schema v12
 
-## Legacy consent columns are non-authoritative
+The private identity table now stores only canonical identity data and timestamps:
 
-Schema v8 still physically contains:
+- guild ID;
+- Discord user ID;
+- preferred name;
+- full birth date;
+- created timestamp;
+- updated timestamp.
 
-- `adult_memory_consent_at`;
-- `memory_consent_version`.
+Current Discord display name remains authoritative in the Coven Registry and is joined into the trusted identity object when loaded.
 
-They remain only so this runtime correction does not destructively rebuild the identity table before the dedicated migration tranche. Existing values are preserved as historical compatibility data. New profiles receive a non-authoritative compatibility marker in the obsolete version column because the current table still requires a non-null value.
+Schema v12 physically removes the obsolete `adult_memory_consent_at` and `memory_consent_version` columns. The old compatibility constants, save arguments, consent property, and `profile_has_current_consent(...)` alias are also removed.
 
-Neither field grants, revokes, upgrades, or downgrades memory/chat authorization.
+### v7/v8 migration
 
-The induction UI no longer asks a member to type `I CONSENT`, and identity completion no longer depends on a consent phrase or exact disclosure version.
+Legacy identity tables are rebuilt transactionally:
+
+1. verify the canonical identity columns needed for preservation;
+2. rename the legacy table inside the current SQLite transaction;
+3. create the v12 table;
+4. copy guild/user IDs, preferred name, full birth date, and original created/updated timestamps;
+5. drop the renamed legacy table;
+6. record schema version 12.
+
+If the copy violates the v12 table contract, the transaction rolls back. Tests cover both v7 and v8 source shapes plus a forced-copy failure to prove the legacy table/data are restored intact rather than left half-migrated.
 
 ## OpenAI boundary
 
 The model receives identity data only through an explicit allow-listed context assembled by trusted Python code. The model does not decide whose profile to load, whether a conversation/source is authorized, or how age is calculated.
 
-Private member-memory/chat calls use the shared asynchronous Responses API boundary with response storage forced off. Live private calls are designed to fail closed unless the deployment explicitly asserts an approved enhanced OpenAI retention posture (`mam` or `zdr`). Provider-side MAM/ZDR configuration remains an OpenAI-project setting; the runtime value is an assertion, not a substitute for actual approval/configuration.
+Private member-memory/chat calls use the shared asynchronous Responses API boundary with response storage forced off. Live private calls fail closed unless the deployment explicitly asserts an approved enhanced OpenAI retention posture (`mam` or `zdr`). Provider-side MAM/ZDR configuration remains an OpenAI-project setting; the runtime value is an assertion, not a substitute for actual approval/configuration.
 
 Prompts, responses, preferred names, and birth dates must not enter operational logs. Safe telemetry may include request ID, model, token usage, latency/status, and content-free identifiers.
-
-## Schema migration status
-
-The private member-identity schema remains version 8 during this tranche. No columns are dropped here.
-
-Existing version-7-style profiles still gain `memory_consent_version` so old databases remain readable, but that migrated value is no longer an authorization gate. Names and full birth dates remain intact.
-
-The next dedicated migration tranche may rebuild the table and physically remove obsolete consent columns after this runtime/UI change has proven stable.

--- a/docs/memory_controls.md
+++ b/docs/memory_controls.md
@@ -1,6 +1,6 @@
 # Memory Ledger Controls
 
-Phase 3 adds the private founder/admin command surface for the Memory Ledger. The feature is implemented by `cogs.memory_admin` over the existing schema-v9 persistence APIs. It does not call OpenAI and does not require an API key.
+`cogs.memory_admin` provides the private founder/admin command surface for the Memory Ledger. It operates on local SQLite persistence APIs, does not call OpenAI, and does not require an API key.
 
 ## Authorization and privacy
 
@@ -18,24 +18,26 @@ Normal members do not receive a Memory Ledger browsing command. Public Registry 
 
 `/memory-admin status` reports the local persistent collection gate, deployment runtime collection policy, designated Wilhelmina channel, content-free record counts, and Memory Ledger integrity checks.
 
-`/memory-admin pause` and `/memory-admin resume` persist `memory_ledger_settings.collection_enabled`. Pausing does not delete existing memories. Resuming does not override `MEMORY_COLLECTION_MODE`; the persistent database gate and the deployment runtime policy remain independent checks.
+`/memory-admin pause` and `/memory-admin resume` persist `memory_ledger_settings.collection_enabled`. Pausing does not delete existing memories. Resuming does not override `MEMORY_COLLECTION_MODE`; the persistent database gate and deployment runtime policy remain independent checks.
 
-`/memory-admin set-channel` and `/memory-admin clear-channel` persist the designated memory-aware Wilhelmina server channel for later chat phases.
+`/memory-admin set-channel` and `/memory-admin clear-channel` persist the designated memory-aware Wilhelmina server channel.
 
 ## Private inspection
 
 The founder/admin surface supports:
 
-- `/memory-admin profile` — paginated full active member profile, including private identity context when available;
+- `/memory-admin profile` — paginated active member profile, including preferred name, full birth date, and calculated current age when the private identity profile exists;
 - `/memory-admin show` — one Memory Ledger record by ID;
 - `/memory-admin receipts` — paginated source evidence for a record;
 - `/memory-admin search` — local FTS search with deterministic reveal-scope filters;
 - `/memory-admin member-data` — content-free Memory Ledger inventory for a current member;
 - `/memory-admin member-data-id` — the same inventory for a departed/archived member by Discord user ID.
 
+The identity surface reports profile state as `complete` or `none`. There is no memory-consent state to inspect after identity schema v12.
+
 Member inventory includes both memories whose subject is that member and receipts authored by that member on somebody else's memory. Cross-subject authored receipts are counted separately so they are not silently missed or double-counted.
 
-Admin search may intentionally include every reveal scope. This does not change the normal chat retrieval defaults and does not make `admin_only` records socially revealable.
+Admin search may intentionally include every reveal scope. This does not change normal chat retrieval defaults and does not make `admin_only` records socially revealable.
 
 ## Manual mutation
 
@@ -53,11 +55,11 @@ Member-wide Memory Ledger deletion requires the exact confirmation text `DELETE 
 
 ### Duplicate admin writes
 
-Exact duplicates still merge receipts rather than creating another record. If the new admin write requests a narrower privacy posture, the stored duplicate is tightened deterministically. Privacy/reveal metadata may tighten but never loosen:
+Exact duplicates merge evidence/receipts rather than creating another record. A duplicate confirmation does **not** implicitly change privacy class, reveal scope, or importance, even if the new `/memory-admin add` invocation requests different metadata.
 
-- `ordinary/cross_member` can become `restricted/admin_only` when a later duplicate requires it;
-- an already restricted/admin-only duplicate cannot be reopened by a later broader duplicate;
-- duplicate `importance` remains the existing stored value unless explicitly changed through `/memory-admin edit`.
+Metadata changes require the explicit `/memory-admin edit` path. An authorized admin may tighten or loosen privacy/reveal metadata so long as the requested pair is valid under the deterministic Memory Ledger rules. For example, an ordinary `cross_member` record may be explicitly tightened to `restricted/admin_only`, and a record may later be explicitly reopened to `ordinary/cross_member` when the admin intends that change.
+
+This keeps evidence confirmation separate from policy mutation and prevents a duplicate write from silently changing how an existing memory may be revealed.
 
 The add command reports the actual stored privacy class, reveal scope, and importance after the write.
 
@@ -69,9 +71,9 @@ A member-wide purge removes:
 2. every receipt authored by that member on another subject's memory;
 3. any other subject's memory that is left with zero receipts after those authored receipts are removed.
 
-A cross-subject memory that still has another receipt survives. This preserves the Memory Ledger rule that every surviving memory has evidence while ensuring a member's authored receipt content is actually removed from the ledger.
+A cross-subject memory that still has another receipt survives. This preserves the rule that every surviving memory has evidence while ensuring a member's authored receipt content is actually removed from the ledger.
 
-`delete-member` and `delete-member-id` are intentionally scoped to the Memory Ledger. They do not silently delete Coven Registry or private identity/consent records; those stores have separate product semantics and must not be destroyed as a side effect of a Memory Ledger command.
+`delete-member` and `delete-member-id` are intentionally scoped to the Memory Ledger. They do not silently delete Coven Registry or private identity records; those stores have separate product semantics and must not be destroyed as a side effect of a Memory Ledger command.
 
 ## Data-access/correction/deletion handling
 
@@ -79,7 +81,7 @@ Member Memory Ledger requests are founder/admin mediated rather than exposed as 
 
 1. use `member-data` for a current member or `member-data-id` for an archived/departed member;
 2. use `profile`, `show`, `search`, and `receipts` for private access review;
-3. use `edit` for Memory Ledger corrections;
+3. use `edit` for Memory Ledger corrections and explicit metadata policy changes;
 4. use `delete`, `delete-member`, or `delete-member-id` for permanent Memory Ledger deletion when appropriate.
 
 The ID routes accept a positive decimal 64-bit Discord snowflake string so large Discord IDs are not forced through a lossy JSON-number boundary.
@@ -100,22 +102,23 @@ The cog is controlled by:
 ENABLE_MEMORY_ADMIN=true
 ```
 
-It defaults enabled because it is the private safety/control surface for the persistent Memory Ledger. Automatic extraction remains separately governed by the runtime memory policy and later implementation phases.
+It defaults enabled because it is the private safety/control surface for the persistent Memory Ledger. Automatic extraction is separately governed by `ENABLE_MEMORY_EXTRACTION`, the runtime memory policy, profile/source eligibility, the persistent pause gate, and the private provider configuration.
 
 ## Validation
 
-Phase-3 tests cover:
+Regression coverage includes:
 
 - founder/admin home-guild authorization;
 - ephemeral denial behavior;
 - archived/departed member ID validation;
 - content-free status/member summaries;
 - restricted/admin-only counting;
-- duplicate privacy tightening and no-loosening;
+- duplicate confirmation leaving privacy/reveal/importance unchanged;
+- explicit privacy tightening and loosening through the edit path;
 - cross-subject authored receipt inventory and purge;
 - preservation of a memory that still has another receipt;
 - deletion of a memory left with zero evidence;
-- Registry survival after Memory Ledger-only deletion;
+- Registry and private identity survival after Memory Ledger-only deletion;
 - content-free deletion audit metadata.
 
 The repository quality gates remain:
@@ -127,4 +130,4 @@ pytest
 
 ## Rollback
 
-Phase 3 adds no database schema migration. Rolling back the command surface means deploying the previous application revision or disabling `ENABLE_MEMORY_ADMIN`. Existing schema-v9 data and persistent Memory Ledger settings remain intact.
+The command surface itself can be disabled with `ENABLE_MEMORY_ADMIN=false`. Schema-v12 identity migration is a separate persistent migration: do not run older identity code against a migrated production database. For a true database rollback, stop Wilhelmina and restore the matching pre-v12 SQLite backup together with the prior application revision; otherwise deploy a forward fix that understands v12.

--- a/docs/memory_extraction.md
+++ b/docs/memory_extraction.md
@@ -35,7 +35,7 @@ If any gate fails, private content does not enter OpenAI extraction.
 
 Mutable authorization is checked more than once. The event path re-checks home guild, runtime mode, persistent pause/resume state, member profile state, and interaction scope inside a SQLite `BEGIN IMMEDIATE` transaction immediately before queue persistence. A claimed job re-checks authorization immediately before the provider request and again inside a write transaction immediately before any Memory Ledger mutation.
 
-The old `profile_has_current_consent(...)` helper name remains only as a compatibility alias for the already-reviewed Phase-4 worker. It now delegates to profile-state eligibility and does **not** inspect `adult_memory_consent_at` or `memory_consent_version`. Those schema-v8 columns are non-authoritative compatibility data pending the later physical migration.
+Identity eligibility is explicit: `profile_is_memory_eligible(...)` currently means that the private identity profile exists. There is no adult-memory-consent flag, exact consent-version gate, or consent-named compatibility helper. Identity schema v12 physically removed the obsolete consent columns while preserving preferred names, full canonical birth dates, and identity timestamps.
 
 ## Eligible Discord text
 
@@ -273,6 +273,7 @@ Regression coverage includes:
 
 - schema v11 initialization and v10 -> v11 migration;
 - legacy tokenless processing-claim invalidation and old-style claim rejection;
+- identity schema v7/v8 -> v12 preservation and rollback safety;
 - permissiveness regressions for medical/mental-health/adult/socially sensitive subject matter;
 - pre-AI credential/private-ID/payment/address rejection;
 - post-model summary/topic/entity dangerous-secret rejection;

--- a/docs/memory_ledger.md
+++ b/docs/memory_ledger.md
@@ -2,44 +2,46 @@
 
 The Memory Ledger is Wilhelmina's private, persistent local memory. SQLite is the canonical source of truth. OpenAI may interpret already-authorized text or reason over already-authorized context, but model output never authorizes access, disclosure, replacement, or deletion.
 
-The product target remains an adult social character: sharp, vulgar, funny, intrusive when useful, and able to remember callbacks, contradictions, preferences, gossip, names, birthdays, projects, and other ordinary social context. Target voice: **mean enough to delight the room, sharp enough to feel intelligent, and still useful.**
+The product target is a sharp, socially aware character that remembers callbacks, contradictions, preferences, gossip, names, birthdays, projects, relationships, communication habits, and other useful social context. Privacy controls exist to prevent dangerous retention or disclosure, not to flatten ordinary social memory.
 
-Quality and memory richness take priority over minimizing model/token cost. Privacy controls exist to prevent dangerous retention or disclosure, not to make Wilhelmina artificially stupid.
+## Current persistence layers
 
-## Current persistence status
+### Private member identity — schema v12
 
-### Member identity schema v8
+The identity profile stores:
 
-The private identity profile stores:
-
-- current Discord display name through the Registry;
+- guild ID;
+- Discord user ID;
 - member-provided preferred name;
 - full self-reported birth date;
-- adult-memory consent timestamp;
-- version of the memory disclosure accepted.
+- created/updated timestamps.
 
-The current disclosure covers interaction memory, DMs directly with Wilhelmina, and ordinary cross-member social callbacks. Legacy consent is not silently upgraded. Full birth date remains canonical and current age is calculated locally when trusted context is assembled.
+Current Discord display name remains in the Coven Registry and is joined into trusted identity context. Full birth date is canonical; age is calculated locally for the relevant date.
 
-### Memory Ledger schema v9
+Schema v12 physically removes the former `adult_memory_consent_at` and `memory_consent_version` fields. Memory/chat authorization does not depend on a consent phrase or disclosure-version token. A completed private profile is only the identity prerequisite; runtime/source/privacy gates remain separate.
 
-Phase 2 upgraded the Memory Ledger from v6 to v9. Version 8 is already occupied by identity-consent migration, so v9 is the persistence version used by the current control surface.
+The existing under-18 profile-completion behavior remains unchanged and is **PRODUCT DECISION PENDING**.
 
-Schema v9 contains:
+### Memory Ledger — schema v9
+
+The persistent ledger contains:
 
 - `memory_ledger_settings`;
 - `memory_records`;
 - `memory_receipts`;
 - `memory_contradictions`;
 - `memory_entities`;
-- `memory_search` (SQLite FTS5 virtual table and sync triggers).
+- `memory_search` (SQLite FTS5 plus sync triggers).
 
-Automatic Discord extraction and the live chat surface are **not** implemented by the schema/control phases. They remain later phases.
+### Automatic extraction queue — schema v11
+
+`memory_extraction_jobs` is the durable transient-work queue for interaction-scoped automatic extraction. Its v11 ownership model includes claim tokens, leases, bounded retry, source versions, absolute raw-text TTL enforcement, and migration protection against legacy tokenless workers.
 
 ## Memory record
 
-Every memory remains guild-scoped and attached to an existing Coven Registry/profile shell. No outsider profile is created merely because somebody gossips about a third party.
+Every memory is guild-scoped and attached to an existing Coven member/profile shell. Gossip about a non-member does not silently create an outsider profile.
 
-A v9 memory stores:
+A memory stores:
 
 - guild ID;
 - subject/member ID;
@@ -56,7 +58,7 @@ A v9 memory stores:
 - creator ID;
 - created, updated, and last-confirmed timestamps.
 
-Categories remain:
+Categories:
 
 - `Identity`
 - `Preference`
@@ -71,49 +73,47 @@ Categories remain:
 - `Wilhelmina impression`
 - `Gossip`
 
-Epistemic labels remain:
+Epistemic labels:
 
 - `Fact`
 - `Inference`
 - `Impression`
 - `Gossip`
 
-Gossip is always treated as attributed/unverified social information rather than established fact.
+Facts, inferences, impressions, and gossip remain distinguishable. Gossip is attributed/unverified social information rather than established fact.
 
 ## Privacy and reveal metadata
 
-Schema v9 separates **what a memory is** from **where it may be revealed**.
-
 ### Privacy class
 
-- `ordinary` — normal adult social memory eligible for approved conversational use.
-- `restricted` — material that requires a narrower reveal scope.
+- `ordinary` — normal social memory eligible for approved conversational use.
+- `restricted` — material requiring a narrower reveal scope.
 
 ### Reveal scope
 
-- `cross_member` — may be used in approved memory-aware conversation even when the current interlocutor is somebody else. This is the default for ordinary social memories and implements the locked "full menace" direction.
+- `cross_member` — may be used in approved memory-aware conversation when the current interlocutor is another permitted member.
 - `owner_only` — may be revealed only when the current interlocutor is the memory's subject.
-- `admin_only` — never enters ordinary member chat; reserved for founder/admin surfaces.
+- `admin_only` — reserved for founder/admin surfaces and excluded from ordinary member chat.
 
-`restricted + cross_member` is invalid. An `Admin note` is always forced to `restricted/admin_only` regardless of caller input.
+`restricted + cross_member` is invalid. `Admin note` is always forced to `restricted/admin_only`.
 
-These fields are deterministic local authorization metadata. OpenAI never gets to override them.
+These fields are deterministic local authorization metadata. OpenAI never overrides them.
 
 ### Importance
 
-`importance` is an integer from 0 through 100, default 50. It is a local retrieval/ranking signal for later context assembly. It is not an authorization signal and does not override reveal scope.
+`importance` is an integer from 0 through 100, default 50. It is a retrieval/ranking signal, not authorization, and never overrides reveal scope.
 
-## Receipts and source context
+## Receipts and evidence
 
-Every memory has evidence.
+Every surviving memory has evidence.
 
-Schema v9 adds `source_context` so a receipt can honestly represent where the evidence came from:
+Receipt `source_context` values:
 
-- `guild` — Discord guild message. Requires channel ID, message ID, and jump URL.
-- `dm` — direct message involving Wilhelmina. Requires message ID but **does not fabricate a guild jump URL**. A DM channel ID may be retained if the event layer has one, but it is not treated as a guild channel.
-- `admin` — founder/admin-authored memory. No Discord channel, message, or jump URL is fabricated.
+- `guild` — Discord guild message, with channel/message IDs and jump URL;
+- `dm` — DM involving Wilhelmina, with message ID and no fabricated guild jump URL;
+- `admin` — founder/admin-authored memory, with no fabricated Discord message metadata.
 
-Discord receipts retain:
+Discord receipts may retain:
 
 - source author;
 - source context;
@@ -126,226 +126,186 @@ Discord receipts retain:
 - edit timestamp;
 - source deletion timestamp.
 
-Deleting the original Discord message does not erase an already-captured receipt. It marks the source deleted. Permanently deleting the Memory Ledger record itself cascades its receipts.
+Deleting the source Discord message marks an existing receipt deleted; it does not rewrite history. Permanently deleting the Memory Ledger record cascades its receipts.
 
 ## Duplicate, replacement, and contradiction behavior
 
-All destructive decisions remain Python/SQLite behavior.
+All destructive or authorization-sensitive decisions remain Python/SQLite behavior.
 
 ### Exact duplicate
 
-An exact duplicate keeps one memory record, adds the new receipt, and updates confirmation timestamps.
+An exact duplicate keeps one memory record, adds a new receipt, and updates confirmation timestamps.
 
-The Phase-3 admin write path adds a fail-safe rule around duplicate metadata: privacy may tighten but never loosen. If a duplicate admin write requests a narrower privacy/reveal posture than the stored record, the existing record is tightened after the receipt merge. A later broader duplicate cannot reopen an already narrower record. Duplicate importance stays at its existing stored value unless an admin explicitly changes it through the edit command.
+**Duplicate confirmation is evidence-only.** It does not implicitly change privacy class, reveal scope, or importance. This applies even when a later admin `/memory-admin add` invocation supplies different metadata.
+
+Privacy/reveal/importance changes require an explicit admin edit. `/memory-admin edit` may intentionally tighten or loosen privacy/reveal metadata as long as the requested pair is valid. This keeps “confirm the same fact again” separate from “change how this memory may be disclosed.”
 
 ### Topic-scoped correction
 
-Ordinary replacement is **topic-scoped**, not category-wide.
+Ordinary replacement is topic-scoped, not category-wide. A new ordinary memory replaces older active ordinary memories only when guild, subject, and normalized `topic_key` match.
 
-A new ordinary memory replaces older active ordinary memories only when all of the following match:
-
-- same guild;
-- same subject;
-- same normalized `topic_key`.
-
-Unrelated memories in the same category coexist. For example, changing a coffee preference does not erase a movie preference merely because both are `Preference` memories.
-
-Superseded ordinary records and their receipts are permanently deleted. A minimal content-free `memory.replaced` audit remains.
-
-The legacy service parameter named `replace_normal_category` is temporarily preserved for compatibility; in v9 it controls topic-scoped replacement and no longer authorizes category-wide deletion.
+Unrelated memories in the same category coexist. Superseded ordinary records and their receipts are permanently deleted, with only content-free audit metadata retained.
 
 ### Gossip contradiction
 
-Multiple gossip claims about the same topic remain separate and are linked through `memory_contradictions`.
-
-If a gossip record's topic/category changes, old contradiction links are cleared before valid links are regenerated. Deleting either memory cascades the relationship.
+Conflicting gossip on the same topic may coexist and is linked through `memory_contradictions`. Editing a gossip record's topic/category clears obsolete links before valid links are regenerated. Deleting either memory cascades the relationship.
 
 ## Entity index
 
-`memory_entities` provides deterministic local relationship/index data for later retrieval. Supported entity types are:
+`memory_entities` provides deterministic local relationship/index data for retrieval.
 
-- `subject` — automatically managed member who owns the memory;
-- `topic` — automatically managed normalized topic key;
-- `member` — additional participating/referenced Coven member IDs or member keys;
+Supported types:
+
+- `subject` — system-managed owner of the memory;
+- `topic` — system-managed normalized topic;
+- `member` — other participating/referenced Coven member identifiers;
 - `term` — bounded normalized terms useful for deterministic lookup.
 
-`subject` and `topic` links are system-managed and cannot be overwritten through the public entity API. Custom entity replacement may change `member` and `term` links only.
-
-Deleting a memory cascades all entity links.
+`subject` and `topic` are system-managed. Custom entity replacement may modify only `member` and `term` links. Memory deletion cascades entity rows.
 
 ## Local full-text search
 
-`memory_search` is an SQLite FTS5 external-content index over:
+`memory_search` is an SQLite FTS5 external-content index over summary and topic key. Insert/update/delete triggers keep it synchronized.
 
-- memory summary;
-- topic key.
+Search supports deterministic filters for guild, reveal scope, optional subject IDs, and bounded result count. Normal search defaults to `cross_member`; owner/admin contexts must request their additional scopes explicitly.
 
-Insert/update/delete triggers keep it synchronized with `memory_records`.
+OpenAI is never asked which private rows it is allowed to retrieve.
 
-The service exposes local search with deterministic filters for:
+## Full-profile and future retrieval contract
 
-- guild;
-- reveal scope;
-- optional subject IDs;
-- bounded result limit.
+The current interlocutor's full permitted active profile remains core future chat context. FTS/entity retrieval supplements that profile with relevant cross-member memories, named/referenced members, contradiction partners, historical callbacks, and evidence budgeting.
 
-Search defaults to `cross_member` records only. A later owner-context assembler may explicitly include `owner_only`. Admin-only records are never accidentally returned by the normal default.
+Authorization is applied before any selected context is sent to the model.
 
-Entity lookup uses the same reveal-scope principle.
+Phase 5 will implement deterministic context intelligence on top of these interfaces. A distinct permanent/evolving psychological/personality-profiling layer remains externally policy-gated and is not smuggled into ordinary retrieval architecture.
 
-This search layer is for local retrieval. OpenAI is **not** asked which private rows it is allowed to retrieve.
+## Dangerous-secret boundary
 
-## Full-profile contract
+Sensitivity by topic is not itself prohibited. Medical or mental-health diagnoses, adult relationship/sexual context, politics, religion, identity, substance use, money, embarrassment, and other ordinary social material may be valid memory when the actual source/authorization rules permit it.
 
-The current interlocutor's full permitted active profile remains core future chat context. FTS/entity retrieval is not a penny-saving excuse to amputate that profile.
+The deterministic local guard instead rejects concrete dangerous-secret classes, including recognizable forms of:
 
-Later retrieval uses these structures primarily for:
+- passwords/login credentials;
+- API keys/access tokens/private secrets;
+- payment-card/banking/account credentials;
+- government/private identity-document numbers;
+- doxxing-grade exact private addresses;
+- equivalent high-risk secrets.
 
-- relevant cross-member memories;
-- named/referenced members;
-- contradiction partners;
-- useful historical callbacks;
-- evidence/receipt budgeting.
+The guard runs before provider use and again on model-controlled persisted strings such as summary/topic/term entities. Admin-only information and unauthorized sources remain outside ordinary disclosure regardless of content category.
 
-Authorization is applied before context is sent to the model.
+A DM sent directly to Wilhelmina is not rejected merely for being private. Third-party DMs Wilhelmina is not part of remain inaccessible.
+
+## Automatic interaction-scoped extraction
+
+Automatic collection is controlled by:
+
+- `ENABLE_MEMORY_EXTRACTION` feature loading;
+- `MEMORY_COLLECTION_MODE` runtime policy;
+- persistent pause/resume state;
+- completed private identity profile;
+- home-guild/source interaction checks;
+- private provider readiness;
+- deterministic dangerous-secret guard.
+
+Current eligible interaction sources are DMs with Wilhelmina, the designated Wilhelmina channel, direct mentions, and resolvable replies to Wilhelmina. Ambient unaddressed whole-server listening remains dormant.
+
+The queue/worker rechecks authorization before queue persistence, before provider use, and inside the final mutation transaction. A provider response is accepted only when the current row still matches status, content hash, and exact claim token after a final stale-job/TTL sweep.
+
+## Edit and deletion ordering
+
+Raw Discord edits are versioned with full timestamp precision. The edit transaction rejects stale/equal handlers, cancels superseded queue work, advances source version state, rechecks authorization, guards the new text, updates authorized receipt evidence, and requeues only the newest valid version.
+
+A stale worker or late edit handler cannot resurrect superseded text.
+
+Discord source deletion clears outstanding queued source text and marks existing receipts deleted.
+
+## Transient raw-text TTL
+
+Raw source text in outstanding extraction jobs has an absolute one-hour lifetime. Retry and provider processing do not extend it. An independent retention worker can revoke an in-flight claim, and the provider-return transaction runs another expiry sweep before reconciliation.
+
+A provider result returning after TTL therefore creates neither memory nor receipt mutation.
 
 ## Audit privacy
 
-Operational audit rows must not serialize memory summaries or receipt excerpts.
+Operational audit rows must not serialize memory summaries, receipt excerpts, preferred names, or birth dates.
 
-Schema-v9 service events keep only content-free metadata such as:
+Safe audit metadata includes identifiers/counts, whether a record was created/merged/replaced, privacy/reveal class changes, and source context. Raw memories and receipts belong in the Memory Ledger, not generic logs.
 
-- memory ID;
-- whether a record was created or merged;
-- whether fields changed;
-- privacy/reveal class;
-- receipt source context.
+## Founder/admin controls
 
-Permanent deletion/replacement audits remain content-free.
+`cogs.memory_admin` is enabled by `ENABLE_MEMORY_ADMIN=true` and is ephemeral, administrator-only, and home-guild restricted.
 
-Raw memories and receipts belong in the Memory Ledger, not generic audit logs.
+Implemented controls include:
 
-## Prohibited information
-
-The deterministic local validator runs before external extraction and before persistence. At minimum it rejects material matching dangerous classes such as:
-
-- passwords and login credentials;
-- API/access tokens;
-- banking/payment/account information;
-- government/private identity-document numbers;
-- exact home/private addresses;
-- medical or mental-health diagnoses;
-- comparable dangerous private secrets.
-
-A DM sent directly to Wilhelmina is not rejected merely because it is private. Third-party DMs Wilhelmina is not part of remain outside accessible collection scope.
-
-Adult/social character direction never converts prohibited secrets or admin-only data into comedy ammunition.
-
-## Collection policy
-
-Automatic collection is controlled separately by the runtime policy:
-
-- `off` — no automatic extraction;
-- `interaction` — eligible interaction involving Wilhelmina;
-- `ambient` — dormant future whole-server path requiring every platform/runtime gate.
-
-The default remains `off`.
-
-Phase 3 adds a separate persistent database pause/resume gate. Resuming that gate never overrides the runtime policy, and automatic extraction itself remains a later implementation phase.
-
-## v6 → v9 migration matrix
-
-Migration is idempotent and preserves existing content.
-
-| Existing v6 data | v9 result |
-|---|---|
-| ordinary memory | preserved; `privacy_class=ordinary`, `reveal_scope=cross_member`, `importance=50` |
-| `Admin note` | preserved but tightened to `restricted/admin_only` |
-| guild Discord receipt | preserved and marked `source_context=guild` |
-| admin receipt | preserved and marked `source_context=admin` |
-| memory subject/topic | backfilled into system entity rows |
-| existing summary/topic | rebuilt into local FTS index |
-| receipts/contradictions | preserved subject to existing foreign-key integrity |
-
-The migration order is deliberate:
-
-1. ensure base Registry/profile dependencies;
-2. ensure core memory tables exist;
-3. add new record columns to legacy tables;
-4. rebuild the receipt table into the v9 context-aware shape when required;
-5. create indexes that reference new columns;
-6. create/rebuild FTS and triggers;
-7. backfill subject/topic entity rows;
-8. record schema version 9.
-
-Indexes never reference v9 columns before those columns exist.
-
-## Integrity checks
-
-`check_memory_integrity()` provides a local diagnostic for:
-
-- SQLite foreign-key violations;
-- orphan/mismatched entity rows;
-- invalid contradiction relationships;
-- missing system subject/topic entities;
-- presence of the FTS structure.
-
-Tests also verify that deleting a memory removes dependent receipts, entity rows, contradiction links, and FTS searchability.
-
-## Phase 3 — Memory controls
-
-Phase 3 adds `cogs.memory_admin`, controlled by `ENABLE_MEMORY_ADMIN=true` by default. Every `/memory-admin` response is ephemeral, administrator-only, and restricted to the configured home guild.
-
-Implemented controls:
-
-- status plus integrity diagnostics;
+- status/integrity diagnostics;
 - persistent pause/resume;
-- designated Wilhelmina channel set/clear;
-- paginated private profiles;
-- record detail and receipt inspection;
-- local FTS search across explicitly selected admin-visible reveal scopes;
-- manual admin-authored add/edit/delete;
-- content-free member data inventory for current or departed members;
-- permanent member-wide Memory Ledger deletion for current or departed members with explicit confirmation.
+- designated channel set/clear;
+- private profile/detail/receipt inspection;
+- local FTS search across explicit admin-visible scopes;
+- manual add/edit/delete;
+- current/departed member data inventory;
+- current/departed member-wide Memory Ledger deletion with explicit confirmation.
 
-Single-record deletion requires `DELETE`. Member-wide Memory Ledger deletion requires `DELETE MEMBER`.
+Single-record deletion requires `DELETE`. Member-wide deletion requires `DELETE MEMBER`.
 
-Current-member commands accept a Discord member selection. Departed/archived-member variants accept a positive decimal Discord user ID string so the same data controls remain available after the member leaves the guild.
+Member-wide deletion removes subject memories plus receipts the member authored on other subjects. If deleting authored evidence leaves another memory with zero receipts, that evidence-less memory is deleted; otherwise it survives.
 
-Member-wide deletion covers both kinds of Memory Ledger data tied to the member: records where they are the subject **and receipts they authored on another subject's memory**. Cross-subject authored receipts are deleted during the purge. If removing them leaves another memory with zero receipts, that now-evidence-less memory is also deleted; if another receipt remains, the memory survives.
+The purge does not silently delete Coven Registry or private identity records.
 
-The purge deliberately does not silently delete Coven Registry or private identity/consent records. Broader member-data handling must use those feature boundaries explicitly.
+See `docs/memory_controls.md` for command details.
 
-See `docs/memory_controls.md` for the command and privacy contract.
+## Migration and rollback
 
-## Rollback notes
+### Memory Ledger v6 -> v9
 
-Do not downgrade an already-migrated production database by merely running older code against it.
+The v9 migration preserves legacy memories/receipts, adds privacy/reveal/importance/source-context fields, backfills system entities, rebuilds FTS, and keeps foreign-key integrity. `Admin note` data is tightened to `restricted/admin_only` during the schema migration because that is a deterministic invariant of the record type.
 
-Safe rollback for the v9 persistence phase is operational:
+### Extraction v10 -> v11
 
-1. stop Wilhelmina before changing database code;
-2. restore the pre-v9 SQLite backup/snapshot together with the previous application revision; or
-3. if no database rollback is needed, deploy a forward fix that continues understanding v9.
+Legacy tokenless `processing` rows are invalidated, transient text is erased, claims are cleared, and database enforcement blocks old-style processing transitions without a claim token. Old v10 workers should still be stopped/drained during rollout.
 
-The migration intentionally does not keep duplicated private-content backup tables after success. Old receipt rows are copied into the v9 table and the temporary legacy table is dropped in the same transaction managed by the caller.
+### Identity v7/v8 -> v12
 
-Phase 3 adds no schema migration. Its command surface can be rolled back by disabling `ENABLE_MEMORY_ADMIN` or deploying the previous application revision; existing v9 data and settings remain intact.
+The private identity table is transactionally rebuilt without the obsolete consent columns while preserving preferred name, full birth date, guild/user identity, and original timestamps. A failed copy rolls back to the intact legacy table.
 
-## Remaining implementation phases
+Do not “rollback” a migrated production database by merely deploying older code. Stop Wilhelmina and restore a matching database backup with the matching application revision, or deploy a forward fix that understands the current schemas.
 
-### Phase 4 — Automatic memory extraction
+## Integrity and tests
 
-Discord interaction/DM event eligibility, local prohibited-data guard, strict structured OpenAI extraction, queue/backpressure, receipt/edit/delete reconciliation.
+`check_memory_integrity()` covers foreign-key violations, entity consistency, contradiction validity, required system entities, and FTS presence.
+
+The regression suite additionally covers:
+
+- v7/v8 identity -> v12 preservation and rollback safety;
+- v10 extraction -> v11 claim migration;
+- secret/identifier/payment/address blocking;
+- socially sensitive content permissiveness;
+- exact claim ownership and stale-worker rejection;
+- absolute TTL including provider-return boundary;
+- uncached/raw edit handling and subsecond ordering;
+- source deletion;
+- explicit-only privacy metadata mutation;
+- member-wide authored-evidence deletion;
+- content-free operational logging/auditing.
+
+Repository quality gates:
+
+```bash
+ruff check .
+pytest
+```
+
+## Next implementation stages
 
 ### Phase 5 — Memory intelligence/context
 
-Deterministic scoring, FTS/entity retrieval, full active speaker profile loading, cross-member selection, contradiction expansion, evidence budgeting.
+Deterministic authorization-first scoring, FTS/entity retrieval, active-speaker profile loading, cross-member selection, contradiction expansion, and evidence budgeting.
 
 ### Phase 6 — Wilhelmina chat brain
 
-Designated server chat, fully memory-aware DM confessional mode, direct responses, selective spontaneous interjections, adult persona/evals.
+Designated server chat and memory-aware direct interaction surfaces using the approved retrieval context.
 
-### Phase 7 — Hardening and dormant ambient path
+### Phase 7 — Hardening / deployment / dormant ambient path
 
-Adversarial/privacy regressions, reconnect/rate-limit testing, observability/rollback controls, and the ambient whole-server path kept disabled until every required gate is satisfied.
+Deployment, backups, monitoring, live validation, reconnect/rate-limit/adversarial testing, and any broader listening path only after its separate product/platform decision.

--- a/services/member_profiles.py
+++ b/services/member_profiles.py
@@ -13,12 +13,8 @@ from services.member_identity import (
     normalize_discord_display_name,
 )
 
-MEMBER_IDENTITY_SCHEMA_VERSION = 8
-# Legacy schema values retained only until the dedicated destructive migration tranche.
-# They are historical/compatibility metadata and MUST NOT authorize memory or chat access.
-LEGACY_MEMORY_CONSENT_VERSION = "legacy-adult-memory-v1"
-CURRENT_MEMORY_CONSENT_VERSION = "2026-08-interaction-dm-cross-reveal-v2"
-NON_AUTHORITATIVE_MEMORY_MARKER = "deprecated-not-authority"
+MEMBER_IDENTITY_SCHEMA_VERSION = 12
+LEGACY_IDENTITY_TABLE = "coven_member_identity_profiles_pre_v12"
 
 
 class MemberIdentityProfileNotFound(LookupError):
@@ -34,10 +30,6 @@ class StoredMemberIdentity:
     discord_display_name: str
     preferred_name: str
     birth_date: str
-    # These two fields remain readable only because schema v8 still physically contains them.
-    # Runtime authorization must use profile existence/source scope, never these values.
-    adult_memory_consent_at: str
-    memory_consent_version: str
     created_at: str
     updated_at: str
 
@@ -54,64 +46,108 @@ class StoredMemberIdentity:
     def trusted_chat_context(self, *, on_date: date) -> TrustedIdentityContext:
         return self.to_domain(today=on_date).trusted_chat_context(on_date=on_date)
 
-    @property
-    def has_current_memory_consent(self) -> bool:
-        """Legacy metadata only; never use this property as an authorization gate."""
 
-        return self.memory_consent_version == CURRENT_MEMORY_CONSENT_VERSION
-
-
-SCHEMA_STATEMENTS: tuple[str, ...] = (
-    """
-    CREATE TABLE IF NOT EXISTS coven_member_identity_profiles (
-        guild_id INTEGER NOT NULL,
-        user_id INTEGER NOT NULL,
-        preferred_name TEXT NOT NULL CHECK (
-            length(trim(preferred_name)) BETWEEN 1 AND 80
-        ),
-        birth_date TEXT NOT NULL CHECK (birth_date GLOB '????-??-??'),
-        adult_memory_consent_at TEXT NOT NULL,
-        memory_consent_version TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        PRIMARY KEY (guild_id, user_id),
-        FOREIGN KEY (guild_id, user_id)
-            REFERENCES coven_registry_entries (guild_id, user_id)
-            ON DELETE CASCADE
-    )
-    """,
+CREATE_IDENTITY_TABLE = """
+CREATE TABLE IF NOT EXISTS coven_member_identity_profiles (
+    guild_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    preferred_name TEXT NOT NULL CHECK (
+        length(trim(preferred_name)) BETWEEN 1 AND 80
+    ),
+    birth_date TEXT NOT NULL CHECK (birth_date GLOB '????-??-??'),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (guild_id, user_id),
+    FOREIGN KEY (guild_id, user_id)
+        REFERENCES coven_registry_entries (guild_id, user_id)
+        ON DELETE CASCADE
 )
+"""
+
+
+def _table_exists(connection: sqlite3.Connection, table: str) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
 
 
 def _column_names(connection: sqlite3.Connection, table: str) -> set[str]:
+    if not _table_exists(connection, table):
+        return set()
     return {
         str(row["name"])
         for row in connection.execute(f"PRAGMA table_info({table})").fetchall()
     }
 
 
-def _migrate_legacy_memory_consent(connection: sqlite3.Connection) -> None:
-    """Keep legacy schema v7 readable until the later physical column-removal migration."""
+def _migrate_identity_profile_v12(connection: sqlite3.Connection) -> None:
+    """Drop obsolete consent columns while preserving canonical identity data.
+
+    SQLite has no portable DROP COLUMN path for all supported deployments, so legacy
+    v7/v8 shapes are rebuilt in-place. The caller's transaction owns commit/rollback;
+    a failed copy therefore leaves the old table intact rather than half-migrated.
+    """
 
     columns = _column_names(connection, "coven_member_identity_profiles")
-    if "memory_consent_version" in columns:
+    if not columns:
+        connection.execute(CREATE_IDENTITY_TABLE)
         return
+
+    required_core = {
+        "guild_id",
+        "user_id",
+        "preferred_name",
+        "birth_date",
+        "created_at",
+        "updated_at",
+    }
+    missing = required_core - columns
+    if missing:
+        raise sqlite3.IntegrityError(
+            "identity profile migration cannot preserve required columns: "
+            + ", ".join(sorted(missing))
+        )
+
+    obsolete = {"adult_memory_consent_at", "memory_consent_version"}
+    if not (columns & obsolete):
+        return
+
+    connection.execute(f"DROP TABLE IF EXISTS {LEGACY_IDENTITY_TABLE}")
     connection.execute(
-        """
-        ALTER TABLE coven_member_identity_profiles
-        ADD COLUMN memory_consent_version TEXT NOT NULL
-        DEFAULT 'legacy-adult-memory-v1'
+        f"ALTER TABLE coven_member_identity_profiles RENAME TO {LEGACY_IDENTITY_TABLE}"
+    )
+    connection.execute(CREATE_IDENTITY_TABLE)
+    connection.execute(
+        f"""
+        INSERT INTO coven_member_identity_profiles (
+            guild_id,
+            user_id,
+            preferred_name,
+            birth_date,
+            created_at,
+            updated_at
+        )
+        SELECT
+            guild_id,
+            user_id,
+            preferred_name,
+            birth_date,
+            created_at,
+            updated_at
+        FROM {LEGACY_IDENTITY_TABLE}
         """
     )
+    connection.execute(f"DROP TABLE {LEGACY_IDENTITY_TABLE}")
 
 
 def initialize_member_identity_schema(connection: sqlite3.Connection) -> None:
     """Create and migrate the private member-identity table idempotently."""
 
     registry.initialize_registry_schema(connection)
-    for statement in SCHEMA_STATEMENTS:
-        connection.execute(statement)
-    _migrate_legacy_memory_consent(connection)
+    _migrate_identity_profile_v12(connection)
+    connection.execute(CREATE_IDENTITY_TABLE)
     connection.execute(
         """
         INSERT OR IGNORE INTO schema_migrations (version, applied_at)
@@ -128,8 +164,6 @@ def _row_to_identity(row: sqlite3.Row) -> StoredMemberIdentity:
         discord_display_name=str(row["display_name"]),
         preferred_name=str(row["preferred_name"]),
         birth_date=str(row["birth_date"]),
-        adult_memory_consent_at=str(row["adult_memory_consent_at"]),
-        memory_consent_version=str(row["memory_consent_version"]),
         created_at=str(row["created_at"]),
         updated_at=str(row["updated_at"]),
     )
@@ -153,8 +187,6 @@ def get_member_identity(
             entry.display_name,
             profile.preferred_name,
             profile.birth_date,
-            profile.adult_memory_consent_at,
-            profile.memory_consent_version,
             profile.created_at,
             profile.updated_at
         FROM coven_member_identity_profiles AS profile
@@ -176,7 +208,7 @@ def profile_is_complete(
     guild_id: int,
     user_id: int,
 ) -> bool:
-    """Return whether the member has a persisted identity profile."""
+    """Return whether the member has a persisted private identity profile."""
 
     return (
         get_member_identity(
@@ -195,32 +227,9 @@ def profile_is_memory_eligible(
     guild_id: int,
     user_id: int,
 ) -> bool:
-    """Return whether identity prerequisites exist for approved memory interactions.
-
-    This is intentionally profile-state based. Consent timestamps/versions left in schema v8
-    are non-authoritative compatibility data and do not grant or revoke runtime access.
-    """
+    """Return whether identity prerequisites exist for approved memory interactions."""
 
     return profile_is_complete(
-        connection,
-        guild_id=guild_id,
-        user_id=user_id,
-    )
-
-
-def profile_has_current_consent(
-    connection: sqlite3.Connection,
-    *,
-    guild_id: int,
-    user_id: int,
-) -> bool:
-    """Deprecated compatibility alias for old Phase-4 callers.
-
-    The old name survives temporarily so the reviewed extraction worker can remain mechanically
-    stable in this tranche. It no longer checks consent and delegates to profile eligibility.
-    """
-
-    return profile_is_memory_eligible(
         connection,
         guild_id=guild_id,
         user_id=user_id,
@@ -237,20 +246,10 @@ def save_member_identity(
     birth_date: str | date,
     today: date,
     actor_user_id: int,
-    adult_memory_consent: bool | None = None,
-    consent_at: str | None = None,
-    consent_version: str | None = None,
 ) -> StoredMemberIdentity:
-    """Validate and persist the member's canonical private identity.
+    """Validate and persist the member's canonical private identity."""
 
-    The consent arguments are accepted only as short-lived source-compatibility parameters while
-    schema v8 and older callers are being retired. Their values are ignored for authorization and
-    new profiles receive a non-authoritative marker in the obsolete NOT NULL columns.
-    """
-
-    del adult_memory_consent, consent_at, consent_version
     initialize_member_identity_schema(connection)
-
     identity = MemberIdentity.create(
         discord_display_name=discord_display_name,
         preferred_name=preferred_name,
@@ -292,12 +291,10 @@ def save_member_identity(
             user_id,
             preferred_name,
             birth_date,
-            adult_memory_consent_at,
-            memory_consent_version,
             created_at,
             updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT (guild_id, user_id) DO UPDATE SET
             preferred_name = excluded.preferred_name,
             birth_date = excluded.birth_date,
@@ -308,8 +305,6 @@ def save_member_identity(
             int(user_id),
             identity.preferred_name,
             identity.birth_date.isoformat(),
-            timestamp,
-            NON_AUTHORITATIVE_MEMORY_MARKER,
             timestamp,
             timestamp,
         ),

--- a/services/memory_admin.py
+++ b/services/memory_admin.py
@@ -5,12 +5,6 @@ from dataclasses import dataclass
 
 from services import audit_log, memory_ledger
 
-_REVEAL_SCOPE_RANK = {
-    "cross_member": 0,
-    "owner_only": 1,
-    "admin_only": 2,
-}
-
 
 @dataclass(frozen=True)
 class LedgerAdminSummary:
@@ -156,27 +150,6 @@ def summarize_member(
     )
 
 
-def _stricter_privacy(
-    *,
-    existing_privacy: str,
-    existing_scope: str,
-    requested_privacy: str,
-    requested_scope: str,
-) -> tuple[str, str]:
-    privacy = (
-        "restricted"
-        if "restricted" in {existing_privacy, requested_privacy}
-        else "ordinary"
-    )
-    scope = max(
-        (existing_scope, requested_scope),
-        key=lambda value: _REVEAL_SCOPE_RANK[value],
-    )
-    if privacy == "restricted" and scope == "cross_member":
-        scope = "owner_only"
-    return privacy, scope
-
-
 def add_admin_memory(
     connection: sqlite3.Connection,
     *,
@@ -191,7 +164,13 @@ def add_admin_memory(
     reveal_scope: str,
     importance: int,
 ) -> tuple[memory_ledger.MemoryWriteResult, memory_ledger.MemoryRecord]:
-    """Add/confirm an admin memory while allowing duplicate privacy to tighten, never loosen."""
+    """Add or confirm an admin memory without implicit metadata mutation.
+
+    Exact duplicates add evidence/confirmation only. Privacy, reveal scope, and importance
+    remain whatever is already stored. An administrator may change those fields explicitly
+    through `memory_ledger.update_memory`, which supports both tightening and loosening when
+    the requested privacy/scope pair is valid.
+    """
 
     result = memory_ledger.add_memory(
         connection,
@@ -207,26 +186,7 @@ def add_admin_memory(
         reveal_scope=reveal_scope,
         importance=importance,
     )
-    stored = result.memory
-    if not result.created:
-        tightened_privacy, tightened_scope = _stricter_privacy(
-            existing_privacy=stored.privacy_class,
-            existing_scope=stored.reveal_scope,
-            requested_privacy=privacy_class,
-            requested_scope=reveal_scope,
-        )
-        if (
-            tightened_privacy != stored.privacy_class
-            or tightened_scope != stored.reveal_scope
-        ):
-            stored = memory_ledger.update_memory(
-                connection,
-                memory_id=stored.id,
-                actor_user_id=actor_user_id,
-                privacy_class=tightened_privacy,
-                reveal_scope=tightened_scope,
-            )
-    return result, stored
+    return result, result.memory
 
 
 def delete_member_data(

--- a/services/persona.py
+++ b/services/persona.py
@@ -46,9 +46,12 @@ Keep factual content exactly aligned with the feature context. Do not add
 commands, stored state, rule acceptance, memory, or server actions that were not
 provided by the calling service. Keep Discord output short.
 
-Do not target protected classes or identity traits. Do not write sexual content
-about minors, encourage self-harm, dox anyone, or make credible real-world
-threats. Wilhelmina can be vicious; she still has to be competent.
+Protected-class and identity traits may be mentioned factually when they are
+relevant to the supplied context. Do not turn a protected class or identity
+trait itself into the basis for a dehumanizing attack, slur, or comparable
+targeted abuse. Do not write sexual content about minors, encourage self-harm,
+dox anyone, or make credible real-world threats. Wilhelmina can be vicious; she
+still has to be competent.
 """.strip()
 
 

--- a/tests/test_member_profiles.py
+++ b/tests/test_member_profiles.py
@@ -1,3 +1,4 @@
+import sqlite3
 from datetime import date
 
 import pytest
@@ -29,6 +30,15 @@ def _bootstrap(path, *, guild_id: int = 1) -> None:
         )
 
 
+def _profile_columns(connection) -> set[str]:
+    return {
+        str(row["name"])
+        for row in connection.execute(
+            "PRAGMA table_info(coven_member_identity_profiles)"
+        ).fetchall()
+    }
+
+
 def test_identity_persists_both_names_and_full_birth_date(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
@@ -54,8 +64,6 @@ def test_identity_persists_both_names_and_full_birth_date(tmp_path) -> None:
     assert stored.discord_display_name == "xXDarkSylveonXx"
     assert stored.preferred_name == "Jessica"
     assert stored.birth_date == "1991-10-31"
-    assert stored.memory_consent_version == member_profiles.NON_AUTHORITATIVE_MEMORY_MARKER
-    assert stored.has_current_memory_consent is False
     assert context.discord_display_name == "xXDarkSylveonXx"
     assert context.preferred_name == "Jessica"
     assert context.birth_date == "1991-10-31"
@@ -96,35 +104,6 @@ def test_identity_survives_a_new_database_connection(tmp_path) -> None:
     assert stored.preferred_name == "Real Name"
     assert stored.birth_date == "1990-01-01"
     assert eligible is True
-
-
-def test_legacy_consent_arguments_do_not_gate_identity(tmp_path) -> None:
-    path = tmp_path / "identity.sqlite3"
-    _bootstrap(path)
-
-    with managed_connection(path) as connection:
-        stored = member_profiles.save_member_identity(
-            connection,
-            guild_id=1,
-            user_id=300,
-            discord_display_name="Screen Name",
-            preferred_name="Real Name",
-            birth_date="1990-01-01",
-            today=date(2026, 8, 6),
-            adult_memory_consent=False,
-            consent_at="",
-            consent_version="",
-            actor_user_id=300,
-        )
-        context = member_profiles.get_trusted_identity_context(
-            connection,
-            guild_id=1,
-            user_id=300,
-            on_date=date(2026, 8, 6),
-        )
-
-    assert stored.memory_consent_version == member_profiles.NON_AUTHORITATIVE_MEMORY_MARKER
-    assert context.preferred_name == "Real Name"
 
 
 def test_underage_profile_does_not_change_registry_name(tmp_path) -> None:
@@ -215,7 +194,7 @@ def test_identity_is_scoped_to_one_guild(tmp_path) -> None:
     assert second is None
 
 
-def test_identity_audit_omits_names_birth_date_and_consent_metadata(tmp_path) -> None:
+def test_identity_audit_omits_names_and_birth_date(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
@@ -240,43 +219,33 @@ def test_identity_audit_omits_names_birth_date_and_consent_metadata(tmp_path) ->
     assert "consent" not in payload.lower()
 
 
-def test_identity_schema_version_and_legacy_columns_are_preserved_for_safe_migration(tmp_path) -> None:
+def test_identity_schema_v12_has_no_consent_columns(tmp_path) -> None:
     path = tmp_path / "identity.sqlite3"
     _bootstrap(path)
 
     with managed_connection(path) as connection:
         member_profiles.initialize_member_identity_schema(connection)
-
-    connection = connect(path)
-    try:
-        table = connection.execute(
-            """
-            SELECT name
-            FROM sqlite_master
-            WHERE type = 'table' AND name = 'coven_member_identity_profiles'
-            """
-        ).fetchone()
-        columns = {
-            str(row["name"])
-            for row in connection.execute(
-                "PRAGMA table_info(coven_member_identity_profiles)"
-            ).fetchall()
-        }
+        columns = _profile_columns(connection)
         versions = {
             int(row["version"])
             for row in connection.execute("SELECT version FROM schema_migrations").fetchall()
         }
-    finally:
-        connection.close()
 
-    assert table is not None
-    assert "adult_memory_consent_at" in columns
-    assert "memory_consent_version" in columns
+    assert columns == {
+        "guild_id",
+        "user_id",
+        "preferred_name",
+        "birth_date",
+        "created_at",
+        "updated_at",
+    }
+    assert "adult_memory_consent_at" not in columns
+    assert "memory_consent_version" not in columns
     assert member_profiles.MEMBER_IDENTITY_SCHEMA_VERSION in versions
 
 
-def test_legacy_identity_profile_migrates_without_remaining_an_authorization_gate(tmp_path) -> None:
-    path = tmp_path / "identity.sqlite3"
+def test_v7_identity_profile_migrates_to_v12_without_losing_identity(tmp_path) -> None:
+    path = tmp_path / "identity-v7.sqlite3"
     _bootstrap(path)
 
     with managed_connection(path) as connection:
@@ -320,18 +289,122 @@ def test_legacy_identity_profile_migrates_without_remaining_an_authorization_gat
             user_id=300,
             on_date=date(2026, 8, 6),
         )
+        columns = _profile_columns(connection)
 
-        assert stored is not None
-        assert stored.memory_consent_version == member_profiles.LEGACY_MEMORY_CONSENT_VERSION
-        assert stored.has_current_memory_consent is False
-        assert member_profiles.profile_is_memory_eligible(
+    assert stored is not None
+    assert stored.preferred_name == "Jessica"
+    assert stored.birth_date == "1991-10-31"
+    assert stored.created_at == "created"
+    assert stored.updated_at == "updated"
+    assert context.birth_date == "1991-10-31"
+    assert member_profiles.profile_is_memory_eligible(
+        connect(path), guild_id=1, user_id=300
+    ) is True
+    assert "adult_memory_consent_at" not in columns
+    assert "memory_consent_version" not in columns
+
+
+def test_v8_identity_profile_migrates_to_v12_and_drops_both_consent_columns(tmp_path) -> None:
+    path = tmp_path / "identity-v8.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE coven_member_identity_profiles (
+                guild_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                preferred_name TEXT NOT NULL,
+                birth_date TEXT NOT NULL,
+                adult_memory_consent_at TEXT NOT NULL,
+                memory_consent_version TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (guild_id, user_id)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO coven_member_identity_profiles (
+                guild_id, user_id, preferred_name, birth_date,
+                adult_memory_consent_at, memory_consent_version, created_at, updated_at
+            )
+            VALUES (1, 300, 'Jessica', '1991-10-31', 'old-consent', 'v2', 'created', 'updated')
+            """
+        )
+        connection.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (8, 'old')"
+        )
+
+        member_profiles.initialize_member_identity_schema(connection)
+        stored = member_profiles.get_member_identity(
             connection,
             guild_id=1,
             user_id=300,
-        ) is True
-        assert member_profiles.profile_has_current_consent(
-            connection,
-            guild_id=1,
-            user_id=300,
-        ) is True
-        assert context.birth_date == "1991-10-31"
+            required=True,
+        )
+        columns = _profile_columns(connection)
+
+    assert stored is not None
+    assert stored.preferred_name == "Jessica"
+    assert stored.birth_date == "1991-10-31"
+    assert stored.created_at == "created"
+    assert stored.updated_at == "updated"
+    assert "adult_memory_consent_at" not in columns
+    assert "memory_consent_version" not in columns
+
+
+def test_failed_v12_copy_rolls_back_to_intact_legacy_table(tmp_path) -> None:
+    path = tmp_path / "identity-bad-legacy.sqlite3"
+    _bootstrap(path)
+
+    with managed_connection(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE coven_member_identity_profiles (
+                guild_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                preferred_name TEXT NOT NULL,
+                birth_date TEXT NOT NULL,
+                adult_memory_consent_at TEXT NOT NULL,
+                memory_consent_version TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (guild_id, user_id)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO coven_member_identity_profiles (
+                guild_id, user_id, preferred_name, birth_date,
+                adult_memory_consent_at, memory_consent_version, created_at, updated_at
+            )
+            VALUES (1, 300, '', '1991-10-31', 'old-consent', 'v2', 'created', 'updated')
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        with managed_connection(path) as connection:
+            member_profiles.initialize_member_identity_schema(connection)
+
+    connection = connect(path)
+    try:
+        columns = _profile_columns(connection)
+        row = connection.execute(
+            "SELECT preferred_name, memory_consent_version FROM coven_member_identity_profiles"
+        ).fetchone()
+        legacy_temp_exists = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (member_profiles.LEGACY_IDENTITY_TABLE,),
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert row is not None
+    assert row["preferred_name"] == ""
+    assert row["memory_consent_version"] == "v2"
+    assert "adult_memory_consent_at" in columns
+    assert "memory_consent_version" in columns
+    assert legacy_temp_exists is None

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -104,7 +104,9 @@ def test_member_summary_counts_private_rows_without_returning_content(database_p
     assert summary.admin_only_count == 1
 
 
-def test_admin_duplicate_can_tighten_privacy_but_never_loosen_it(database_path):
+def test_duplicate_confirmation_never_mutates_privacy_and_explicit_edit_can_move_both_ways(
+    database_path,
+):
     with managed_connection(database_path) as connection:
         first_result, first_stored = memory_admin.add_admin_memory(
             connection,
@@ -123,7 +125,7 @@ def test_admin_duplicate_can_tighten_privacy_but_never_loosen_it(database_path):
         assert first_stored.privacy_class == "ordinary"
         assert first_stored.reveal_scope == "cross_member"
 
-        tightened_result, tightened = memory_admin.add_admin_memory(
+        duplicate_result, unchanged = memory_admin.add_admin_memory(
             connection,
             guild_id=100,
             subject_user_id=2,
@@ -136,13 +138,23 @@ def test_admin_duplicate_can_tighten_privacy_but_never_loosen_it(database_path):
             reveal_scope="admin_only",
             importance=90,
         )
-        assert tightened_result.created is False
-        assert tightened.id == first_stored.id
+        assert duplicate_result.created is False
+        assert unchanged.id == first_stored.id
+        assert unchanged.privacy_class == "ordinary"
+        assert unchanged.reveal_scope == "cross_member"
+        assert unchanged.importance == 50
+
+        tightened = memory_ledger.update_memory(
+            connection,
+            memory_id=unchanged.id,
+            actor_user_id=2,
+            privacy_class="restricted",
+            reveal_scope="admin_only",
+        )
         assert tightened.privacy_class == "restricted"
         assert tightened.reveal_scope == "admin_only"
-        assert tightened.importance == 50
 
-        broader_result, still_tight = memory_admin.add_admin_memory(
+        second_duplicate, still_tight = memory_admin.add_admin_memory(
             connection,
             guild_id=100,
             subject_user_id=2,
@@ -155,11 +167,21 @@ def test_admin_duplicate_can_tighten_privacy_but_never_loosen_it(database_path):
             reveal_scope="cross_member",
             importance=10,
         )
-        assert broader_result.created is False
+        assert second_duplicate.created is False
         assert still_tight.privacy_class == "restricted"
         assert still_tight.reveal_scope == "admin_only"
         assert still_tight.importance == 50
-        assert len(memory_ledger.list_receipts(connection, still_tight.id)) == 3
+
+        loosened = memory_ledger.update_memory(
+            connection,
+            memory_id=still_tight.id,
+            actor_user_id=2,
+            privacy_class="ordinary",
+            reveal_scope="cross_member",
+        )
+        assert loosened.privacy_class == "ordinary"
+        assert loosened.reveal_scope == "cross_member"
+        assert len(memory_ledger.list_receipts(connection, loosened.id)) == 3
 
 
 def test_delete_member_memories_cascades_evidence_and_keeps_registry(database_path):

--- a/tests/test_memory_extraction_cog.py
+++ b/tests/test_memory_extraction_cog.py
@@ -34,7 +34,7 @@ def database_path(tmp_path):
     return path
 
 
-def _grant_consent(path):
+def _create_profile(path):
     with managed_connection(path) as connection:
         member_profiles.save_member_identity(
             connection,
@@ -44,7 +44,6 @@ def _grant_consent(path):
             preferred_name="Founder",
             birth_date="1990-01-01",
             today=date(2026, 8, 13),
-            adult_memory_consent=True,
             actor_user_id=2,
         )
 
@@ -84,19 +83,19 @@ async def test_runtime_off_blocks_before_collection(database_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_current_consent_is_required(database_path, monkeypatch):
+async def test_completed_profile_is_required(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
     result = await _cog(database_path)._eligibility(
         _message(mentions=(SimpleNamespace(id=999),))
     )
     assert result.eligible is False
-    assert result.reason == "consent_missing"
+    assert result.reason == "profile_missing"
 
 
 @pytest.mark.asyncio
-async def test_dm_with_current_consent_is_eligible(database_path, monkeypatch):
+async def test_dm_with_completed_profile_is_eligible(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     result = await _cog(database_path)._eligibility(_message(guild_id=None))
     assert result.eligible is True
     assert result.guild_id == 100
@@ -106,7 +105,7 @@ async def test_dm_with_current_consent_is_eligible(database_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_designated_channel_is_explicit_wilhelmina_interaction(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     with managed_connection(database_path) as connection:
         memory_ledger.set_wilhelmina_channel(
             connection,
@@ -122,7 +121,7 @@ async def test_designated_channel_is_explicit_wilhelmina_interaction(database_pa
 @pytest.mark.asyncio
 async def test_mention_is_eligible_outside_designated_channel(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     result = await _cog(database_path)._eligibility(
         _message(channel_id=20, mentions=(SimpleNamespace(id=999),))
     )
@@ -134,7 +133,7 @@ async def test_unaddressed_guild_message_is_not_ambient_collection(database_path
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "ambient")
     monkeypatch.setenv("ENABLE_AMBIENT_MEMORY", "true")
     monkeypatch.setenv("AMBIENT_MEMORY_APPROVAL_REFERENCE", "future-reference")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     result = await _cog(database_path)._eligibility(_message(channel_id=20))
     assert result.eligible is False
     assert result.reason == "not_interaction"
@@ -143,7 +142,7 @@ async def test_unaddressed_guild_message_is_not_ambient_collection(database_path
 @pytest.mark.asyncio
 async def test_persistent_pause_blocks_collection(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     with managed_connection(database_path) as connection:
         memory_ledger.set_collection_enabled(
             connection,
@@ -161,7 +160,7 @@ async def test_persistent_pause_blocks_collection(database_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_bot_and_wrong_guild_are_rejected(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     bot_message = await _cog(database_path)._eligibility(_message(author_bot=True))
     wrong_guild = await _cog(database_path)._eligibility(
         _message(guild_id=101, mentions=(SimpleNamespace(id=999),))
@@ -173,7 +172,7 @@ async def test_bot_and_wrong_guild_are_rejected(database_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_enqueue_rechecks_pause_in_same_write_transaction(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     with managed_connection(database_path) as connection:
         memory_extraction.initialize_extraction_schema(connection)
     cog = _cog(database_path)
@@ -203,7 +202,7 @@ async def test_enqueue_rechecks_pause_in_same_write_transaction(database_path, m
 @pytest.mark.asyncio
 async def test_uncached_secret_raw_edit_cancels_old_queue(database_path, monkeypatch):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     with managed_connection(database_path) as connection:
         memory_extraction.initialize_extraction_schema(connection)
         queued = memory_extraction.enqueue_message(
@@ -244,7 +243,7 @@ async def test_worker_discards_provider_result_that_crosses_absolute_ttl(
     monkeypatch,
 ):
     monkeypatch.setenv("MEMORY_COLLECTION_MODE", "interaction")
-    _grant_consent(database_path)
+    _create_profile(database_path)
     monkeypatch.setattr(memory_extraction_provider, "provider_ready", lambda: True)
     monkeypatch.setattr(
         memory_extraction_retention,

--- a/tests/test_memory_extraction_hardening.py
+++ b/tests/test_memory_extraction_hardening.py
@@ -68,7 +68,7 @@ def _add_existing_receipt(connection):
     )
 
 
-def _grant_consent(connection):
+def _create_profile(connection):
     member_profiles.save_member_identity(
         connection,
         guild_id=100,
@@ -77,7 +77,6 @@ def _grant_consent(connection):
         preferred_name="Founder",
         birth_date="1990-01-01",
         today=date(2026, 8, 13),
-        adult_memory_consent=True,
         actor_user_id=2,
     )
 
@@ -208,7 +207,7 @@ def test_worker_authorization_rechecks_mutable_pause_gate(database_path, monkeyp
     )
 
     with managed_connection(database_path) as connection:
-        _grant_consent(connection)
+        _create_profile(connection)
         queued = _enqueue(connection)
         assert cog._job_authorized(connection, queued) is True
         memory_ledger.set_collection_enabled(

--- a/tests/test_memory_extraction_phase4_regressions.py
+++ b/tests/test_memory_extraction_phase4_regressions.py
@@ -287,7 +287,7 @@ def test_v10_processing_claim_is_invalidated_and_old_style_reclaim_is_blocked(tm
             )
 
 
-def test_legacy_consent_version_does_not_revoke_profile_or_safe_edit(
+def test_completed_profile_allows_safe_raw_edit_requeue(
     database_path,
     monkeypatch,
 ):
@@ -303,14 +303,6 @@ def test_legacy_consent_version_does_not_revoke_profile_or_safe_edit(
         )
         memory = _add_receipt_memory(connection)
         queued = _enqueue(connection, content="I prefer tea")
-        connection.execute(
-            """
-            UPDATE coven_member_identity_profiles
-            SET memory_consent_version = ?
-            WHERE guild_id = 100 AND user_id = 2
-            """,
-            (member_profiles.LEGACY_MEMORY_CONSENT_VERSION,),
-        )
 
     payload = SimpleNamespace(
         guild_id=100,
@@ -329,14 +321,11 @@ def test_legacy_consent_version_does_not_revoke_profile_or_safe_edit(
     with managed_connection(database_path) as connection:
         current = memory_extraction.get_job(connection, queued.id)
         receipt = memory_ledger.list_receipts(connection, memory.id)[0]
-        profile = member_profiles.get_member_identity(
+        assert member_profiles.profile_is_memory_eligible(
             connection,
             guild_id=100,
             user_id=2,
-            required=True,
-        )
-    assert profile is not None
-    assert profile.has_current_memory_consent is False
+        ) is True
     assert current is not None
     assert current.status == "pending"
     assert current.content == "Actually I prefer coffee"


### PR DESCRIPTION
## Purpose

Complete the permanent post-Phase-4 cleanup on top of PR #41: physically remove the obsolete adult-memory-consent schema/API surface, make identity/profile eligibility explicit, and stop duplicate confirmations from silently changing privacy metadata.

This is intentionally a **stacked draft PR** on `phase-3-remove-memory-consent-gate`. It must not merge independently while PR #39 and PR #41 remain unmerged.

## Implemented

- private member identity schema advances to v12;
- `adult_memory_consent_at` and `memory_consent_version` are physically removed from the identity table;
- v7/v8 identity rows migrate transactionally while preserving guild/user IDs, preferred name, full canonical birth date, and original timestamps;
- a forced-copy migration regression proves rollback restores the legacy table/data on failure;
- obsolete consent constants, save arguments, consent property, and `profile_has_current_consent(...)` alias are removed;
- automatic extraction calls `profile_is_memory_eligible(...)` directly and reports `profile_missing` rather than `consent_missing`;
- Memory Admin reports identity as complete/none and shows preferred name/full DOB/calculated age without consent state;
- duplicate admin confirmations add evidence only and never implicitly mutate privacy/reveal/importance;
- explicit admin record edits may tighten or loosen privacy/reveal metadata when the requested pair is valid;
- persona guidance permits factual identity-trait mention while retaining the boundary against identity-based dehumanizing/targeted abuse;
- README and memory/identity/admin docs are reconciled with schema v12, permissive social-content doctrine, implemented interaction extraction, and explicit-only metadata changes;
- existing under-18 behavior remains unchanged and PRODUCT DECISION PENDING.

## Safety boundaries retained

- Phase-4 durable queue, claim tokens, stale-worker rejection, absolute TTL/final TTL gate, raw-edit ordering, source deletion, restart recovery, and transaction-time authorization remain intact;
- dangerous-secret/private-ID/payment/address guards remain intact;
- ambient whole-server listening remains dormant;
- SQLite/Python remain authoritative;
- no merge authorization is implied by this PR.

## Validation

Current exact head: `48b9e0df8e082b3c2112675743ca2195ebf9de93`

- CI run `32593053131` / run #364 — **success**
- dependency installation — passed
- `ruff check .` — passed
- `pytest` — **236 passed**
- identity v7/v8 -> v12 preservation/rollback regressions — passed
- explicit duplicate-metadata + explicit tighten/loosen regressions — passed
- full Phase-4 extraction queue/lease/claim-token/TTL/edit-ordering/provider/retention suite — passed
- no live OpenAI key or provider request used

## Deliberately not changed here

- the existing under-18 gate — `PRODUCT DECISION PENDING`;
- Phase 5 retrieval/context intelligence;
- permanent/evolving personality profiling — separate external-policy gate;
- broad ambient whole-server listening — later approved tranche.
