### PR TITLE
Phase 6A: add memory-aware chat contract and Discord routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ ENABLE_MEMORY_ADMIN=true
 # Loads interaction-scoped automatic memory extraction and requests Message Content intent.
 # Keep false until the Discord Developer Portal intent and private OpenAI runtime are configured.
 ENABLE_MEMORY_EXTRACTION=false
+# Phase 6 chat surface. In Phase 6A this enables interaction routing/context preparation only;
+# no OpenAI chat response is generated yet. It also requests Message Content intent so the
+# designated Wilhelmina channel can receive ordinary free-form messages.
+ENABLE_CHAT=false
 ENABLE_INVITE=false
 ENABLE_ROLL=false
 ENABLE_EIGHT_BALL=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -805,8 +805,8 @@ The current broad build sequence is:
 2. Memory architecture — completed.
 3. Memory administration — completed.
 4. Automatic memory extraction — **BUILT + TESTED + IN REVIEW** in the current stacked PR sequence; not merged.
-5. Context intelligence / retrieval — current work.
-6. Wilhelmina's memory-aware chat brain.
+5. Context intelligence / retrieval — **BUILT + TESTED + IN REVIEW** in the current stacked PR sequence; not merged.
+6. Wilhelmina's memory-aware chat brain — current work; Phase 6A builds the Discord routing and audience-aware context contract before provider-backed replies.
 7. Hardening, deployment, broader listening pathway, and final operational readiness.
 
 Additional work required before or alongside later phases includes:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ cogs.help               /help
 cogs.rules              /rules, /rules-admin ...
 cogs.memory_admin       /memory-admin ...
 cogs.memory_extraction  interaction-scoped automatic Memory Ledger extraction
+cogs.chat               Phase-6A interaction routing + authorized context preparation
 cogs.invite             /invite
 cogs.roll               /roll
 cogs.eight_ball         /8ball
@@ -28,7 +29,7 @@ cogs.fortune            /fortune
 cogs.broadcasts         /broadcast-admin ...
 ```
 
-Phase-5 context intelligence is currently a service-layer capability (`services.memory_context`), not a Discord cog or command. The later Phase-6 chat cog will consume it.
+Phase-5 context intelligence is the service-layer retrieval capability in `services.memory_context`. Phase 6A adds `services.chat` and `cogs.chat` to route approved Discord interactions into audience-aware authorized memory context. Phase 6A deliberately does **not** generate an OpenAI chat response yet.
 
 Each optional feature has its own flag:
 
@@ -37,6 +38,7 @@ ENABLE_HELP=true
 ENABLE_RULES=true
 ENABLE_MEMORY_ADMIN=true
 ENABLE_MEMORY_EXTRACTION=false
+ENABLE_CHAT=false
 ENABLE_INVITE=false
 ENABLE_ROLL=false
 ENABLE_EIGHT_BALL=false
@@ -146,6 +148,8 @@ memory_extraction_jobs
 schema_migrations
 ```
 
+Phase 6A adds no chat transcript table and persists no new conversational content.
+
 Private identity schema v12 stores preferred name, full canonical birth date, and timestamps; current Discord display name remains in the Coven Registry. The obsolete adult-memory-consent timestamp/version columns are physically removed. The existing under-18 profile-completion behavior remains unchanged and is a separate product decision.
 
 The stored guild configuration is the source of truth for server role/channel IDs after Phase 2. Environment variables for role/channel IDs are not used by the new config layer.
@@ -250,17 +254,37 @@ See `docs/memory_extraction.md` for the full eligibility, privacy, queue, rollou
 
 ## Phase 5 memory context intelligence
 
-`services.memory_context` assembles deterministic memory context for the later Phase-6 chat brain. It is not a new Discord command and has no separate environment flag because nothing invokes it from live chat yet.
+`services.memory_context` assembles deterministic memory context for the Phase-6 chat brain.
 
 The current speaker receives their complete **permitted** active profile: `cross_member` and their own `owner_only` memories, but never `admin_only`. Relevant memories about other members are retrieved only from `cross_member` rows through local FTS and explicit member/entity links. Authorization happens before ranking, so importance, relevance, recency, or contradiction cannot widen a memory's reveal scope.
 
-Phase 5 also expands revealable contradiction partners, includes bounded receipt evidence, preserves `Fact`/`Inference`/`Impression`/unverified `Gossip`, and re-runs the deterministic hard-secret guard at retrieval time so a malformed or legacy credential-containing row cannot be resurrected into a future prompt.
+Phase 5 also expands revealable contradiction partners, includes bounded receipt evidence, preserves `Fact`/`Inference`/`Impression`/unverified `Gossip`, and re-runs the deterministic hard-secret guard at retrieval time so a malformed or legacy credential-containing row cannot be resurrected into a future prompt. Corruption-tolerant retrieval also rechecks guild isolation, valid privacy/reveal combinations, Admin-note invariants, and recognizable private-key formats before context can escape the service layer.
 
 The service uses the speaker's trusted identity context, including current Discord display name, preferred name, full canonical birth date, and locally calculated age. The existing under-18 profile-completion behavior remains **PRODUCT DECISION PENDING** and Phase 5 does not expand it.
 
 This phase does **not** build the separately policy-gated permanent/evolving personality-analysis dossier, does not add ambient whole-server listening, does not create a new consent/version gate, does not call OpenAI, and does not persist a new context table.
 
 See `docs/memory_context.md` for the authorization matrix, ranking, contradiction, evidence, secret-hardening, rollback, and validation contract.
+
+## Phase 6A chat contract and Discord routing
+
+`cogs.chat` and `services.chat` add the first tranche of Wilhelmina's memory-aware live-chat architecture. The feature is disabled by default:
+
+```env
+ENABLE_CHAT=false
+```
+
+Phase 6A recognizes only approved direct-interaction surfaces: one-to-one DMs, direct mentions, resolvable replies to Wilhelmina, and ordinary human text in the designated Wilhelmina channel. Unaddressed chatter elsewhere in the guild is ignored. Bots, webhooks, empty messages, wrong-guild messages, and existing `!` prefix commands are also excluded.
+
+Chat and automatic memory extraction are independent. `ENABLE_CHAT=true` requests Message Content intent even when extraction is off, because the designated free-form channel requires message content. Pausing Memory Ledger collection does **not** mute chat or prevent already-authorized memory from being used for conversation.
+
+Phase 6A adds an audience boundary that Phase 5 alone did not need: the speaker's `owner_only` memories may remain available in a one-to-one DM, but they are removed before any guild-visible prompt can exist. Other-member context remains `cross_member` only and `admin_only` never enters ordinary chat context. This authorization is local Python logic, not a model instruction.
+
+Trusted explicit member references come only from Discord-resolved mentions/reply authors or an exact Coven Mark resolved through the local Registry. Plain-language/fuzzy names cannot become retrieval IDs.
+
+The Phase-6A cog currently stops after authorized context preparation and content-free diagnostics. It makes **no OpenAI chat call and sends no generated reply yet**. Prompt construction/provider execution starts in Phase 6B.
+
+See `docs/chat.md` for the full routing matrix, audience rules, trusted-reference boundary, configuration, tests, and rollback contract.
 
 ## Scheduled Daily Broadcasts
 
@@ -316,17 +340,22 @@ rules_acceptance     rules acceptance copy
 admin                admin/status copy hooks
 fortune              /fortune
 welcome              future welcome messages
+chat                 Phase-6 chat response profile
 broadcast_morning    The Vanguard Frequency generation
 broadcast_evening    W.W.N. Broadcast generation
 ```
 
 This keeps Wilhelmina recognizable while allowing each feature to apply the right functional limits. Protected/identity traits may be mentioned factually when relevant; the persona boundary is against using the trait itself as the basis for dehumanizing or comparable targeted abuse.
 
+The `chat` profile is defined in Phase 6A so later chat generation never silently falls back to the `help` profile. Phase 6A itself does not call the Persona Engine's AI renderer.
+
 ## AI-backed features
 
 `/8ball`, `/fortune`, `/help`, `/rules`, and `/broadcast-admin preview/send-test` can use AI first when `OPENAI_API_KEY` is configured, then fall back to static or stored responses if AI is unavailable.
 
 Automatic Memory Ledger extraction is different: when enabled, it uses the private structured-memory provider path and fails closed if the required private retention configuration is unavailable. It has no static fallback that persists guessed memories.
+
+Phase-6A chat routing is not AI-backed yet. The private chat provider path, prompt construction, and generated Discord replies are Phase-6B work.
 
 ```env
 OPENAI_API_KEY=
@@ -369,6 +398,7 @@ ENABLE_HELP=true
 ENABLE_RULES=true
 ENABLE_MEMORY_ADMIN=true
 ENABLE_MEMORY_EXTRACTION=false
+ENABLE_CHAT=false
 ENABLE_INVITE=false
 ENABLE_ROLL=false
 ENABLE_EIGHT_BALL=false

--- a/bot.py
+++ b/bot.py
@@ -28,7 +28,9 @@ def build_intents(settings: RuntimeSettings) -> discord.Intents:
     intents = discord.Intents.default()
     if settings.is_cog_enabled("cogs.rules"):
         intents.members = True
-    if settings.is_cog_enabled("cogs.memory_extraction"):
+    if settings.is_cog_enabled("cogs.memory_extraction") or settings.is_cog_enabled(
+        "cogs.chat"
+    ):
         intents.message_content = True
     return intents
 

--- a/cogs/chat.py
+++ b/cogs/chat.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+from services import chat, memory_context, memory_ledger, member_profiles
+from services.database import initialize_database, managed_connection
+
+logger = logging.getLogger("wilhelmina.chat.events")
+
+
+def _database_path(bot: commands.Bot) -> Path:
+    return Path(bot.settings.database_path)
+
+
+def _reply_author_user_id(message: discord.Message) -> int | None:
+    reference = message.reference
+    if reference is None:
+        return None
+    resolved = reference.resolved
+    if isinstance(resolved, discord.Message):
+        return int(resolved.author.id)
+    return None
+
+
+def _message_envelope(message: discord.Message) -> chat.ChatMessageEnvelope:
+    return chat.ChatMessageEnvelope(
+        message_id=int(message.id),
+        author_user_id=int(message.author.id),
+        author_is_bot=bool(message.author.bot),
+        webhook_id=None if message.webhook_id is None else int(message.webhook_id),
+        content=str(message.content or ""),
+        guild_id=None if message.guild is None else int(message.guild.id),
+        channel_id=int(message.channel.id),
+        mentioned_user_ids=tuple(int(user.id) for user in message.mentions),
+        reply_author_user_id=_reply_author_user_id(message),
+    )
+
+
+class Chat(commands.Cog):
+    """Phase-6A interaction routing and authorized context preparation.
+
+    This tranche intentionally performs no OpenAI call and sends no generated reply.
+    """
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if self.bot.user is None:
+            return
+
+        home_guild_id = getattr(self.bot.settings, "home_guild_id", None)
+        if home_guild_id is None:
+            return
+        home_guild_id = int(home_guild_id)
+
+        envelope = _message_envelope(message)
+        if envelope.guild_id is not None and envelope.guild_id != home_guild_id:
+            return
+
+        path = _database_path(self.bot)
+        try:
+            initialize_database(path)
+            with managed_connection(path) as connection:
+                ledger_settings = memory_ledger.get_or_create_settings(
+                    connection,
+                    home_guild_id,
+                )
+                route = chat.route_chat_message(
+                    envelope,
+                    home_guild_id=home_guild_id,
+                    bot_user_id=int(self.bot.user.id),
+                    designated_channel_id=ledger_settings.wilhelmina_channel_id,
+                    command_prefix=str(self.bot.command_prefix or "!"),
+                )
+                if not route.eligible:
+                    return
+
+                referenced_member_ids = chat.resolve_referenced_member_ids(
+                    connection,
+                    guild_id=home_guild_id,
+                    interlocutor_user_id=envelope.author_user_id,
+                    bot_user_id=int(self.bot.user.id),
+                    content=envelope.content,
+                    mentioned_user_ids=envelope.mentioned_user_ids,
+                    reply_author_user_id=envelope.reply_author_user_id,
+                )
+                bundle = chat.assemble_chat_memory_context(
+                    connection,
+                    route=route,
+                    interlocutor_user_id=envelope.author_user_id,
+                    query=envelope.content,
+                    referenced_member_ids=referenced_member_ids,
+                )
+        except member_profiles.MemberIdentityProfileNotFound:
+            logger.info(
+                "chat_routing_skipped reason=profile_missing guild_id=%s message_id=%s author_user_id=%s",
+                home_guild_id,
+                envelope.message_id,
+                envelope.author_user_id,
+            )
+            return
+        except (chat.ChatContractError, memory_context.MemoryContextError):
+            logger.warning(
+                "chat_routing_skipped reason=context_contract guild_id=%s message_id=%s "
+                "author_user_id=%s",
+                home_guild_id,
+                envelope.message_id,
+                envelope.author_user_id,
+            )
+            return
+        except Exception as exc:
+            logger.warning(
+                "chat_routing_failed guild_id=%s message_id=%s author_user_id=%s exception=%s",
+                home_guild_id,
+                envelope.message_id,
+                envelope.author_user_id,
+                type(exc).__name__,
+            )
+            return
+
+        assert route.surface is not None
+        assert route.audience_scope is not None
+        logger.info(
+            "chat_context_prepared guild_id=%s message_id=%s author_user_id=%s surface=%s "
+            "audience=%s referenced_count=%s speaker_memory_count=%s contextual_memory_count=%s",
+            home_guild_id,
+            envelope.message_id,
+            envelope.author_user_id,
+            route.surface.value,
+            route.audience_scope.value,
+            len(referenced_member_ids),
+            len(bundle.speaker_profile),
+            len(bundle.contextual_memories),
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Chat(bot))

--- a/config/settings.py
+++ b/config/settings.py
@@ -92,6 +92,12 @@ COG_FLAGS: tuple[CogFlag, ...] = (
         description="Interaction-scoped automatic Memory Ledger extraction.",
     ),
     CogFlag(
+        extension="cogs.chat",
+        env_var="ENABLE_CHAT",
+        default_enabled=False,
+        description="Memory-aware direct-interaction chat routing.",
+    ),
+    CogFlag(
         extension="cogs.invite",
         env_var="ENABLE_INVITE",
         default_enabled=False,
@@ -346,6 +352,7 @@ ENABLE_HELP = _get_bool_or_default("ENABLE_HELP", default=True)
 ENABLE_RULES = _get_bool_or_default("ENABLE_RULES", default=True)
 ENABLE_MEMORY_ADMIN = _get_bool_or_default("ENABLE_MEMORY_ADMIN", default=True)
 ENABLE_MEMORY_EXTRACTION = _get_bool_or_default("ENABLE_MEMORY_EXTRACTION", default=False)
+ENABLE_CHAT = _get_bool_or_default("ENABLE_CHAT", default=False)
 ENABLE_INVITE = _get_bool_or_default("ENABLE_INVITE", default=False)
 ENABLE_ROLL = _get_bool_or_default("ENABLE_ROLL", default=False)
 ENABLE_EIGHT_BALL = _get_bool_or_default("ENABLE_EIGHT_BALL", default=False)

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,0 +1,196 @@
+# Phase 6A Chat Contract and Discord Routing
+
+Phase 6A builds the deterministic Discord-facing boundary for Wilhelmina's future memory-aware chat brain.
+
+It does **not** generate a chat response yet. The Phase-6A cog recognizes approved interactions, resolves trusted member references, assembles the locally authorized Phase-5 memory context, applies the Discord-audience reveal boundary, and records content-free operational metadata. Phase 6B will add the private OpenAI response path on top of this contract.
+
+## Status
+
+Phase 6A is implemented behind `ENABLE_CHAT=false` on its stacked feature branch and remains unmerged while under review.
+
+## Approved interaction surfaces
+
+Phase 6A responds to the same interaction-scoped surfaces already approved for Wilhelmina-facing conversation:
+
+| Discord source | Routed surface | Audience |
+| --- | --- | --- |
+| Direct DM to Wilhelmina | `dm` | `private_interlocutor` |
+| Reply to Wilhelmina in the home guild | `reply` | `guild_visible` |
+| Direct mention of Wilhelmina in the home guild | `mention` | `guild_visible` |
+| Any eligible human text in the designated Wilhelmina channel | `designated_channel` | `guild_visible` |
+
+Unaddressed messages outside the designated Wilhelmina channel are not chat interactions. Phase 6A does not activate ambient whole-server listening.
+
+Messages from bots/webhooks, empty text, messages from another guild, and existing `!` prefix commands are ignored by the chat router.
+
+When more than one guild trigger applies, the diagnostic surface precedence is reply, then mention, then designated channel. All three are still `guild_visible`, so the precedence changes only routing metadata, not memory authorization.
+
+## Discord Message Content intent
+
+`ENABLE_CHAT=true` requests Discord's Message Content gateway intent independently from Memory Ledger extraction. The intent is required for ordinary free-form messages in the designated Wilhelmina channel and must also be enabled for the bot application in Discord's Developer Portal where Discord requires it.
+
+The runtime rule is:
+
+```text
+message_content = ENABLE_CHAT or ENABLE_MEMORY_EXTRACTION
+```
+
+Chat and memory extraction are separate features. Enabling chat does not enable automatic memory extraction, and enabling extraction is not required for chat routing.
+
+## Feature flag
+
+```env
+ENABLE_CHAT=false
+```
+
+The default remains off. In Phase 6A, setting this flag to true loads `cogs.chat`, requests Message Content intent, and enables routing/context preparation only. It does not make an OpenAI chat request and does not send a generated chat reply.
+
+## Designated Wilhelmina channel
+
+Phase 6A deliberately reuses the existing Memory Ledger setting:
+
+```text
+memory_ledger_settings.wilhelmina_channel_id
+```
+
+There is no duplicate chat-channel configuration or new schema. The existing `/memory-admin set-channel` and `/memory-admin clear-channel` controls remain the source of truth for the designated Wilhelmina interaction channel.
+
+The Memory Ledger collection pause is **not** a chat mute switch. `collection_enabled=false` pauses durable automatic collection but does not disable direct conversation routing or memory use for an already-authorized chat interaction.
+
+## Audience-aware memory authorization
+
+Phase 5 authorizes memory relative to the interlocutor. Phase 6 adds another fact: who can read Wilhelmina's eventual Discord response.
+
+Phase 6A therefore applies this additional deterministic audience matrix after Phase-5 assembly and before any future model call:
+
+| Memory | One-to-one DM | Guild-visible chat |
+| --- | ---: | ---: |
+| Current speaker `cross_member` | yes | yes |
+| Current speaker `owner_only` | yes | **no** |
+| Current speaker `admin_only` | no | no |
+| Other member `cross_member` | relevant only | relevant only |
+| Other member `owner_only` | no | no |
+| Other member `admin_only` | no | no |
+
+This is enforced locally in `services.chat`; it is not a prompt request to a model.
+
+If the audience filter removes a memory, contradiction IDs are also trimmed so an allowed memory does not retain an internal pointer to a hidden memory.
+
+All Phase-5 corruption and dangerous-secret defenses remain in force before this audience filter, including same-guild record/entity/receipt checks, invalid privacy/reveal-pair rejection, Admin-note invariants, and private-key/credential filtering.
+
+## Trusted member references
+
+Phase 5 accepts explicit member IDs as trusted retrieval input only when Discord-facing code resolves them deterministically. Phase 6A implements that boundary.
+
+Allowed reference sources are:
+
+- Discord-resolved user mentions;
+- the author of a resolved replied-to message when that author is a Registry member;
+- an exact Coven Mark such as `WTCH-0003` or `⛧WTCH-0003⛧`, resolved locally through the Coven Registry.
+
+Every resolved member must exist in the home guild's Coven Registry. Wilhelmina's system entry, the current speaker, unknown IDs, and malformed/unknown Coven Marks are excluded.
+
+Plain-language or fuzzy names are **not** resolved into member IDs. A future model cannot decide that the word `Alex` means a particular user and thereby widen the memory candidate set.
+
+## Guild-local date and identity
+
+Phase 6A derives the date used by Phase-5 trusted identity context from the configured guild timezone. If no guild configuration exists, the existing UTC default is used.
+
+This preserves the current identity contract: full canonical birth date stays in trusted local identity context and age is calculated locally for the relevant date. Phase 6A does not change the existing under-18 behavior, which remains a separate `PRODUCT DECISION PENDING` item.
+
+## Cog/service split
+
+`cogs.chat` owns Discord event adaptation only:
+
+```text
+Discord Message
+  -> ChatMessageEnvelope
+  -> route_chat_message(...)
+  -> resolve_referenced_member_ids(...)
+  -> assemble_chat_memory_context(...)
+  -> content-free context-prepared log
+```
+
+`services.chat` owns the reusable deterministic rules:
+
+- surface routing;
+- audience classification;
+- trusted member-reference resolution;
+- guild-local chat date;
+- Phase-5 context delegation;
+- DM versus guild-visible reveal filtering.
+
+The cog does not own privacy rules and does not instantiate an OpenAI client.
+
+## No provider call in Phase 6A
+
+Phase 6A intentionally stops after authorized context preparation.
+
+It does not:
+
+- call OpenAI;
+- use `services.persona.render_persona_text`;
+- send a generated Discord response;
+- create provider-managed conversation state;
+- persist raw chat turns;
+- add streaming;
+- add image generation;
+- add semantic/vector retrieval;
+- implement the separately policy-gated permanent/evolving personality dossier.
+
+An explicit `chat` Persona Engine profile is added now so later Phase-6 work does not accidentally fall back to the `help` profile. The profile's future Discord output ceiling is 1,900 characters.
+
+## Operational logging
+
+Phase 6A logs no message content, identity profile text, memory summaries, receipt excerpts, birth dates, or generated responses.
+
+A successful route records only operational metadata such as:
+
+- guild/message/author IDs;
+- selected surface and audience class;
+- count of trusted referenced members;
+- speaker-memory count;
+- contextual-memory count.
+
+Failures log a reason/category and exception type without private content.
+
+## Tests
+
+Phase-6A regression coverage includes:
+
+- DM, designated-channel, mention, and reply routing;
+- wrong-guild/unaddressed/bot/webhook/empty/prefix-command rejection;
+- Message Content intent independence between chat and extraction;
+- exact Registry/Coven-Mark reference resolution;
+- refusal to fuzzy-resolve plain names;
+- guild-local date rollover;
+- `owner_only` present in DM context;
+- `owner_only` removed from guild-visible context;
+- other-member `cross_member` context preserved;
+- contradiction pointers trimmed when a linked hidden memory is removed;
+- Memory Ledger collection pause does not disable chat context;
+- chat cog prepares context without sending a response;
+- explicit chat Persona profile and disabled-by-default configuration.
+
+Required repository gates remain:
+
+```bash
+ruff check .
+pytest
+```
+
+No live OpenAI validation applies to Phase 6A because the tranche intentionally has no provider call.
+
+A real Discord canary remains later rollout work; mocked/unit CI does not prove Developer Portal intent configuration or live Gateway delivery.
+
+## Rollback
+
+Phase 6A adds no database schema and no durable chat-content store.
+
+Runtime rollback is:
+
+```env
+ENABLE_CHAT=false
+```
+
+Then restart Wilhelmina. Phase-5 memory state, extraction state, Registry data, identity data, and existing designated-channel configuration remain untouched.

--- a/services/chat.py
+++ b/services/chat.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass, replace
+from datetime import date, datetime, timezone
+from enum import Enum
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from services import coven_registry, guild_config, memory_context
+
+COVEN_MARK_PATTERN = re.compile(
+    r"(?<![A-Z0-9])(?:⛧)?WTCH-\d{4,}(?:⛧)?(?![A-Z0-9])",
+    re.IGNORECASE,
+)
+
+
+class ChatContractError(ValueError):
+    """Raised when a trusted chat-routing request is structurally invalid."""
+
+
+class ConversationSurface(str, Enum):
+    """Approved direct-interaction surfaces for Phase 6 chat."""
+
+    DM = "dm"
+    DESIGNATED_CHANNEL = "designated_channel"
+    MENTION = "mention"
+    REPLY = "reply"
+
+
+class AudienceScope(str, Enum):
+    """Who can read the eventual Discord response."""
+
+    PRIVATE_INTERLOCUTOR = "private_interlocutor"
+    GUILD_VISIBLE = "guild_visible"
+
+
+@dataclass(frozen=True)
+class ChatMessageEnvelope:
+    """Discord-derived facts used by deterministic chat routing."""
+
+    message_id: int
+    author_user_id: int
+    author_is_bot: bool
+    webhook_id: int | None
+    content: str
+    guild_id: int | None
+    channel_id: int
+    mentioned_user_ids: tuple[int, ...] = ()
+    reply_author_user_id: int | None = None
+
+
+@dataclass(frozen=True)
+class ChatRoute:
+    """Deterministic routing decision made before memory retrieval."""
+
+    eligible: bool
+    guild_id: int | None = None
+    surface: ConversationSurface | None = None
+    audience_scope: AudienceScope | None = None
+    reason: str = ""
+
+
+def route_chat_message(
+    envelope: ChatMessageEnvelope,
+    *,
+    home_guild_id: int | None,
+    bot_user_id: int,
+    designated_channel_id: int | None,
+    command_prefix: str = "!",
+) -> ChatRoute:
+    """Classify one message without widening the approved interaction scope."""
+
+    if envelope.author_is_bot or envelope.webhook_id is not None:
+        return ChatRoute(False, reason="non_human")
+
+    content = str(envelope.content or "")
+    if not content.strip():
+        return ChatRoute(False, reason="no_text")
+    if command_prefix and content.lstrip().startswith(command_prefix):
+        return ChatRoute(False, reason="prefix_command")
+    if home_guild_id is None:
+        return ChatRoute(False, reason="home_guild_unset")
+
+    resolved_home_guild_id = int(home_guild_id)
+    if envelope.guild_id is None:
+        return ChatRoute(
+            True,
+            guild_id=resolved_home_guild_id,
+            surface=ConversationSurface.DM,
+            audience_scope=AudienceScope.PRIVATE_INTERLOCUTOR,
+            reason="dm",
+        )
+
+    if int(envelope.guild_id) != resolved_home_guild_id:
+        return ChatRoute(False, reason="wrong_guild")
+
+    if envelope.reply_author_user_id == int(bot_user_id):
+        return ChatRoute(
+            True,
+            guild_id=resolved_home_guild_id,
+            surface=ConversationSurface.REPLY,
+            audience_scope=AudienceScope.GUILD_VISIBLE,
+            reason="reply",
+        )
+
+    if int(bot_user_id) in {int(value) for value in envelope.mentioned_user_ids}:
+        return ChatRoute(
+            True,
+            guild_id=resolved_home_guild_id,
+            surface=ConversationSurface.MENTION,
+            audience_scope=AudienceScope.GUILD_VISIBLE,
+            reason="mention",
+        )
+
+    if (
+        designated_channel_id is not None
+        and int(envelope.channel_id) == int(designated_channel_id)
+    ):
+        return ChatRoute(
+            True,
+            guild_id=resolved_home_guild_id,
+            surface=ConversationSurface.DESIGNATED_CHANNEL,
+            audience_scope=AudienceScope.GUILD_VISIBLE,
+            reason="designated_channel",
+        )
+
+    return ChatRoute(False, reason="not_interaction")
+
+
+def _append_registry_member(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    user_id: int,
+    interlocutor_user_id: int,
+    bot_user_id: int,
+    resolved: list[int],
+    seen: set[int],
+) -> None:
+    candidate_id = int(user_id)
+    if candidate_id <= 0 or candidate_id in seen:
+        return
+    if candidate_id in {int(interlocutor_user_id), int(bot_user_id)}:
+        return
+
+    entry = coven_registry.get_entry(
+        connection,
+        guild_id=guild_id,
+        user_id=candidate_id,
+        required=False,
+    )
+    if entry is None or entry.is_system:
+        return
+
+    seen.add(candidate_id)
+    resolved.append(candidate_id)
+
+
+def resolve_referenced_member_ids(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    interlocutor_user_id: int,
+    bot_user_id: int,
+    content: str,
+    mentioned_user_ids: tuple[int, ...] = (),
+    reply_author_user_id: int | None = None,
+) -> tuple[int, ...]:
+    """Resolve only Discord- or Registry-authenticated member references.
+
+    Natural-language names are intentionally not resolved here. A future model may not
+    invent member IDs or use fuzzy name matching to widen memory retrieval authority.
+    """
+
+    resolved: list[int] = []
+    seen: set[int] = set()
+    max_members = memory_context.MAX_REFERENCED_MEMBERS
+
+    for user_id in mentioned_user_ids:
+        _append_registry_member(
+            connection,
+            guild_id=guild_id,
+            user_id=user_id,
+            interlocutor_user_id=interlocutor_user_id,
+            bot_user_id=bot_user_id,
+            resolved=resolved,
+            seen=seen,
+        )
+        if len(resolved) >= max_members:
+            return tuple(resolved)
+
+    if reply_author_user_id is not None:
+        _append_registry_member(
+            connection,
+            guild_id=guild_id,
+            user_id=reply_author_user_id,
+            interlocutor_user_id=interlocutor_user_id,
+            bot_user_id=bot_user_id,
+            resolved=resolved,
+            seen=seen,
+        )
+        if len(resolved) >= max_members:
+            return tuple(resolved)
+
+    for match in COVEN_MARK_PATTERN.finditer(str(content or "")):
+        try:
+            entry = coven_registry.get_entry_by_mark(
+                connection,
+                guild_id=guild_id,
+                mark=match.group(0),
+            )
+        except coven_registry.RegistryError:
+            continue
+        _append_registry_member(
+            connection,
+            guild_id=guild_id,
+            user_id=entry.user_id,
+            interlocutor_user_id=interlocutor_user_id,
+            bot_user_id=bot_user_id,
+            resolved=resolved,
+            seen=seen,
+        )
+        if len(resolved) >= max_members:
+            break
+
+    return tuple(resolved)
+
+
+def local_chat_date(
+    connection: sqlite3.Connection,
+    *,
+    guild_id: int,
+    now: datetime | None = None,
+) -> date:
+    """Return the guild-local date used for trusted age/birthday context."""
+
+    config = guild_config.get_guild_config(connection, guild_id)
+    timezone_name = config.timezone if config is not None else guild_config.DEFAULT_TIMEZONE
+    try:
+        zone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        zone = ZoneInfo(guild_config.DEFAULT_TIMEZONE)
+
+    instant = now if now is not None else datetime.now(timezone.utc)
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=timezone.utc)
+    return instant.astimezone(zone).date()
+
+
+def _filter_bundle_for_audience(
+    bundle: memory_context.MemoryContextBundle,
+    *,
+    audience_scope: AudienceScope,
+) -> memory_context.MemoryContextBundle:
+    """Apply Discord-audience reveal rules after Phase-5 authorization."""
+
+    if audience_scope is AudienceScope.PRIVATE_INTERLOCUTOR:
+        speaker_profile = tuple(
+            item
+            for item in bundle.speaker_profile
+            if item.memory.reveal_scope in {"cross_member", "owner_only"}
+        )
+    elif audience_scope is AudienceScope.GUILD_VISIBLE:
+        speaker_profile = tuple(
+            item
+            for item in bundle.speaker_profile
+            if item.memory.reveal_scope == "cross_member"
+        )
+    else:  # pragma: no cover - Enum exhaustiveness defence
+        raise ChatContractError(f"Unsupported audience scope: {audience_scope!r}")
+
+    contextual_memories = tuple(
+        item
+        for item in bundle.contextual_memories
+        if item.memory.reveal_scope == "cross_member"
+    )
+    included_ids = {
+        item.memory.id for item in (*speaker_profile, *contextual_memories)
+    }
+
+    def trim_contradictions(
+        item: memory_context.ContextMemory,
+    ) -> memory_context.ContextMemory:
+        return replace(
+            item,
+            contradicts_memory_ids=tuple(
+                memory_id
+                for memory_id in item.contradicts_memory_ids
+                if memory_id in included_ids
+            ),
+        )
+
+    return replace(
+        bundle,
+        speaker_profile=tuple(trim_contradictions(item) for item in speaker_profile),
+        contextual_memories=tuple(
+            trim_contradictions(item) for item in contextual_memories
+        ),
+    )
+
+
+def assemble_chat_memory_context(
+    connection: sqlite3.Connection,
+    *,
+    route: ChatRoute,
+    interlocutor_user_id: int,
+    query: str,
+    referenced_member_ids: tuple[int, ...] = (),
+    on_date: date | None = None,
+) -> memory_context.MemoryContextBundle:
+    """Assemble Phase-5 memory context and enforce the Phase-6 audience boundary."""
+
+    if not route.eligible or route.guild_id is None or route.audience_scope is None:
+        raise ChatContractError("Chat route must be eligible before context assembly")
+
+    resolved_date = on_date or local_chat_date(connection, guild_id=route.guild_id)
+    bundle = memory_context.assemble_memory_context(
+        connection,
+        guild_id=route.guild_id,
+        interlocutor_user_id=interlocutor_user_id,
+        query=query,
+        on_date=resolved_date,
+        referenced_member_ids=referenced_member_ids,
+    )
+    return _filter_bundle_for_audience(bundle, audience_scope=route.audience_scope)

--- a/services/persona.py
+++ b/services/persona.py
@@ -102,6 +102,12 @@ FEATURE_PROFILES: Mapping[str, FeatureProfile] = {
         fallback="Step inside. The house has already noticed you.",
         max_chars=500,
     ),
+    "chat": FeatureProfile(
+        key="chat",
+        label="Chat",
+        fallback="The machine has chosen incompetence. Try again.",
+        max_chars=1900,
+    ),
     "broadcast_morning": FeatureProfile(
         key="broadcast_morning",
         label="Morning broadcast",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from services import chat, coven_registry, guild_config, memory_ledger, member_profiles
+from services.database import initialize_database, managed_connection
+
+TODAY = date(2026, 8, 24)
+
+
+def _envelope(
+    *,
+    guild_id: int | None = 100,
+    channel_id: int = 10,
+    content: str = "hello",
+    author_user_id: int = 2,
+    author_is_bot: bool = False,
+    webhook_id: int | None = None,
+    mentioned_user_ids: tuple[int, ...] = (),
+    reply_author_user_id: int | None = None,
+) -> chat.ChatMessageEnvelope:
+    return chat.ChatMessageEnvelope(
+        message_id=500,
+        author_user_id=author_user_id,
+        author_is_bot=author_is_bot,
+        webhook_id=webhook_id,
+        content=content,
+        guild_id=guild_id,
+        channel_id=channel_id,
+        mentioned_user_ids=mentioned_user_ids,
+        reply_author_user_id=reply_author_user_id,
+    )
+
+
+def _route(
+    envelope: chat.ChatMessageEnvelope,
+    *,
+    designated_channel_id: int | None = 10,
+) -> chat.ChatRoute:
+    return chat.route_chat_message(
+        envelope,
+        home_guild_id=100,
+        bot_user_id=999,
+        designated_channel_id=designated_channel_id,
+    )
+
+
+def _setup(path) -> None:
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=100,
+            user_id=2,
+            discord_display_name="Founder",
+            preferred_name="Mina",
+            birth_date="1990-10-31",
+            today=TODAY,
+            actor_user_id=2,
+        )
+        for user_id, name in ((3, "Alex"), (4, "Sam")):
+            coven_registry.register_pending_member(
+                connection,
+                guild_id=100,
+                user_id=user_id,
+                display_name=name,
+                actor_user_id=2,
+            )
+            member_profiles.save_member_identity(
+                connection,
+                guild_id=100,
+                user_id=user_id,
+                discord_display_name=name,
+                preferred_name=name,
+                birth_date="1991-09-01",
+                today=TODAY,
+                actor_user_id=2,
+            )
+        memory_ledger.initialize_memory_schema(connection)
+
+
+def _add_memory(
+    connection,
+    *,
+    subject_user_id: int,
+    summary: str,
+    topic: str,
+    reveal_scope: str = "cross_member",
+    category: str = "Interest",
+    label: str = "Fact",
+):
+    return memory_ledger.add_memory(
+        connection,
+        guild_id=100,
+        subject_user_id=subject_user_id,
+        category=category,
+        epistemic_label=label,
+        summary=summary,
+        topic_key=topic,
+        actor_user_id=2,
+        privacy_class="ordinary",
+        reveal_scope=reveal_scope,
+    ).memory
+
+
+def test_dm_routes_to_private_interlocutor():
+    route = _route(_envelope(guild_id=None, channel_id=77))
+    assert route.eligible is True
+    assert route.surface is chat.ConversationSurface.DM
+    assert route.audience_scope is chat.AudienceScope.PRIVATE_INTERLOCUTOR
+    assert route.guild_id == 100
+
+
+def test_designated_channel_routes_to_guild_visible():
+    route = _route(_envelope(channel_id=10))
+    assert route.eligible is True
+    assert route.surface is chat.ConversationSurface.DESIGNATED_CHANNEL
+    assert route.audience_scope is chat.AudienceScope.GUILD_VISIBLE
+
+
+def test_mention_and_reply_are_direct_interactions_outside_designated_channel():
+    mention = _route(
+        _envelope(channel_id=20, mentioned_user_ids=(999,)),
+        designated_channel_id=10,
+    )
+    reply = _route(
+        _envelope(channel_id=20, reply_author_user_id=999),
+        designated_channel_id=10,
+    )
+    assert mention.surface is chat.ConversationSurface.MENTION
+    assert reply.surface is chat.ConversationSurface.REPLY
+    assert mention.audience_scope is chat.AudienceScope.GUILD_VISIBLE
+    assert reply.audience_scope is chat.AudienceScope.GUILD_VISIBLE
+
+
+def test_reply_and_mention_take_precedence_over_designated_surface_label():
+    reply = _route(
+        _envelope(
+            channel_id=10,
+            mentioned_user_ids=(999,),
+            reply_author_user_id=999,
+        )
+    )
+    mention = _route(_envelope(channel_id=10, mentioned_user_ids=(999,)))
+    assert reply.surface is chat.ConversationSurface.REPLY
+    assert mention.surface is chat.ConversationSurface.MENTION
+
+
+@pytest.mark.parametrize(
+    ("envelope", "reason"),
+    [
+        (_envelope(guild_id=200), "wrong_guild"),
+        (_envelope(channel_id=20), "not_interaction"),
+        (_envelope(author_is_bot=True), "non_human"),
+        (_envelope(webhook_id=88), "non_human"),
+        (_envelope(content="   "), "no_text"),
+        (_envelope(content="  !help"), "prefix_command"),
+    ],
+)
+def test_unapproved_or_nonhuman_messages_do_not_route(envelope, reason):
+    route = _route(envelope, designated_channel_id=10)
+    assert route.eligible is False
+    assert route.reason == reason
+
+
+def test_home_guild_is_required_even_for_dm():
+    route = chat.route_chat_message(
+        _envelope(guild_id=None),
+        home_guild_id=None,
+        bot_user_id=999,
+        designated_channel_id=10,
+    )
+    assert route.eligible is False
+    assert route.reason == "home_guild_unset"
+
+
+def test_trusted_member_references_use_discord_and_registry_ids_only(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        refs = chat.resolve_referenced_member_ids(
+            connection,
+            guild_id=100,
+            interlocutor_user_id=2,
+            bot_user_id=999,
+            content="Ask Alex and ⛧WTCH-0004⛧ about it, not ImaginaryName.",
+            mentioned_user_ids=(3, 999, 2, 999999),
+            reply_author_user_id=4,
+        )
+
+    assert refs == (3, 4)
+
+
+def test_plain_language_name_does_not_become_a_member_reference(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        refs = chat.resolve_referenced_member_ids(
+            connection,
+            guild_id=100,
+            interlocutor_user_id=2,
+            bot_user_id=999,
+            content="What did Alex say?",
+        )
+
+    assert refs == ()
+
+
+def test_unknown_or_malformed_coven_mark_does_not_widen_retrieval(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        refs = chat.resolve_referenced_member_ids(
+            connection,
+            guild_id=100,
+            interlocutor_user_id=2,
+            bot_user_id=999,
+            content="WTCH-9999 WTCH-12",
+        )
+
+    assert refs == ()
+
+
+def test_local_chat_date_uses_configured_guild_timezone(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        guild_config.ensure_guild_config(connection, 100, timezone="Pacific/Kiritimati")
+        instant = datetime(2026, 8, 24, 12, 30, tzinfo=timezone.utc)
+        resolved = chat.local_chat_date(connection, guild_id=100, now=instant)
+
+    assert resolved == date(2026, 8, 25)
+
+
+def test_dm_keeps_speaker_owner_only_memory(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        owner_only = _add_memory(
+            connection,
+            subject_user_id=2,
+            summary="Prefers private midnight planning",
+            topic="planning.private",
+            reveal_scope="owner_only",
+        )
+        route = _route(_envelope(guild_id=None, content="planning"))
+        bundle = chat.assemble_chat_memory_context(
+            connection,
+            route=route,
+            interlocutor_user_id=2,
+            query="planning",
+            on_date=TODAY,
+        )
+
+    assert owner_only.id in {item.memory.id for item in bundle.speaker_profile}
+
+
+def test_guild_visible_chat_strips_speaker_owner_only_memory(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        public = _add_memory(
+            connection,
+            subject_user_id=2,
+            summary="Likes public astronomy debates",
+            topic="astronomy.public",
+        )
+        owner_only = _add_memory(
+            connection,
+            subject_user_id=2,
+            summary="Privately fears karaoke",
+            topic="karaoke.private",
+            reveal_scope="owner_only",
+        )
+        route = _route(_envelope(content="astronomy and karaoke"))
+        bundle = chat.assemble_chat_memory_context(
+            connection,
+            route=route,
+            interlocutor_user_id=2,
+            query="astronomy karaoke",
+            on_date=TODAY,
+        )
+
+    speaker_ids = {item.memory.id for item in bundle.speaker_profile}
+    assert public.id in speaker_ids
+    assert owner_only.id not in speaker_ids
+
+
+def test_guild_visible_context_keeps_other_member_cross_member_memory(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        other = _add_memory(
+            connection,
+            subject_user_id=3,
+            summary="Alex collects antique telescopes",
+            topic="astronomy.alex",
+        )
+        route = _route(_envelope(content="<@3> telescopes", mentioned_user_ids=(3,)))
+        refs = chat.resolve_referenced_member_ids(
+            connection,
+            guild_id=100,
+            interlocutor_user_id=2,
+            bot_user_id=999,
+            content="<@3> telescopes",
+            mentioned_user_ids=(3,),
+        )
+        bundle = chat.assemble_chat_memory_context(
+            connection,
+            route=route,
+            interlocutor_user_id=2,
+            query="telescopes",
+            referenced_member_ids=refs,
+            on_date=TODAY,
+        )
+
+    assert other.id in {item.memory.id for item in bundle.contextual_memories}
+
+
+def test_public_filter_removes_contradiction_pointer_to_hidden_owner_only(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        public = _add_memory(
+            connection,
+            subject_user_id=2,
+            summary="Claims karaoke is delightful",
+            topic="karaoke.opinion",
+            category="Gossip",
+            label="Gossip",
+        )
+        hidden = _add_memory(
+            connection,
+            subject_user_id=2,
+            summary="Claims karaoke is unbearable",
+            topic="karaoke.opinion",
+            reveal_scope="owner_only",
+            category="Gossip",
+            label="Gossip",
+        )
+        route = _route(_envelope(content="karaoke"))
+        bundle = chat.assemble_chat_memory_context(
+            connection,
+            route=route,
+            interlocutor_user_id=2,
+            query="karaoke",
+            on_date=TODAY,
+        )
+
+    item = next(item for item in bundle.speaker_profile if item.memory.id == public.id)
+    assert hidden.id not in {member.memory.id for member in bundle.speaker_profile}
+    assert hidden.id not in item.contradicts_memory_ids
+
+
+def test_collection_pause_does_not_disable_chat_context(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        memory_ledger.set_wilhelmina_channel(
+            connection,
+            guild_id=100,
+            channel_id=10,
+            actor_user_id=2,
+        )
+        paused = memory_ledger.set_collection_enabled(
+            connection,
+            guild_id=100,
+            enabled=False,
+            actor_user_id=2,
+        )
+        route = chat.route_chat_message(
+            _envelope(channel_id=10),
+            home_guild_id=100,
+            bot_user_id=999,
+            designated_channel_id=paused.wilhelmina_channel_id,
+        )
+        bundle = chat.assemble_chat_memory_context(
+            connection,
+            route=route,
+            interlocutor_user_id=2,
+            query="hello",
+            on_date=TODAY,
+        )
+
+    assert paused.collection_enabled is False
+    assert route.eligible is True
+    assert bundle.interlocutor_user_id == 2
+
+
+def test_ineligible_route_cannot_assemble_context(tmp_path):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+
+    with managed_connection(path) as connection:
+        with pytest.raises(chat.ChatContractError):
+            chat.assemble_chat_memory_context(
+                connection,
+                route=chat.ChatRoute(False, reason="not_interaction"),
+                interlocutor_user_id=2,
+                query="hello",
+                on_date=TODAY,
+            )

--- a/tests/test_chat_cog.py
+++ b/tests/test_chat_cog.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.chat import Chat
+from services import coven_registry, memory_ledger, member_profiles
+from services.database import initialize_database, managed_connection
+
+TODAY = date(2026, 8, 24)
+
+
+def _setup(path) -> None:
+    initialize_database(path)
+    with managed_connection(path) as connection:
+        coven_registry.bootstrap_registry(
+            connection,
+            guild_id=100,
+            wilhelmina_user_id=999,
+            founder_user_id=2,
+            founder_name="Founder",
+            actor_user_id=2,
+        )
+        member_profiles.save_member_identity(
+            connection,
+            guild_id=100,
+            user_id=2,
+            discord_display_name="Founder",
+            preferred_name="Mina",
+            birth_date="1990-10-31",
+            today=TODAY,
+            actor_user_id=2,
+        )
+        memory_ledger.set_wilhelmina_channel(
+            connection,
+            guild_id=100,
+            channel_id=10,
+            actor_user_id=2,
+        )
+
+
+def _bot(path):
+    return SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        settings=SimpleNamespace(home_guild_id=100, database_path=path),
+        command_prefix="!",
+    )
+
+
+def _message(*, channel_id: int = 10, content: str = "hello"):
+    return SimpleNamespace(
+        id=500,
+        author=SimpleNamespace(id=2, bot=False),
+        webhook_id=None,
+        content=content,
+        guild=SimpleNamespace(id=100),
+        channel=SimpleNamespace(id=channel_id),
+        mentions=[],
+        reference=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_cog_prepares_context_but_sends_no_reply(tmp_path, caplog):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+    cog = Chat(_bot(path))
+    message = _message()
+
+    with caplog.at_level("INFO", logger="wilhelmina.chat.events"):
+        await cog.on_message(message)
+
+    assert "chat_context_prepared" in caplog.text
+    assert "surface=designated_channel" in caplog.text
+    assert not hasattr(message.channel, "send")
+
+
+@pytest.mark.asyncio
+async def test_chat_cog_ignores_unaddressed_non_designated_guild_message(tmp_path, caplog):
+    path = tmp_path / "chat.sqlite3"
+    _setup(path)
+    cog = Chat(_bot(path))
+
+    with caplog.at_level("INFO", logger="wilhelmina.chat.events"):
+        await cog.on_message(_message(channel_id=20))
+
+    assert "chat_context_prepared" not in caplog.text

--- a/tests/test_chat_config.py
+++ b/tests/test_chat_config.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from config import settings as settings_module
+from services import persona
+
+
+def _load_with_env(values):
+    with mock.patch.object(settings_module, "load_dotenv", lambda *args, **kwargs: None):
+        with mock.patch.dict("os.environ", values, clear=True):
+            return settings_module.load_settings()
+
+
+def test_chat_is_disabled_by_default():
+    loaded = _load_with_env(
+        {
+            "DISCORD_TOKEN": "token",
+            "COMMAND_SYNC_MODE": "off",
+        }
+    )
+    assert loaded.is_cog_enabled("cogs.chat") is False
+
+
+def test_chat_can_be_enabled_independently_from_memory_extraction():
+    loaded = _load_with_env(
+        {
+            "DISCORD_TOKEN": "token",
+            "COMMAND_SYNC_MODE": "off",
+            "ENABLE_CHAT": "true",
+            "ENABLE_MEMORY_EXTRACTION": "false",
+        }
+    )
+    assert loaded.is_cog_enabled("cogs.chat") is True
+    assert loaded.is_cog_enabled("cogs.memory_extraction") is False
+
+
+def test_chat_has_an_explicit_persona_profile():
+    profile = persona.get_feature_profile("chat")
+    assert profile.key == "chat"
+    assert profile.label == "Chat"
+    assert profile.max_chars == 1900
+    assert persona.fallback_for("chat")

--- a/tests/test_memory_extraction_intents.py
+++ b/tests/test_memory_extraction_intents.py
@@ -5,25 +5,31 @@ from types import SimpleNamespace
 from bot import build_intents
 
 
-def _settings(*, rules: bool = False, extraction: bool = False):
+def _settings(*, rules: bool = False, extraction: bool = False, chat: bool = False):
     enabled = {
         "cogs.rules": rules,
         "cogs.memory_extraction": extraction,
+        "cogs.chat": chat,
     }
     return SimpleNamespace(is_cog_enabled=lambda extension: enabled.get(extension, False))
 
 
-def test_message_content_intent_stays_off_when_extractor_is_disabled():
-    intents = build_intents(_settings(extraction=False))
+def test_message_content_intent_stays_off_when_chat_and_extractor_are_disabled():
+    intents = build_intents(_settings(extraction=False, chat=False))
     assert intents.message_content is False
 
 
 def test_extractor_explicitly_enables_message_content_intent():
-    intents = build_intents(_settings(extraction=True))
+    intents = build_intents(_settings(extraction=True, chat=False))
     assert intents.message_content is True
 
 
-def test_rules_member_intent_is_independent_from_extraction():
-    intents = build_intents(_settings(rules=True, extraction=False))
+def test_chat_explicitly_enables_message_content_intent_without_extraction():
+    intents = build_intents(_settings(extraction=False, chat=True))
+    assert intents.message_content is True
+
+
+def test_rules_member_intent_is_independent_from_chat_and_extraction():
+    intents = build_intents(_settings(rules=True, extraction=False, chat=False))
     assert intents.members is True
     assert intents.message_content is False


### PR DESCRIPTION
## Purpose

Implement Phase 6A of Wilhelmina's memory-aware chat brain: deterministic Discord interaction routing and audience-aware authorized memory-context preparation, **without making an OpenAI chat call yet**.

This is a stacked PR on `phase-5-context-intelligence-retrieval`. It must not merge independently while the earlier stack remains unmerged.

## Approved 6A scope

- new `cogs.chat` interaction listener, disabled by default via `ENABLE_CHAT=false`;
- approved response surfaces only: direct DM, designated Wilhelmina channel, direct mention, and reply to Wilhelmina;
- unaddressed messages outside the designated channel remain excluded; no ambient whole-server listening;
- bots, webhooks, empty text, wrong-guild messages, and existing `!` prefix commands are ignored;
- deterministic `private_interlocutor` versus `guild_visible` audience classification;
- Phase-5 memory assembly remains authoritative, followed by a local audience filter;
- the speaker's `owner_only` memories are allowed in one-to-one DM context but removed from guild-visible context before any later provider stage;
- other-member context remains `cross_member` only and `admin_only` never becomes ordinary chat context;
- contradiction IDs are trimmed when audience filtering removes a linked memory;
- trusted referenced-member IDs come only from Discord-resolved mentions/reply authors or exact Registry Coven Marks; plain-language/fuzzy names cannot widen retrieval;
- designated-chat routing reuses `memory_ledger_settings.wilhelmina_channel_id` and remains independent from Memory Ledger collection pause;
- chat or extraction can independently request Discord Message Content intent;
- explicit Persona Engine `chat` profile with a 1,900-character future output ceiling;
- content-free routing/context-prepared logs only.

## Explicitly not in 6A

- no OpenAI/Responses chat generation;
- no user-facing generated reply;
- no short-term transcript/history store;
- no provider-managed conversation state;
- no streaming or image generation;
- no ambient whole-server listening;
- no new consent/version gate;
- no change to the unresolved under-18 behavior;
- no permanent/evolving personality dossier.

## Dependency closeout

Before final 6A validation, Phase 5 received the remaining credential-boundary fixes for OpenPGP, PuTTY, and SSH2 private-key formats plus the corrupted Admin-note invariant. Phase 6A was then rebuilt as a single commit directly on exact Phase-5 head `ad23e10f8c1ff088325e18346a39a785096466cd`; it is 1 ahead / 0 behind with no merge commit.

## Validation

Current exact head: `ea96480b91a2db423be7d07eac162e645a8fb01b`

- GitHub Actions CI run `32830114578` / run #426 — **success**
- `ruff check .` — **passed**
- `pytest` — **291 passed, 1 warning**
- no live OpenAI call is part of this tranche
- no unresolved review thread exists as of this update

## Merge discipline

No merge is authorized by this PR or by implementation approval.