### PR TITLE
Phase 5: add authorization-first memory context intelligence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,9 +226,7 @@ Important:
 
 > **Internal profile creation is part of the intended Wilhelmina system. Do not invent a separate “may Wilhelmina build a profile about you?” permission ceremony.**
 
-The previously implemented `adult_memory_consent` / exact `memory_consent_version` authorization architecture was an agent-created product assumption and must not be treated as permanent product doctrine.
-
-It is technical debt pending deliberate removal/migration.
+The previously implemented `adult_memory_consent` / exact `memory_consent_version` authorization architecture was an agent-created product assumption. It has been removed from the current stacked implementation and must not be treated as permanent product doctrine or revived from historical branches/discussion.
 
 Do not reintroduce equivalent permission gates under a different name without explicit product approval.
 
@@ -806,8 +804,8 @@ The current broad build sequence is:
 1. Foundation reconciliation — completed.
 2. Memory architecture — completed.
 3. Memory administration — completed.
-4. Automatic memory extraction — current work.
-5. Context intelligence / retrieval.
+4. Automatic memory extraction — **BUILT + TESTED + IN REVIEW** in the current stacked PR sequence; not merged.
+5. Context intelligence / retrieval — current work.
 6. Wilhelmina's memory-aware chat brain.
 7. Hardening, deployment, broader listening pathway, and final operational readiness.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cogs.fortune            /fortune
 cogs.broadcasts         /broadcast-admin ...
 ```
 
+Phase-5 context intelligence is currently a service-layer capability (`services.memory_context`), not a Discord cog or command. The later Phase-6 chat cog will consume it.
+
 Each optional feature has its own flag:
 
 ```env
@@ -245,6 +247,20 @@ Phase 4 uses schema-v11 queue ownership with per-claim tokens, absolute raw-text
 For upgrades from the earlier v10 extraction draft, stop/drain old workers before enabling v11. v11 invalidates leftover tokenless processing rows and installs database enforcement that prevents old-style tokenless claims from entering `processing`.
 
 See `docs/memory_extraction.md` for the full eligibility, privacy, queue, rollout, and rollback contract.
+
+## Phase 5 memory context intelligence
+
+`services.memory_context` assembles deterministic memory context for the later Phase-6 chat brain. It is not a new Discord command and has no separate environment flag because nothing invokes it from live chat yet.
+
+The current speaker receives their complete **permitted** active profile: `cross_member` and their own `owner_only` memories, but never `admin_only`. Relevant memories about other members are retrieved only from `cross_member` rows through local FTS and explicit member/entity links. Authorization happens before ranking, so importance, relevance, recency, or contradiction cannot widen a memory's reveal scope.
+
+Phase 5 also expands revealable contradiction partners, includes bounded receipt evidence, preserves `Fact`/`Inference`/`Impression`/unverified `Gossip`, and re-runs the deterministic hard-secret guard at retrieval time so a malformed or legacy credential-containing row cannot be resurrected into a future prompt.
+
+The service uses the speaker's trusted identity context, including current Discord display name, preferred name, full canonical birth date, and locally calculated age. The existing under-18 profile-completion behavior remains **PRODUCT DECISION PENDING** and Phase 5 does not expand it.
+
+This phase does **not** build the separately policy-gated permanent/evolving personality-analysis dossier, does not add ambient whole-server listening, does not create a new consent/version gate, does not call OpenAI, and does not persist a new context table.
+
+See `docs/memory_context.md` for the authorization matrix, ranking, contradiction, evidence, secret-hardening, rollback, and validation contract.
 
 ## Scheduled Daily Broadcasts
 

--- a/docs/memory_context.md
+++ b/docs/memory_context.md
@@ -1,0 +1,225 @@
+# Phase 5 — Memory context intelligence
+
+## Purpose
+
+Phase 5 turns the existing Memory Ledger into deterministic conversational context for the later Phase-6 chat brain.
+
+It does **not** create a new Discord command, does not listen to new sources, does not call OpenAI, and does not persist a new personality/relationship dossier. It decides which already-stored, already-authorized memory rows are appropriate to place into a future chat prompt.
+
+The core rule is:
+
+> **Authorization happens before relevance ranking. A memory cannot become revealable merely because it is relevant, recent, important, or contradictory.**
+
+SQLite remains canonical. The context assembler is local Python code.
+
+## Context bundle
+
+`services.memory_context.assemble_memory_context(...)` produces four things:
+
+1. trusted identity context for the current interlocutor;
+2. the current interlocutor's complete permitted active Memory Ledger profile;
+3. a bounded set of relevant cross-member memories selected from FTS/member-entity retrieval;
+4. bounded evidence receipts for the included memories.
+
+The renderer preserves the existing epistemic distinction:
+
+- `Fact` — factual memory;
+- `Inference` — qualified interpretation, not established fact;
+- `Impression` — qualified Wilhelmina/member impression, not established fact;
+- `Gossip` — attributed/unverified social claim.
+
+Phase 5 does not collapse these labels into one truth bucket.
+
+## Authorization matrix
+
+| Memory owner | `cross_member` | `owner_only` | `admin_only` |
+|---|---:|---:|---:|
+| Current speaker | included in full profile | included in full profile | never included |
+| Another member | eligible for contextual retrieval | never included | never included |
+
+The current speaker therefore receives their full *permitted* active profile rather than a token-saving subset. Cross-member retrieval remains selective so Wilhelmina does not indiscriminately dump every other member's memory into every conversation.
+
+`restricted + cross_member` remains invalid at the Memory Ledger layer. Phase 5 also treats that combination as non-revealable if a malformed legacy/manually-edited row somehow exists despite normal service validation. `Admin note` remains forced to `restricted/admin_only` and cannot enter ordinary chat context.
+
+## Retrieval-time dangerous-secret guard
+
+Phase 5 revalidates memory summaries and receipt excerpts against the existing deterministic dangerous-secret guard before placing them in conversational context.
+
+This is deliberate defense in depth for old or manually modified databases. A legacy row containing a password, authentication token, payment credential, exact private identity-document number, doxxing-grade address, or comparable hard secret is not allowed to become prompt context merely because it predates the current ingestion guards.
+
+A memory whose summary fails the guard is excluded from context. If the summary is safe but an old receipt excerpt fails the guard, the memory may still be included while that unsafe receipt excerpt is omitted.
+
+This does **not** reintroduce subject-matter censorship. Medical, mental-health, adult relationship/sexual, political, religious, identity-related, substance-use, embarrassing, gossip, and other socially sensitive material remains permitted when it does not match an actual hard-secret boundary.
+
+## Retrieval inputs
+
+The assembler accepts:
+
+- the current guild ID;
+- the current interlocutor/member ID;
+- the current conversational query text;
+- the server date used to calculate age from the canonical full birthday;
+- optional member IDs that trusted Discord-facing code has already resolved as explicitly referenced members.
+
+The member-reference input is not a model authorization channel. Phase 6 may later pass Discord-resolved mentions/references into this interface; a model must not be allowed to invent an arbitrary member ID and thereby widen access.
+
+## Full speaker profile
+
+The full active speaker profile is loaded first with deterministic reveal checks.
+
+This includes permitted social memory regardless of whether its subject matter is medical, mental-health related, romantic, sexual between adults, political, religious, identity-related, embarrassing, substance-related, or otherwise socially sensitive.
+
+It does not include `admin_only` rows, invalid `restricted/cross_member` rows, or a legacy memory whose summary trips the hard-secret guard.
+
+Because the full profile is a first-class product requirement, FTS is not used as an excuse to omit the speaker's other permitted memories.
+
+## Cross-member FTS retrieval
+
+FTS searches `memory_search` only through `cross_member` reveal scope for other members.
+
+Rows with `owner_only` or `admin_only` scope never enter the candidate set. This means a hidden importance-100 row cannot beat an allowed importance-1 row: the hidden row is removed before scoring exists.
+
+Speaker-owned FTS hits are not duplicated into the contextual section because the complete permitted speaker profile is already present.
+
+Emoji-only or otherwise non-searchable conversational text does not fail the context request; the assembler simply skips FTS and still returns the speaker profile.
+
+`search_memories(...)` already returns SQLite FTS5/BM25 results in best-first order. Phase 5 converts that returned ordering into a descending deterministic FTS priority rather than attempting to reinterpret the raw BM25 number, which can be negative and extremely small.
+
+## Member/entity retrieval
+
+For explicitly referenced members, Phase 5 checks two existing local entity indexes using `cross_member` scope only:
+
+- `subject:<member id>` — memories whose subject is the referenced member;
+- `member:<member id>` — memories about another subject that explicitly link the referenced member.
+
+This allows relevant relationship/social context to appear without making name/entity resolution a model-controlled authorization decision.
+
+## Deterministic ranking
+
+Only authorized cross-member candidates are ranked.
+
+The current implementation gives deterministic priority to:
+
+1. memories whose subject is an explicitly referenced member;
+2. memories carrying an explicit `member` entity link to a referenced member;
+3. best-first FTS matches in the order returned by the Ledger search service;
+4. the memory's existing `importance` signal and deterministic recency/ID tie-breaks.
+
+These weights are retrieval mechanics, not privacy mechanics. No score can widen reveal scope.
+
+## Contradiction expansion
+
+After the base contextual set is chosen, linked contradiction partners may be added.
+
+Every contradiction partner is independently checked again through the same Phase-5 reveal/secret boundary for the current interlocutor.
+
+Therefore:
+
+- revealable contradictory gossip may travel together so Wilhelmina can see the conflict;
+- another member's `owner_only` contradiction partner remains hidden;
+- `admin_only` contradiction partners remain hidden;
+- invalid `restricted/cross_member` partners remain hidden;
+- legacy hard-secret partners remain hidden;
+- wrong-guild partners are rejected;
+- the prompt records which included memory IDs contradict each other.
+
+Contradiction expansion is bounded per selected memory so a pathological graph cannot grow prompt context without limit.
+
+## Evidence budget
+
+Memory summaries remain available even when receipt evidence reaches its budget.
+
+Evidence is added separately with generous deterministic bounds:
+
+- default total receipt-excerpt budget: 16,000 characters;
+- default maximum receipts per memory: 2;
+- default maximum excerpt contribution per receipt: 1,200 characters.
+
+Contextually selected memories receive evidence priority, followed by high-importance speaker-profile memories.
+
+For an edited source receipt, the latest authorized `edited_excerpt` is used instead of the original wording. If Discord later deleted the source message, the previously retained receipt remains available as evidence and is marked as deleted-after-capture; Phase 5 does not fabricate current source availability.
+
+Unsafe legacy receipt excerpts are omitted before budgeting. The evidence budget exists to prevent unbounded raw-history growth, not to optimize away useful intelligence for token cost.
+
+## Identity context
+
+A completed private member identity profile is required before assembly.
+
+The trusted identity section contains the already-approved local context:
+
+- current Discord display name;
+- preferred name;
+- full canonical birth date;
+- age calculated locally for the supplied server date.
+
+There is no adult-memory-consent/version permission gate.
+
+The existing under-18 profile-completion behavior remains **PRODUCT DECISION PENDING** and is not changed or expanded in Phase 5.
+
+## Personality-analysis boundary
+
+Phase 5 contextual retrieval is intentionally separate from the proposed permanent/evolving personality-analysis layer.
+
+This PR may retrieve existing `Inference` and `Impression` records while preserving their qualified epistemic labels, but it does **not**:
+
+- create psychological scores;
+- infer personality traits from conversation as a new persistent feature;
+- build relationship dossiers;
+- persist a new analyzed personality profile;
+- run a model pass that converts Discord activity into permanent behavioral profiling.
+
+The broader permanent/evolving personality-analysis feature remains behind the repository's separately recorded external-policy/release gate. Phase 5 does not silently narrow that long-term product vision, and it does not silently ignore the gate.
+
+## What a future Discord member experiences
+
+Nothing new is user-facing yet. Phase 5 is infrastructure for Phase 6.
+
+When Phase 6 is built, this layer is what allows Wilhelmina to:
+
+- remember the current speaker's established preferences/history without forgetting unrelated profile context;
+- pull in relevant cross-member callbacks when the current topic or referenced person makes them useful;
+- know when two gossip claims conflict;
+- preserve whether something was fact, inference, impression, or gossip;
+- avoid exposing another person's owner-only memory or any admin-only record;
+- avoid resurfacing a legacy hard secret that should never enter conversation context.
+
+## What the founder/admin experiences
+
+No new admin command is added. Existing `/memory-admin` controls remain the authoritative inspection/correction/deletion surface.
+
+Explicit privacy/reveal edits continue to take effect immediately because context assembly reads the current Memory Ledger state every time.
+
+## Rollback
+
+Phase 5 adds no database migration and no new persisted context table.
+
+Rolling it back means deploying the previous application revision or simply not wiring the service into the future Phase-6 chat cog. Existing identity, Memory Ledger, extraction queue, receipts, entities, contradictions, FTS, and admin controls remain intact.
+
+## Validation contract
+
+Automated tests must cover at minimum:
+
+- complete permitted speaker profile loading;
+- `admin_only` exclusion;
+- other-member `owner_only` exclusion;
+- malformed `restricted/cross_member` fail-closed behavior;
+- retrieval-time legacy hard-secret exclusion;
+- authorization before importance/relevance ranking;
+- referenced subject/member entity retrieval;
+- FTS best-first ordering preservation;
+- deterministic ranking behavior;
+- revealable contradiction expansion;
+- hidden contradiction filtering;
+- wrong-guild isolation;
+- bounded evidence and latest edited evidence;
+- unsafe legacy receipt omission;
+- epistemic/gossip label preservation;
+- missing identity profile fail-closed behavior;
+- non-searchable query fallback.
+
+Repository quality gates remain:
+
+```bash
+ruff check .
+pytest
+```

--- a/docs/memory_ledger.md
+++ b/docs/memory_ledger.md
@@ -37,6 +37,8 @@ The persistent ledger contains:
 
 `memory_extraction_jobs` is the durable transient-work queue for interaction-scoped automatic extraction. Its v11 ownership model includes claim tokens, leases, bounded retry, source versions, absolute raw-text TTL enforcement, and migration protection against legacy tokenless workers.
 
+Phase 5 adds no new persistent table. `services.memory_context` reads the current identity/Ledger state and returns an in-memory authorization-filtered context bundle for the later chat brain.
+
 ## Memory record
 
 Every memory is guild-scoped and attached to an existing Coven member/profile shell. Gossip about a non-member does not silently create an outsider profile.
@@ -99,6 +101,8 @@ Facts, inferences, impressions, and gossip remain distinguishable. Gossip is att
 
 These fields are deterministic local authorization metadata. OpenAI never overrides them.
 
+Phase 5 additionally fails closed if a malformed legacy/manually-edited `restricted/cross_member` row exists despite normal service validation.
+
 ### Importance
 
 `importance` is an integer from 0 through 100, default 50. It is a retrieval/ranking signal, not authorization, and never overrides reveal scope.
@@ -150,6 +154,8 @@ Unrelated memories in the same category coexist. Superseded ordinary records and
 
 Conflicting gossip on the same topic may coexist and is linked through `memory_contradictions`. Editing a gossip record's topic/category clears obsolete links before valid links are regenerated. Deleting either memory cascades the relationship.
 
+Phase 5 may expand a selected gossip memory with bounded contradiction partners, but every partner is independently rechecked for the current interlocutor before it can enter context.
+
 ## Entity index
 
 `memory_entities` provides deterministic local relationship/index data for retrieval.
@@ -171,13 +177,21 @@ Search supports deterministic filters for guild, reveal scope, optional subject 
 
 OpenAI is never asked which private rows it is allowed to retrieve.
 
-## Full-profile and future retrieval contract
+Phase 5 consumes the existing best-first FTS ordering rather than reinterpreting raw BM25 sign/magnitude, then combines that deterministic priority with explicit member-reference and importance signals after authorization.
 
-The current interlocutor's full permitted active profile remains core future chat context. FTS/entity retrieval supplements that profile with relevant cross-member memories, named/referenced members, contradiction partners, historical callbacks, and evidence budgeting.
+## Full-profile and Phase 5 retrieval contract
 
-Authorization is applied before any selected context is sent to the model.
+The current interlocutor's full permitted active profile is core chat context. Phase 5 loads that profile first: the speaker's own `cross_member` and `owner_only` rows are eligible, while `admin_only`, invalid `restricted/cross_member`, and legacy hard-secret rows are excluded.
 
-Phase 5 will implement deterministic context intelligence on top of these interfaces. A distinct permanent/evolving psychological/personality-profiling layer remains externally policy-gated and is not smuggled into ordinary retrieval architecture.
+FTS/entity retrieval supplements the speaker profile with relevant **other-member `cross_member`** memories, named/referenced members, contradiction partners, historical callbacks, and bounded evidence receipts.
+
+Authorization is applied before relevance ranking. A high-importance or highly relevant hidden row therefore cannot outrank its way into context.
+
+Explicit member-reference IDs are a trusted service input intended for later Discord-resolved mentions/references. They are not a model-controlled authorization mechanism.
+
+A distinct permanent/evolving psychological/personality-profiling layer remains externally policy-gated and is not smuggled into ordinary retrieval architecture. Phase 5 may retrieve existing `Inference` and `Impression` memories while preserving those qualified epistemic labels; it does not create a new analyzed personality dossier.
+
+See `docs/memory_context.md` for the complete Phase-5 contract.
 
 ## Dangerous-secret boundary
 
@@ -192,7 +206,11 @@ The deterministic local guard instead rejects concrete dangerous-secret classes,
 - doxxing-grade exact private addresses;
 - equivalent high-risk secrets.
 
-The guard runs before provider use and again on model-controlled persisted strings such as summary/topic/term entities. Admin-only information and unauthorized sources remain outside ordinary disclosure regardless of content category.
+The guard runs before provider use and again on model-controlled persisted strings such as summary/topic/term entities. Phase 5 also revalidates summaries and receipt excerpts at retrieval time so an unsafe legacy or manually modified row cannot bypass the modern ingestion guards and reappear in a future chat prompt.
+
+If a legacy memory summary fails the guard, that memory is excluded from context. If a summary is safe but a legacy receipt excerpt fails, the memory may remain while that unsafe evidence excerpt is omitted.
+
+Admin-only information and unauthorized sources remain outside ordinary disclosure regardless of content category.
 
 A DM sent directly to Wilhelmina is not rejected merely for being private. Third-party DMs Wilhelmina is not part of remain inaccessible.
 
@@ -269,6 +287,10 @@ Legacy tokenless `processing` rows are invalidated, transient text is erased, cl
 
 The private identity table is transactionally rebuilt without the obsolete consent columns while preserving preferred name, full birth date, guild/user identity, and original timestamps. A failed copy rolls back to the intact legacy table.
 
+### Phase 5 context layer
+
+Phase 5 has no database migration and persists no context cache/profile table. Rollback is application-only: do not wire/use the context service from the later chat brain, or deploy the previous application revision. Existing Ledger/identity/extraction data is unchanged.
+
 Do not “rollback” a migrated production database by merely deploying older code. Stop Wilhelmina and restore a matching database backup with the matching application revision, or deploy a forward fix that understands the current schemas.
 
 ## Integrity and tests
@@ -287,7 +309,18 @@ The regression suite additionally covers:
 - source deletion;
 - explicit-only privacy metadata mutation;
 - member-wide authored-evidence deletion;
-- content-free operational logging/auditing.
+- content-free operational logging/auditing;
+- complete permitted speaker-profile loading;
+- owner/admin reveal-scope isolation;
+- malformed `restricted/cross_member` fail-closed behavior;
+- authorization-before-ranking;
+- referenced-member/entity retrieval;
+- FTS ordering preservation;
+- contradiction expansion/filtering;
+- wrong-guild context isolation;
+- bounded evidence with latest-edit preference;
+- retrieval-time legacy hard-secret exclusion;
+- epistemic/gossip preservation.
 
 Repository quality gates:
 
@@ -296,11 +329,11 @@ ruff check .
 pytest
 ```
 
-## Next implementation stages
+## Current and next implementation stages
 
-### Phase 5 — Memory intelligence/context
+### Phase 5 — Memory intelligence/context — current work
 
-Deterministic authorization-first scoring, FTS/entity retrieval, active-speaker profile loading, cross-member selection, contradiction expansion, and evidence budgeting.
+Authorization-first scoring, full active-speaker profile loading, FTS/entity cross-member selection, contradiction expansion, evidence budgeting, retrieval-time hard-secret defense, and prompt-ready epistemic rendering are implemented in the current stacked Phase-5 branch and remain subject to exact-head CI/review before any merge.
 
 ### Phase 6 — Wilhelmina chat brain
 

--- a/services/memory_context.py
+++ b/services/memory_context.py
@@ -1,0 +1,620 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Iterable, Sequence
+
+from services import memory_extraction, memory_ledger, member_profiles
+from services.member_identity import TrustedIdentityContext
+
+DEFAULT_CONTEXTUAL_LIMIT = 18
+MAX_CONTEXTUAL_LIMIT = 50
+DEFAULT_EVIDENCE_CHAR_BUDGET = 16_000
+MAX_EVIDENCE_CHAR_BUDGET = 50_000
+DEFAULT_EVIDENCE_PER_MEMORY = 2
+MAX_EVIDENCE_PER_MEMORY = 5
+MAX_EVIDENCE_EXCERPT_CHARS = 1_200
+MAX_REFERENCED_MEMBERS = 16
+MAX_CONTRADICTION_PARTNERS_PER_MEMORY = 2
+
+REFERENCED_SUBJECT_WEIGHT = 500.0
+REFERENCED_MEMBER_WEIGHT = 425.0
+FTS_TOP_WEIGHT = 300.0
+PRIVATE_KEY_PATTERNS = (
+    re.compile(
+        r"-----BEGIN(?: [A-Z0-9-]+)* PRIVATE KEY(?: BLOCK)?-----",
+        re.IGNORECASE,
+    ),
+    re.compile(r"^PuTTY-User-Key-File-\d+:\s*\S+", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"---- BEGIN SSH2(?: ENCRYPTED)? PRIVATE KEY ----", re.IGNORECASE),
+)
+
+
+class MemoryContextError(ValueError):
+    """Raised when a trusted context request is structurally invalid."""
+
+
+@dataclass(frozen=True)
+class ContextEvidence:
+    receipt_id: int
+    memory_id: int
+    source_kind: str
+    source_context: str
+    author_user_id: int
+    excerpt: str
+    source_created_at: str
+    source_edited_at: str | None
+    source_deleted_at: str | None
+
+
+@dataclass(frozen=True)
+class ContextMemory:
+    memory: memory_ledger.MemoryRecord
+    relevance_score: float
+    reasons: tuple[str, ...]
+    evidence: tuple[ContextEvidence, ...]
+    contradicts_memory_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class MemoryContextBundle:
+    guild_id: int
+    interlocutor_user_id: int
+    identity: TrustedIdentityContext
+    speaker_profile: tuple[ContextMemory, ...]
+    contextual_memories: tuple[ContextMemory, ...]
+
+
+@dataclass
+class _Candidate:
+    memory: memory_ledger.MemoryRecord
+    score: float
+    reasons: set[str] = field(default_factory=set)
+
+
+def _bounded_int(value: int, *, minimum: int, maximum: int, field_name: str) -> int:
+    resolved = int(value)
+    if resolved < minimum:
+        raise MemoryContextError(f"{field_name} must be at least {minimum}")
+    return min(resolved, maximum)
+
+
+def _normalize_referenced_member_ids(
+    member_ids: Sequence[int],
+    *,
+    interlocutor_user_id: int,
+) -> tuple[int, ...]:
+    resolved: list[int] = []
+    seen: set[int] = set()
+    for raw_value in member_ids:
+        value = int(raw_value)
+        if value <= 0:
+            raise MemoryContextError("referenced member IDs must be positive integers")
+        if value == int(interlocutor_user_id) or value in seen:
+            continue
+        seen.add(value)
+        resolved.append(value)
+        if len(resolved) >= MAX_REFERENCED_MEMBERS:
+            break
+    return tuple(resolved)
+
+
+def _content_is_safe(value: str) -> bool:
+    """Keep legacy dangerous-secret content out of future chat context."""
+
+    if any(pattern.search(value) for pattern in PRIVATE_KEY_PATTERNS):
+        return False
+    try:
+        memory_extraction.guard_extractable_text(value)
+    except memory_ledger.MemoryLedgerError:
+        return False
+    return True
+
+
+def _memory_is_context_revealable(
+    memory: memory_ledger.MemoryRecord,
+    *,
+    interlocutor_user_id: int,
+) -> bool:
+    # The service layer defines restricted + cross_member as invalid even though the
+    # SQLite columns have independent CHECK constraints. Fail closed if a legacy,
+    # manually-edited, or corrupted row ever reaches that impossible combination.
+    if memory.privacy_class == "restricted" and memory.reveal_scope == "cross_member":
+        return False
+    # Admin notes are canonical restricted/admin-only records. Recheck the category
+    # invariant here so manually repaired/imported rows cannot become chat-revealable.
+    if memory.category == "Admin note" and (
+        memory.privacy_class != "restricted" or memory.reveal_scope != "admin_only"
+    ):
+        return False
+    if not _content_is_safe(memory.summary) or not _content_is_safe(memory.topic_key):
+        return False
+    return memory_ledger.memory_is_revealable(
+        memory,
+        interlocutor_user_id=interlocutor_user_id,
+        allow_admin=False,
+    )
+
+
+def _add_candidate(
+    candidates: dict[int, _Candidate],
+    memory: memory_ledger.MemoryRecord,
+    *,
+    reason: str,
+    weight: float,
+) -> None:
+    candidate = candidates.get(memory.id)
+    if candidate is None:
+        candidate = _Candidate(memory=memory, score=float(memory.importance))
+        candidates[memory.id] = candidate
+    if reason in candidate.reasons:
+        return
+    candidate.reasons.add(reason)
+    candidate.score += float(weight)
+
+
+def _candidate_sort_key(candidate: _Candidate) -> tuple[float, int, str, int]:
+    return (
+        candidate.score,
+        candidate.memory.importance,
+        candidate.memory.updated_at,
+        candidate.memory.id,
+    )
+
+
+def _safe_search_query(query: str) -> str:
+    return " ".join(str(query or "").split())[:500]
+
+
+def _authorized_cross_member_candidates(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    interlocutor_user_id: int,
+    query: str,
+    referenced_member_ids: Sequence[int],
+    contextual_limit: int,
+) -> dict[int, _Candidate]:
+    """Collect only already-authorized cross-member rows before ranking them."""
+
+    candidates: dict[int, _Candidate] = {}
+    fetch_limit = min(100, max(20, contextual_limit * 4))
+    search_query = _safe_search_query(query)
+
+    if search_query:
+        try:
+            hits = memory_ledger.search_memories(
+                connection,
+                guild_id=guild_id,
+                query=search_query,
+                reveal_scopes=("cross_member",),
+                limit=fetch_limit,
+            )
+        except memory_ledger.MemoryLedgerError:
+            hits = []
+        # search_memories already orders SQLite bm25 smaller-is-better. Convert that
+        # ordering to a deterministic descending weight rather than reinterpreting the
+        # provider-specific rank number (which may be negative and extremely small).
+        for index, hit in enumerate(hits):
+            memory = hit.memory
+            if memory.subject_user_id == int(interlocutor_user_id):
+                continue
+            if not _memory_is_context_revealable(
+                memory,
+                interlocutor_user_id=interlocutor_user_id,
+            ):
+                continue
+            _add_candidate(
+                candidates,
+                memory,
+                reason="fts",
+                weight=max(1.0, FTS_TOP_WEIGHT - float(index)),
+            )
+
+    for member_id in referenced_member_ids:
+        subject_memories = memory_ledger.find_memories_by_entity(
+            connection,
+            guild_id=guild_id,
+            entity_type="subject",
+            entity_key=str(member_id),
+            reveal_scopes=("cross_member",),
+            limit=fetch_limit,
+        )
+        for memory in subject_memories:
+            if memory.guild_id != int(guild_id):
+                continue
+            if memory.subject_user_id == int(interlocutor_user_id):
+                continue
+            if not _memory_is_context_revealable(
+                memory,
+                interlocutor_user_id=interlocutor_user_id,
+            ):
+                continue
+            _add_candidate(
+                candidates,
+                memory,
+                reason=f"referenced_subject:{member_id}",
+                weight=REFERENCED_SUBJECT_WEIGHT,
+            )
+
+        linked_memories = memory_ledger.find_memories_by_entity(
+            connection,
+            guild_id=guild_id,
+            entity_type="member",
+            entity_key=str(member_id),
+            reveal_scopes=("cross_member",),
+            limit=fetch_limit,
+        )
+        for memory in linked_memories:
+            if memory.guild_id != int(guild_id):
+                continue
+            if memory.subject_user_id == int(interlocutor_user_id):
+                continue
+            if not _memory_is_context_revealable(
+                memory,
+                interlocutor_user_id=interlocutor_user_id,
+            ):
+                continue
+            _add_candidate(
+                candidates,
+                memory,
+                reason=f"referenced_member:{member_id}",
+                weight=REFERENCED_MEMBER_WEIGHT,
+            )
+
+    return candidates
+
+
+def _authorized_contradiction_partners(
+    connection: sqlite3.Connection,
+    *,
+    memory: memory_ledger.MemoryRecord,
+    interlocutor_user_id: int,
+) -> list[memory_ledger.MemoryRecord]:
+    partners: list[memory_ledger.MemoryRecord] = []
+    for link in memory_ledger.list_contradictions(connection, memory_id=memory.id):
+        partner_id = (
+            link.right_memory_id if link.left_memory_id == memory.id else link.left_memory_id
+        )
+        partner = memory_ledger.get_memory(connection, partner_id, required=False)
+        if partner is None or not partner.active or partner.guild_id != memory.guild_id:
+            continue
+        if not _memory_is_context_revealable(
+            partner,
+            interlocutor_user_id=interlocutor_user_id,
+        ):
+            continue
+        partners.append(partner)
+    partners.sort(
+        key=lambda item: (item.importance, item.updated_at, item.id),
+        reverse=True,
+    )
+    return partners[:MAX_CONTRADICTION_PARTNERS_PER_MEMORY]
+
+
+def _expand_contradictions(
+    connection: sqlite3.Connection,
+    *,
+    candidates: dict[int, _Candidate],
+    base_selected: Sequence[_Candidate],
+    speaker_profile_ids: set[int],
+    interlocutor_user_id: int,
+) -> set[int]:
+    included_ids = {candidate.memory.id for candidate in base_selected}
+    for candidate in base_selected:
+        for partner in _authorized_contradiction_partners(
+            connection,
+            memory=candidate.memory,
+            interlocutor_user_id=interlocutor_user_id,
+        ):
+            if partner.id in speaker_profile_ids:
+                continue
+            weight = max(0.0, candidate.score - float(partner.importance) - 0.01)
+            _add_candidate(
+                candidates,
+                partner,
+                reason=f"contradiction:{candidate.memory.id}",
+                weight=weight,
+            )
+            included_ids.add(partner.id)
+    return included_ids
+
+
+def _effective_excerpt(receipt: memory_ledger.MemoryReceipt) -> str:
+    value = (
+        receipt.edited_excerpt
+        if receipt.edited_excerpt is not None
+        else receipt.original_excerpt
+    )
+    cleaned = " ".join(str(value).split())
+    return cleaned if cleaned and _content_is_safe(cleaned) else ""
+
+
+def _clip_excerpt(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    if limit <= 1:
+        return value[:limit]
+    return value[: limit - 1].rstrip() + "…"
+
+
+def _allocate_evidence(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    memory_ids_in_priority_order: Iterable[int],
+    char_budget: int,
+    receipts_per_memory: int,
+) -> dict[int, tuple[ContextEvidence, ...]]:
+    remaining = char_budget
+    evidence: dict[int, tuple[ContextEvidence, ...]] = {}
+    if remaining <= 0 or receipts_per_memory <= 0:
+        return evidence
+
+    for memory_id in memory_ids_in_priority_order:
+        if remaining <= 0:
+            break
+        receipts = list(reversed(memory_ledger.list_receipts(connection, memory_id)))
+        selected: list[ContextEvidence] = []
+        for receipt in receipts:
+            if remaining <= 0 or len(selected) >= receipts_per_memory:
+                break
+            if receipt.guild_id != int(guild_id):
+                continue
+            excerpt = _effective_excerpt(receipt)
+            if not excerpt:
+                continue
+            clipped = _clip_excerpt(
+                excerpt,
+                min(MAX_EVIDENCE_EXCERPT_CHARS, remaining),
+            )
+            if not clipped:
+                continue
+            selected.append(
+                ContextEvidence(
+                    receipt_id=receipt.id,
+                    memory_id=receipt.memory_id,
+                    source_kind=receipt.source_kind,
+                    source_context=receipt.source_context,
+                    author_user_id=receipt.author_user_id,
+                    excerpt=clipped,
+                    source_created_at=receipt.source_created_at,
+                    source_edited_at=receipt.source_edited_at,
+                    source_deleted_at=receipt.source_deleted_at,
+                )
+            )
+            remaining -= len(clipped)
+        if selected:
+            evidence[memory_id] = tuple(selected)
+    return evidence
+
+
+def _contradiction_ids_for_included_memories(
+    connection: sqlite3.Connection,
+    *,
+    memory: memory_ledger.MemoryRecord,
+    included_memory_ids: set[int],
+) -> tuple[int, ...]:
+    ids: list[int] = []
+    for link in memory_ledger.list_contradictions(connection, memory_id=memory.id):
+        partner_id = (
+            link.right_memory_id if link.left_memory_id == memory.id else link.left_memory_id
+        )
+        if partner_id in included_memory_ids:
+            ids.append(partner_id)
+    return tuple(sorted(set(ids)))
+
+
+def assemble_memory_context(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    interlocutor_user_id: int,
+    query: str,
+    on_date: date,
+    referenced_member_ids: Sequence[int] = (),
+    contextual_limit: int = DEFAULT_CONTEXTUAL_LIMIT,
+    evidence_char_budget: int = DEFAULT_EVIDENCE_CHAR_BUDGET,
+    evidence_per_memory: int = DEFAULT_EVIDENCE_PER_MEMORY,
+) -> MemoryContextBundle:
+    """Assemble deterministic, authorization-first memory context for future chat.
+
+    The current speaker receives their complete active profile except `admin_only` rows.
+    Other members contribute only valid `cross_member` rows. FTS/entity retrieval and
+    contradiction expansion happen only after those reveal boundaries are fixed locally.
+    This service performs no model call and persists no personality/profile analysis.
+    """
+
+    resolved_limit = _bounded_int(
+        contextual_limit,
+        minimum=1,
+        maximum=MAX_CONTEXTUAL_LIMIT,
+        field_name="contextual_limit",
+    )
+    resolved_evidence_budget = _bounded_int(
+        evidence_char_budget,
+        minimum=0,
+        maximum=MAX_EVIDENCE_CHAR_BUDGET,
+        field_name="evidence_char_budget",
+    )
+    resolved_evidence_per_memory = _bounded_int(
+        evidence_per_memory,
+        minimum=0,
+        maximum=MAX_EVIDENCE_PER_MEMORY,
+        field_name="evidence_per_memory",
+    )
+    resolved_references = _normalize_referenced_member_ids(
+        referenced_member_ids,
+        interlocutor_user_id=interlocutor_user_id,
+    )
+
+    stored_identity = member_profiles.get_member_identity(
+        connection,
+        guild_id=guild_id,
+        user_id=interlocutor_user_id,
+        required=True,
+    )
+    assert stored_identity is not None
+    identity = stored_identity.trusted_chat_context(on_date=on_date)
+
+    speaker_memories = [
+        memory
+        for memory in memory_ledger.list_revealable_profile(
+            connection,
+            guild_id=guild_id,
+            subject_user_id=interlocutor_user_id,
+            interlocutor_user_id=interlocutor_user_id,
+            allow_admin=False,
+        )
+        if _memory_is_context_revealable(
+            memory,
+            interlocutor_user_id=interlocutor_user_id,
+        )
+    ]
+    speaker_profile_ids = {memory.id for memory in speaker_memories}
+
+    candidates = _authorized_cross_member_candidates(
+        connection,
+        guild_id=guild_id,
+        interlocutor_user_id=interlocutor_user_id,
+        query=query,
+        referenced_member_ids=resolved_references,
+        contextual_limit=resolved_limit,
+    )
+    base_selected = sorted(
+        candidates.values(),
+        key=_candidate_sort_key,
+        reverse=True,
+    )[:resolved_limit]
+    contextual_ids = _expand_contradictions(
+        connection,
+        candidates=candidates,
+        base_selected=base_selected,
+        speaker_profile_ids=speaker_profile_ids,
+        interlocutor_user_id=interlocutor_user_id,
+    )
+    contextual_candidates = sorted(
+        (
+            candidate
+            for memory_id, candidate in candidates.items()
+            if memory_id in contextual_ids
+        ),
+        key=_candidate_sort_key,
+        reverse=True,
+    )
+
+    contextual_priority_ids = [candidate.memory.id for candidate in contextual_candidates]
+    speaker_priority_ids = [
+        memory.id
+        for memory in sorted(
+            speaker_memories,
+            key=lambda item: (item.importance, item.updated_at, item.id),
+            reverse=True,
+        )
+    ]
+    evidence_by_memory = _allocate_evidence(
+        connection,
+        guild_id=guild_id,
+        memory_ids_in_priority_order=(*contextual_priority_ids, *speaker_priority_ids),
+        char_budget=resolved_evidence_budget,
+        receipts_per_memory=resolved_evidence_per_memory,
+    )
+
+    included_ids = speaker_profile_ids | set(contextual_priority_ids)
+    speaker_profile = tuple(
+        ContextMemory(
+            memory=memory,
+            relevance_score=float(memory.importance),
+            reasons=("speaker_profile",),
+            evidence=evidence_by_memory.get(memory.id, ()),
+            contradicts_memory_ids=_contradiction_ids_for_included_memories(
+                connection,
+                memory=memory,
+                included_memory_ids=included_ids,
+            ),
+        )
+        for memory in speaker_memories
+    )
+    contextual_memories = tuple(
+        ContextMemory(
+            memory=candidate.memory,
+            relevance_score=candidate.score,
+            reasons=tuple(sorted(candidate.reasons)),
+            evidence=evidence_by_memory.get(candidate.memory.id, ()),
+            contradicts_memory_ids=_contradiction_ids_for_included_memories(
+                connection,
+                memory=candidate.memory,
+                included_memory_ids=included_ids,
+            ),
+        )
+        for candidate in contextual_candidates
+    )
+
+    return MemoryContextBundle(
+        guild_id=int(guild_id),
+        interlocutor_user_id=int(interlocutor_user_id),
+        identity=identity,
+        speaker_profile=speaker_profile,
+        contextual_memories=contextual_memories,
+    )
+
+
+def _memory_prompt_line(item: ContextMemory) -> str:
+    memory = item.memory
+    qualifier = "Unverified gossip" if memory.is_gossip else memory.epistemic_label
+    contradiction = (
+        f" | contradicts={','.join(str(value) for value in item.contradicts_memory_ids)}"
+        if item.contradicts_memory_ids
+        else ""
+    )
+    return (
+        f"- memory#{memory.id} [{memory.category} | {qualifier} | {memory.reveal_scope}"
+        f"{contradiction}] {memory.summary}"
+    )
+
+
+def render_memory_context_for_prompt(bundle: MemoryContextBundle) -> str:
+    """Render the locally authorized bundle without changing epistemic labels."""
+
+    lines = [
+        "TRUSTED MEMBER IDENTITY",
+        f"- discord_display_name: {bundle.identity.discord_display_name}",
+        f"- preferred_name: {bundle.identity.preferred_name}",
+        f"- birth_date: {bundle.identity.birth_date}",
+        f"- age: {bundle.identity.age}",
+        "",
+        "MEMORY INTERPRETATION RULE",
+        "- Fact is factual memory; Inference and Impression are qualified interpretations; "
+        "Gossip is unverified.",
+        "- Do not treat a qualified interpretation or gossip claim as established fact.",
+        "",
+        "FULL ACTIVE SPEAKER PROFILE",
+    ]
+    if bundle.speaker_profile:
+        lines.extend(_memory_prompt_line(item) for item in bundle.speaker_profile)
+    else:
+        lines.append("- No saved speaker memories.")
+
+    lines.extend(("", "RELEVANT CROSS-MEMBER CONTEXT"))
+    if bundle.contextual_memories:
+        lines.extend(_memory_prompt_line(item) for item in bundle.contextual_memories)
+    else:
+        lines.append("- No additional cross-member context selected.")
+
+    evidence_items = [*bundle.contextual_memories, *bundle.speaker_profile]
+    lines.extend(("", "EVIDENCE RECEIPTS"))
+    emitted = False
+    for item in evidence_items:
+        for receipt in item.evidence:
+            emitted = True
+            deleted = " | source_deleted_after_capture" if receipt.source_deleted_at else ""
+            lines.append(
+                f"- memory#{item.memory.id} receipt#{receipt.receipt_id} "
+                f"[{receipt.source_context} | author={receipt.author_user_id}{deleted}] "
+                f"{receipt.excerpt}"
+            )
+    if not emitted:
+        lines.append("- No receipt excerpts included in this context budget.")
+    return "\n".join(lines)

--- a/tests/test_memory_context.py
+++ b/tests/test_memory_context.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from services import coven_registry, memory_context, memory_ledger, member_profiles
+from services.database import initialize_database, managed_connection
+
+TODAY = date(2026, 8, 23)
+
+
+@pytest.fixture()
+def database_path(tmp_path):
+    path = tmp_path / "wilhelmina.sqlite3"
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        _save_profile(connection, user_id=2, display_name="Founder", preferred_name="Mina")
+        _register_profile(connection, user_id=3, display_name="Alex", preferred_name="Alex")
+        _register_profile(connection, user_id=4, display_name="Jordan", preferred_name="Jordan")
+        memory_ledger.initialize_memory_schema(connection)
+    return path
+
+
+def _save_profile(connection, *, user_id: int, display_name: str, preferred_name: str) -> None:
+    member_profiles.save_member_identity(
+        connection,
+        guild_id=100,
+        user_id=user_id,
+        discord_display_name=display_name,
+        preferred_name=preferred_name,
+        birth_date="1990-10-31",
+        today=TODAY,
+        actor_user_id=2,
+    )
+
+
+def _register_profile(connection, *, user_id: int, display_name: str, preferred_name: str) -> None:
+    coven_registry.register_pending_member(
+        connection,
+        guild_id=100,
+        user_id=user_id,
+        display_name=display_name,
+        actor_user_id=2,
+    )
+    _save_profile(
+        connection,
+        user_id=user_id,
+        display_name=display_name,
+        preferred_name=preferred_name,
+    )
+
+
+def _add(
+    connection,
+    *,
+    subject_user_id: int,
+    summary: str,
+    topic: str,
+    category: str = "Interest",
+    label: str = "Fact",
+    privacy_class: str | None = None,
+    reveal_scope: str | None = None,
+    importance: int = 50,
+    author_user_id: int | None = None,
+    channel_id: int | None = None,
+    message_id: int | None = None,
+    excerpt: str | None = None,
+    source_created_at: str | None = None,
+):
+    jump_url = (
+        f"https://discord.com/channels/100/{channel_id}/{message_id}"
+        if channel_id is not None and message_id is not None
+        else None
+    )
+    return memory_ledger.add_memory(
+        connection,
+        guild_id=100,
+        subject_user_id=subject_user_id,
+        category=category,
+        epistemic_label=label,
+        summary=summary,
+        topic_key=topic,
+        actor_user_id=2,
+        privacy_class=privacy_class,
+        reveal_scope=reveal_scope,
+        importance=importance,
+        author_user_id=author_user_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        jump_url=jump_url,
+        excerpt=excerpt,
+        source_created_at=source_created_at,
+    )
+
+
+def _bundle(connection, *, query: str = "", referenced_member_ids=(), **kwargs):
+    return memory_context.assemble_memory_context(
+        connection,
+        guild_id=100,
+        interlocutor_user_id=2,
+        query=query,
+        on_date=TODAY,
+        referenced_member_ids=referenced_member_ids,
+        **kwargs,
+    )
+
+
+def test_full_speaker_profile_includes_owner_only_but_never_admin_only(database_path):
+    with managed_connection(database_path) as connection:
+        ordinary = _add(
+            connection,
+            subject_user_id=2,
+            summary="Loves black coffee",
+            topic="drink.coffee",
+            category="Preference",
+        )
+        owner_only = _add(
+            connection,
+            subject_user_id=2,
+            summary="Keeps a private birthday list",
+            topic="birthday.private.list",
+            reveal_scope="owner_only",
+        )
+        admin_only = _add(
+            connection,
+            subject_user_id=2,
+            summary="Founder-only operational note",
+            topic="admin.private.note",
+            category="Admin note",
+        )
+
+        bundle = _bundle(connection)
+
+    profile_ids = {item.memory.id for item in bundle.speaker_profile}
+    assert ordinary.memory.id in profile_ids
+    assert owner_only.memory.id in profile_ids
+    assert admin_only.memory.id not in profile_ids
+    assert bundle.contextual_memories == ()
+    assert bundle.identity.preferred_name == "Mina"
+    assert bundle.identity.birth_date == "1990-10-31"
+
+
+def test_high_importance_hidden_memory_cannot_beat_low_importance_allowed_memory(database_path):
+    with managed_connection(database_path) as connection:
+        allowed = _add(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+            topic="astronomy.telescope.lenses",
+            importance=1,
+        )
+        hidden_owner = _add(
+            connection,
+            subject_user_id=3,
+            summary="Keeps a private telescope journal",
+            topic="astronomy.telescope.private",
+            reveal_scope="owner_only",
+            importance=100,
+        )
+        hidden_admin = _add(
+            connection,
+            subject_user_id=3,
+            summary="Admin telescope note",
+            topic="astronomy.telescope.admin",
+            category="Admin note",
+            importance=100,
+        )
+
+        bundle = _bundle(connection, query="telescope", referenced_member_ids=(3,))
+
+    ids = {item.memory.id for item in bundle.contextual_memories}
+    assert allowed.memory.id in ids
+    assert hidden_owner.memory.id not in ids
+    assert hidden_admin.memory.id not in ids
+
+
+def test_referenced_member_entity_retrieves_cross_member_relationship_context(database_path):
+    with managed_connection(database_path) as connection:
+        linked = _add(
+            connection,
+            subject_user_id=4,
+            summary="Jordan promised Alex the vinyl box set",
+            topic="relationship.alex.vinyl.promise",
+            category="Relationship context",
+        )
+        memory_ledger.set_memory_entities(
+            connection,
+            memory_id=linked.memory.id,
+            entities=(("member", "3"),),
+        )
+
+        bundle = _bundle(connection, referenced_member_ids=(3,))
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == linked.memory.id)
+    assert "referenced_member:3" in item.reasons
+
+
+def test_referenced_subject_outranks_unrelated_fts_hit(database_path):
+    with managed_connection(database_path) as connection:
+        referenced = _add(
+            connection,
+            subject_user_id=3,
+            summary="Prefers mint tea",
+            topic="drink.mint.tea",
+            category="Preference",
+            importance=1,
+        )
+        unrelated = _add(
+            connection,
+            subject_user_id=4,
+            summary="Runs a tea tasting club",
+            topic="club.tea.tasting",
+            importance=100,
+        )
+
+        bundle = _bundle(
+            connection,
+            query="tea",
+            referenced_member_ids=(3,),
+            contextual_limit=2,
+        )
+
+    assert bundle.contextual_memories[0].memory.id == referenced.memory.id
+    assert {item.memory.id for item in bundle.contextual_memories} == {
+        referenced.memory.id,
+        unrelated.memory.id,
+    }
+
+
+def test_contradiction_expansion_adds_revealable_partner_and_filters_hidden_partner(database_path):
+    with managed_connection(database_path) as connection:
+        first = _add(
+            connection,
+            subject_user_id=3,
+            summary="Sam says the project was cancelled",
+            topic="project.status.claim",
+            category="Gossip",
+            label="Gossip",
+            importance=90,
+        )
+        second = _add(
+            connection,
+            subject_user_id=3,
+            summary="Lee says the project is only delayed",
+            topic="project.status.claim",
+            category="Gossip",
+            label="Gossip",
+            importance=10,
+        )
+        hidden = _add(
+            connection,
+            subject_user_id=3,
+            summary="Private claim about the project status",
+            topic="project.status.claim",
+            category="Gossip",
+            label="Gossip",
+            reveal_scope="owner_only",
+            importance=100,
+        )
+
+        bundle = _bundle(connection, query="project", contextual_limit=1)
+
+    ids = {item.memory.id for item in bundle.contextual_memories}
+    assert first.memory.id in ids
+    assert second.memory.id in ids
+    assert hidden.memory.id not in ids
+    first_item = next(item for item in bundle.contextual_memories if item.memory.id == first.memory.id)
+    second_item = next(item for item in bundle.contextual_memories if item.memory.id == second.memory.id)
+    assert second.memory.id in first_item.contradicts_memory_ids
+    assert first.memory.id in second_item.contradicts_memory_ids
+
+
+def test_evidence_budget_prefers_latest_effective_excerpt_and_is_hard_bounded(database_path):
+    with managed_connection(database_path) as connection:
+        created = _add(
+            connection,
+            subject_user_id=3,
+            summary="Practises opera every weekend",
+            topic="music.opera.practice",
+            author_user_id=3,
+            channel_id=10,
+            message_id=501,
+            excerpt="First opera receipt with a deliberately long supporting sentence.",
+            source_created_at="2026-08-20T10:00:00+00:00",
+        )
+        _add(
+            connection,
+            subject_user_id=3,
+            summary="Practises opera every weekend",
+            topic="music.opera.practice",
+            author_user_id=3,
+            channel_id=10,
+            message_id=502,
+            excerpt="Second opera receipt with another deliberately long supporting sentence.",
+            source_created_at="2026-08-21T10:00:00+00:00",
+        )
+        _add(
+            connection,
+            subject_user_id=3,
+            summary="Practises opera every weekend",
+            topic="music.opera.practice",
+            author_user_id=3,
+            channel_id=10,
+            message_id=503,
+            excerpt="Third opera receipt before the edit.",
+            source_created_at="2026-08-22T10:00:00+00:00",
+        )
+        memory_ledger.mark_message_edited(
+            connection,
+            guild_id=100,
+            message_id=503,
+            edited_excerpt="Latest edited opera evidence is authoritative for this receipt.",
+            edited_at="2026-08-22T10:05:00+00:00",
+        )
+
+        bundle = _bundle(
+            connection,
+            query="opera",
+            evidence_char_budget=35,
+            evidence_per_memory=3,
+        )
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == created.memory.id)
+    assert item.evidence
+    assert item.evidence[0].receipt_id > 0
+    assert item.evidence[0].excerpt.startswith("Latest edited opera evidence")
+    assert sum(len(receipt.excerpt) for receipt in item.evidence) <= 35
+
+
+def test_wrong_guild_memory_never_enters_context(database_path):
+    with managed_connection(database_path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=200,
+            wilhelmina_user_id=1999,
+            founder_user_id=20,
+            founder_name="Other Founder",
+            actor_user_id=20,
+        )
+        memory_ledger.add_memory(
+            connection,
+            guild_id=200,
+            subject_user_id=20,
+            category="Interest",
+            epistemic_label="Fact",
+            summary="Obsessed with eclipse photography",
+            topic_key="astronomy.eclipse.photo",
+            actor_user_id=20,
+        )
+        local = _add(
+            connection,
+            subject_user_id=3,
+            summary="Enjoys eclipse forecasts",
+            topic="astronomy.eclipse.forecast",
+        )
+
+        bundle = _bundle(connection, query="eclipse")
+
+    assert [item.memory.id for item in bundle.contextual_memories] == [local.memory.id]
+    assert all(item.memory.guild_id == 100 for item in bundle.contextual_memories)
+
+
+def test_renderer_preserves_epistemic_labels_gossip_and_identity_without_admin_leak(database_path):
+    with managed_connection(database_path) as connection:
+        inference = _add(
+            connection,
+            subject_user_id=2,
+            summary="May prefer late-night planning sessions",
+            topic="planning.late.night",
+            category="Communication style",
+            label="Inference",
+            reveal_scope="owner_only",
+        )
+        gossip = _add(
+            connection,
+            subject_user_id=3,
+            summary="Sam claims Alex secretly hates karaoke",
+            topic="alex.karaoke.claim",
+            category="Gossip",
+            label="Gossip",
+        )
+        hidden = _add(
+            connection,
+            subject_user_id=3,
+            summary="Admin-only karaoke note",
+            topic="alex.karaoke.admin",
+            category="Admin note",
+        )
+
+        bundle = _bundle(connection, query="karaoke")
+        rendered = memory_context.render_memory_context_for_prompt(bundle)
+
+    assert f"memory#{inference.memory.id}" in rendered
+    assert "Inference" in rendered
+    assert f"memory#{gossip.memory.id}" in rendered
+    assert "Unverified gossip" in rendered
+    assert "birth_date: 1990-10-31" in rendered
+    assert hidden.memory.summary not in rendered
+
+
+def test_missing_identity_profile_fails_before_context_retrieval(database_path):
+    with managed_connection(database_path) as connection:
+        coven_registry.register_pending_member(
+            connection,
+            guild_id=100,
+            user_id=5,
+            display_name="No Profile",
+            actor_user_id=2,
+        )
+        with pytest.raises(member_profiles.MemberIdentityProfileNotFound):
+            memory_context.assemble_memory_context(
+                connection,
+                guild_id=100,
+                interlocutor_user_id=5,
+                query="anything",
+                on_date=TODAY,
+            )
+
+
+def test_non_searchable_query_still_returns_full_speaker_profile(database_path):
+    with managed_connection(database_path) as connection:
+        memory = _add(
+            connection,
+            subject_user_id=2,
+            summary="Likes reaction images",
+            topic="chat.reaction.images",
+        )
+        bundle = _bundle(connection, query="✨😂✨")
+
+    assert {item.memory.id for item in bundle.speaker_profile} == {memory.memory.id}
+    assert bundle.contextual_memories == ()

--- a/tests/test_memory_context_hardening.py
+++ b/tests/test_memory_context_hardening.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from datetime import date
+
+from services import coven_registry, memory_context, memory_ledger, member_profiles
+from services.database import initialize_database, managed_connection
+
+TODAY = date(2026, 8, 23)
+
+
+def _save_profile(connection, *, user_id: int, display_name: str) -> None:
+    member_profiles.save_member_identity(
+        connection,
+        guild_id=100,
+        user_id=user_id,
+        discord_display_name=display_name,
+        preferred_name=display_name,
+        birth_date="1990-10-31",
+        today=TODAY,
+        actor_user_id=2,
+    )
+
+
+def _setup(path) -> None:
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        _save_profile(connection, user_id=2, display_name="Founder")
+        coven_registry.register_pending_member(
+            connection,
+            guild_id=100,
+            user_id=3,
+            display_name="Alex",
+            actor_user_id=2,
+        )
+        _save_profile(connection, user_id=3, display_name="Alex")
+        memory_ledger.initialize_memory_schema(connection)
+
+
+def _add_memory(
+    connection,
+    *,
+    subject_user_id: int,
+    summary: str,
+    topic: str = "astronomy.telescope",
+    message_id: int | None = None,
+    excerpt: str | None = None,
+):
+    return memory_ledger.add_memory(
+        connection,
+        guild_id=100,
+        subject_user_id=subject_user_id,
+        category="Interest",
+        epistemic_label="Fact",
+        summary=summary,
+        topic_key=topic,
+        actor_user_id=2,
+        reveal_scope="cross_member",
+        author_user_id=subject_user_id if message_id is not None else None,
+        channel_id=10 if message_id is not None else None,
+        message_id=message_id,
+        jump_url=(
+            f"https://discord.com/channels/100/10/{message_id}"
+            if message_id is not None
+            else None
+        ),
+        excerpt=excerpt,
+        source_created_at=(
+            "2026-08-22T10:00:00+00:00" if message_id is not None else None
+        ),
+    ).memory
+
+
+def _assemble(connection, *, query: str, referenced_member_ids=()):
+    return memory_context.assemble_memory_context(
+        connection,
+        guild_id=100,
+        interlocutor_user_id=2,
+        query=query,
+        on_date=TODAY,
+        referenced_member_ids=referenced_member_ids,
+    )
+
+
+def test_corrupted_restricted_cross_member_row_is_excluded_from_other_member_context(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+        )
+        connection.execute(
+            """
+            UPDATE memory_records
+            SET privacy_class = 'restricted', reveal_scope = 'cross_member'
+            WHERE id = ?
+            """,
+            (memory.id,),
+        )
+        bundle = _assemble(
+            connection,
+            query="telescope",
+            referenced_member_ids=(3,),
+        )
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_corrupted_restricted_cross_member_row_is_excluded_from_speaker_profile(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=2,
+            summary="Keeps a telescope notebook",
+        )
+        connection.execute(
+            """
+            UPDATE memory_records
+            SET privacy_class = 'restricted', reveal_scope = 'cross_member'
+            WHERE id = ?
+            """,
+            (memory.id,),
+        )
+        bundle = _assemble(connection, query="telescope")
+
+    assert memory.id not in {item.memory.id for item in bundle.speaker_profile}
+
+
+def test_legacy_memory_summary_containing_dangerous_secret_is_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+        )
+        connection.execute(
+            "UPDATE memory_records SET summary = ? WHERE id = ?",
+            ("auth token: abcdefgh123456", memory.id),
+        )
+        bundle = _assemble(
+            connection,
+            query="auth token",
+            referenced_member_ids=(3,),
+        )
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_legacy_memory_topic_containing_dangerous_secret_is_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+        )
+        connection.execute(
+            "UPDATE memory_records SET topic_key = ? WHERE id = ?",
+            ("auth token: abcdefgh123456", memory.id),
+        )
+        bundle = _assemble(
+            connection,
+            query="telescope",
+            referenced_member_ids=(3,),
+        )
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_legacy_private_key_variants_are_excluded_before_context_rendering(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+        )
+        for key_type in ("ENCRYPTED", "DSA"):
+            connection.execute(
+                "UPDATE memory_records SET summary = ? WHERE id = ?",
+                (
+                    f"-----BEGIN {key_type} PRIVATE KEY-----\nsecret-material\n"
+                    f"-----END {key_type} PRIVATE KEY-----",
+                    memory.id,
+                ),
+            )
+            bundle = _assemble(
+                connection,
+                query="telescope",
+                referenced_member_ids=(3,),
+            )
+            assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_legacy_receipt_private_key_is_omitted_from_safe_memory(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+            message_id=501,
+            excerpt="I collect telescope lenses.",
+        )
+        connection.execute(
+            "UPDATE memory_receipts SET original_excerpt = ? WHERE memory_id = ?",
+            (
+                "-----BEGIN DSA PRIVATE KEY-----\nsecret-material\n"
+                "-----END DSA PRIVATE KEY-----",
+                memory.id,
+            ),
+        )
+        bundle = _assemble(connection, query="telescope")
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == memory.id)
+    assert item.evidence == ()
+
+
+def test_corrupted_entity_guild_cannot_pull_cross_guild_memory(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=200,
+            wilhelmina_user_id=1999,
+            founder_user_id=20,
+            founder_name="Other Founder",
+            actor_user_id=20,
+        )
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=200,
+            user_id=20,
+            discord_display_name="Other Founder",
+            preferred_name="Other Founder",
+            birth_date="1990-10-31",
+            today=TODAY,
+            actor_user_id=20,
+        )
+        foreign_memory = memory_ledger.add_memory(
+            connection,
+            guild_id=200,
+            subject_user_id=20,
+            category="Interest",
+            epistemic_label="Fact",
+            summary="Other guild telescope secret",
+            topic_key="astronomy.other-guild",
+            actor_user_id=20,
+            reveal_scope="cross_member",
+        ).memory
+        connection.execute(
+            """
+            UPDATE memory_entities
+            SET guild_id = 100, entity_key = '3'
+            WHERE memory_id = ? AND entity_type = 'subject'
+            """,
+            (foreign_memory.id,),
+        )
+        bundle = _assemble(
+            connection,
+            query="unrelated",
+            referenced_member_ids=(3,),
+        )
+
+    assert foreign_memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_corrupted_receipt_guild_is_excluded_from_evidence(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+            message_id=501,
+            excerpt="This receipt should not cross guilds.",
+        )
+        connection.execute(
+            "UPDATE memory_receipts SET guild_id = 200 WHERE memory_id = ?",
+            (memory.id,),
+        )
+        bundle = _assemble(connection, query="telescope")
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == memory.id)
+    assert item.evidence == ()
+
+
+def test_legacy_receipt_secret_is_omitted_without_dropping_safe_memory(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+            message_id=501,
+            excerpt="I collect telescope lenses.",
+        )
+        connection.execute(
+            "UPDATE memory_receipts SET original_excerpt = ? WHERE memory_id = ?",
+            ("auth token: abcdefgh123456", memory.id),
+        )
+        bundle = _assemble(connection, query="telescope")
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == memory.id)
+    assert item.evidence == ()
+
+
+def test_unsafe_newer_receipt_does_not_hide_older_safe_evidence(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+            message_id=501,
+            excerpt="Older safe telescope evidence.",
+        )
+        _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Collects telescope lenses",
+            message_id=502,
+            excerpt="Newer safe telescope evidence before corruption.",
+        )
+        connection.execute(
+            "UPDATE memory_receipts SET original_excerpt = ? WHERE message_id = 502",
+            ("auth token: abcdefgh123456",),
+        )
+        bundle = _assemble(connection, query="telescope")
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == memory.id)
+    assert [receipt.excerpt for receipt in item.evidence] == ["Older safe telescope evidence."]
+
+
+def test_context_fts_priority_preserves_ledger_search_order(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        first = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Telescope telescope telescope astronomy",
+            topic="astronomy.telescope.primary",
+        )
+        second = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Owns one telescope",
+            topic="astronomy.telescope.secondary",
+        )
+        ledger_hits = memory_ledger.search_memories(
+            connection,
+            guild_id=100,
+            query="telescope",
+            reveal_scopes=("cross_member",),
+        )
+        bundle = _assemble(connection, query="telescope")
+
+    ledger_ids = [hit.memory.id for hit in ledger_hits if hit.memory.id in {first.id, second.id}]
+    context_ids = [
+        item.memory.id
+        for item in bundle.contextual_memories
+        if item.memory.id in {first.id, second.id}
+    ]
+    assert context_ids == ledger_ids

--- a/tests/test_memory_context_review_regressions.py
+++ b/tests/test_memory_context_review_regressions.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from datetime import date
+
+from services import coven_registry, memory_context, memory_ledger, member_profiles
+from services.database import initialize_database, managed_connection
+
+TODAY = date(2026, 8, 24)
+
+
+def _setup(path) -> None:
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=100,
+            user_id=2,
+            discord_display_name="Founder",
+            preferred_name="Founder",
+            birth_date="1990-10-31",
+            today=TODAY,
+            actor_user_id=2,
+        )
+        coven_registry.register_pending_member(
+            connection,
+            guild_id=100,
+            user_id=3,
+            display_name="Alex",
+            actor_user_id=2,
+        )
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=100,
+            user_id=3,
+            discord_display_name="Alex",
+            preferred_name="Alex",
+            birth_date="1991-09-01",
+            today=TODAY,
+            actor_user_id=2,
+        )
+        memory_ledger.initialize_memory_schema(connection)
+
+
+def _add_memory(
+    connection,
+    *,
+    subject_user_id: int,
+    message_id: int | None = None,
+):
+    return memory_ledger.add_memory(
+        connection,
+        guild_id=100,
+        subject_user_id=subject_user_id,
+        category="Interest",
+        epistemic_label="Fact",
+        summary="Collects telescope lenses",
+        topic_key="astronomy.telescope",
+        actor_user_id=2,
+        reveal_scope="cross_member",
+        author_user_id=subject_user_id if message_id is not None else None,
+        channel_id=10 if message_id is not None else None,
+        message_id=message_id,
+        jump_url=(
+            f"https://discord.com/channels/100/10/{message_id}"
+            if message_id is not None
+            else None
+        ),
+        excerpt="Safe telescope evidence." if message_id is not None else None,
+        source_created_at=(
+            "2026-08-24T08:00:00+00:00" if message_id is not None else None
+        ),
+    ).memory
+
+
+def _assemble(connection):
+    return memory_context.assemble_memory_context(
+        connection,
+        guild_id=100,
+        interlocutor_user_id=2,
+        query="telescope",
+        on_date=TODAY,
+        referenced_member_ids=(3,),
+    )
+
+
+def test_openpgp_private_key_memory_is_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=3)
+        connection.execute(
+            "UPDATE memory_records SET summary = ? WHERE id = ?",
+            (
+                "-----BEGIN PGP PRIVATE KEY BLOCK-----\nsecret-material\n"
+                "-----END PGP PRIVATE KEY BLOCK-----",
+                memory.id,
+            ),
+        )
+        bundle = _assemble(connection)
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_openpgp_private_key_receipt_is_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=3, message_id=700)
+        connection.execute(
+            "UPDATE memory_receipts SET original_excerpt = ? WHERE memory_id = ?",
+            (
+                "-----BEGIN PGP PRIVATE KEY BLOCK-----\nsecret-material\n"
+                "-----END PGP PRIVATE KEY BLOCK-----",
+                memory.id,
+            ),
+        )
+        bundle = _assemble(connection)
+
+    item = next(item for item in bundle.contextual_memories if item.memory.id == memory.id)
+    assert item.evidence == ()
+
+
+def test_putty_private_key_memory_is_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=3)
+        connection.execute(
+            "UPDATE memory_records SET summary = ? WHERE id = ?",
+            (
+                "PuTTY-User-Key-File-3: ssh-rsa\nEncryption: aes256-cbc\n"
+                "Private-Lines: 1\nsecret-material",
+                memory.id,
+            ),
+        )
+        bundle = _assemble(connection)
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_ssh2_private_key_memory_is_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=3)
+        connection.execute(
+            "UPDATE memory_records SET summary = ? WHERE id = ?",
+            (
+                "---- BEGIN SSH2 ENCRYPTED PRIVATE KEY ----\nsecret-material\n"
+                "---- END SSH2 ENCRYPTED PRIVATE KEY ----",
+                memory.id,
+            ),
+        )
+        bundle = _assemble(connection)
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_non_pem_private_key_receipts_are_excluded(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=3, message_id=701)
+        for secret in (
+            "PuTTY-User-Key-File-2: ssh-rsa\nPrivate-Lines: 1\nsecret-material",
+            "---- BEGIN SSH2 PRIVATE KEY ----\nsecret-material\n---- END SSH2 PRIVATE KEY ----",
+        ):
+            connection.execute(
+                "UPDATE memory_receipts SET original_excerpt = ? WHERE memory_id = ?",
+                (secret, memory.id),
+            )
+            bundle = _assemble(connection)
+            item = next(
+                item for item in bundle.contextual_memories if item.memory.id == memory.id
+            )
+            assert item.evidence == ()
+
+
+def test_corrupted_admin_note_cross_member_is_excluded_from_other_member_context(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=3)
+        connection.execute(
+            """
+            UPDATE memory_records
+            SET category = 'Admin note', privacy_class = 'ordinary', reveal_scope = 'cross_member'
+            WHERE id = ?
+            """,
+            (memory.id,),
+        )
+        bundle = _assemble(connection)
+
+    assert memory.id not in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_corrupted_admin_note_cross_member_is_excluded_from_speaker_profile(tmp_path):
+    path = tmp_path / "context.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory = _add_memory(connection, subject_user_id=2)
+        connection.execute(
+            """
+            UPDATE memory_records
+            SET category = 'Admin note', privacy_class = 'ordinary', reveal_scope = 'cross_member'
+            WHERE id = ?
+            """,
+            (memory.id,),
+        )
+        bundle = _assemble(connection)
+
+    assert memory.id not in {item.memory.id for item in bundle.speaker_profile}


### PR DESCRIPTION
## Purpose

Build Phase 5 context intelligence on top of the permanent Phase-4 cleanup without starting the Phase-6 chat brain.

This is intentionally a **stacked PR** on `phase-4-permanent-memory-cleanup`. It must not merge independently while the earlier stack remains unmerged.

## Approved product objective

Decide what Wilhelmina should remember *right now* for an already-authorized conversation using deterministic local retrieval, while preserving the full permitted speaker profile, cross-member reveal boundaries, gossip/epistemic labels, contradiction context, and evidence.

## Implemented

- new `services.memory_context` deterministic context assembler;
- completed private identity is required before assembly;
- full active speaker profile is loaded, including the speaker's permitted `owner_only` memories but excluding `admin_only`;
- memories about other people enter chat context only through valid `cross_member` reveal scope;
- malformed legacy/manually edited `restricted/cross_member` rows fail closed;
- FTS and member-entity retrieval happen only after reveal scope is fixed locally;
- explicit trusted Discord/member references receive deterministic ranking weight without becoming authorization;
- both entity-retrieval paths recheck the returned memory record's `guild_id` before ranking/evidence, preventing a poisoned/mismatched entity row from crossing guild boundaries;
- receipt evidence independently requires `receipt.guild_id == requested guild_id`, preventing a corrupted/manual receipt from crossing guild boundaries even when its memory ID is valid;
- FTS uses the Ledger's existing best-first result ordering instead of reinterpreting raw negative/tiny BM25 values;
- contradiction expansion includes only partners independently revealable to the current interlocutor;
- receipt evidence is bounded by a generous deterministic character/per-memory budget, prefers latest edited evidence, and can fall back to older safe receipts;
- the existing Phase-4 dangerous-secret guard is reapplied to legacy memory summaries, topic keys, and receipt evidence before context use;
- Phase 5 additionally rejects generic PEM private-key headers ending in `PRIVATE KEY`, including `ENCRYPTED PRIVATE KEY` and `DSA PRIVATE KEY`, before rendering legacy/manually corrupted content;
- renderer preserves `Fact`, `Inference`, `Impression`, and unverified `Gossip` distinctions;
- trusted identity context includes current Discord display name, preferred name, full canonical DOB, and locally calculated age;
- no OpenAI call, no model-controlled retrieval authorization, no new schema, and no new persisted context/profile table occurs in this layer;
- no permanent/evolving psychological or relationship profiling is implemented here.

## Adversarial regressions

- full speaker profile keeps permitted `owner_only` rows and excludes `admin_only`;
- a hidden importance-100 memory cannot outrank or leak past an allowed importance-1 memory;
- malformed `restricted/cross_member` rows are excluded for both speaker and other-member contexts;
- referenced-member subject/entity retrieval;
- referenced subject priority over unrelated FTS hits;
- FTS best-first ordering remains a deterministic retrieval signal;
- poisoned `memory_entities.guild_id` cannot pull another guild's record into context;
- mismatched `memory_receipts.guild_id` cannot enter another guild's evidence bundle;
- revealable contradiction expansion with hidden contradiction filtering;
- evidence budget hard bounds and latest-edited evidence preference;
- unsafe newer receipt does not suppress older safe evidence;
- legacy dangerous-secret summary/topic/evidence exclusion;
- encrypted/DSA PEM private-key memory + receipt exclusion;
- wrong-guild isolation;
- epistemic/gossip renderer semantics;
- missing identity profile fails closed;
- non-searchable/emoji-only queries still return the full speaker profile.

## Review closeout

Codex reviewed prior head `0f74b0cd5e...` and raised two concrete P1s:

1. unsupported encrypted/DSA PEM private-key variants could bypass retrieval-time secret validation;
2. a corrupted `memory_entities.guild_id` could point at another guild's memory because entity lookup did not recheck the returned record guild.

Both findings were accepted as legitimate under `AGENTS.md`, fixed, covered by adversarial regressions, replied to with exact-head evidence, and their inline threads are resolved.

A subsequent manual hostile pass found the adjacent receipt form of the same guild-isolation problem: `memory_receipts` has its own guild ID but is keyed to memory by `memory_id` only. Phase 5 now independently rejects receipt evidence whose guild differs from the requested context guild, with a dedicated corruption regression.

A fresh Codex review has been requested specifically for the current exact head below. At the time of this update the request is acknowledged by Codex and no new P0/P1 thread or blocking review has appeared.

## Documentation reconciliation

- `AGENTS.md` doctrine remains unchanged; stale status text records consent cleanup as removed and Phase 5 as current work;
- README documents the service-layer Phase-5 capability and absence of a new live command/flag;
- `docs/memory_context.md` records the authorization/ranking/evidence/personality-analysis boundary;
- `docs/memory_ledger.md` records the implemented context contract and retrieval-time hard-secret defense;
- `.env.example` was inspected and needs no Phase-5 change because this layer adds no new feature flag or runtime configuration.

## Validation

Current exact head: `7491ff553e30f969faae4250591d859ce7511944`

- GitHub Actions CI run `32607308293` / run #398 — **success**
- `ruff check .` — **passed**
- `pytest` — **257 passed, 1 warning**
- all Phase-4 extraction/claim/TTL/edit/deletion regressions remain green
- Codex's two original P1 regressions pass
- the manually-found cross-guild receipt-evidence regression passes
- no live OpenAI key or provider request used

Historical validation note: run #386 correctly caught a first-pass legacy-secret regression; that was fixed before run #390. Codex then found two additional P1s on `0f74...`; run #394 validated those fixes. The later receipt-guild hardening moved the head again, so run #398 is the authoritative exact-head validation.

## Explicitly outside this PR

- Phase 6 Discord chat behavior;
- ambient whole-server listening;
- changes to the unresolved under-18 gate (`PRODUCT DECISION PENDING`);
- permanent/evolving personality-analysis profiling, which remains behind the separately documented external-policy gate;
- any new consent/version permission architecture;
- merge of this PR or any earlier stacked PR without explicit owner authorization.
